### PR TITLE
Add LICENSE, CI workflow, SECURITY.md, and repo health improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.enc
 *.key
 *.pem
+.env*
 
 # Compiled binaries (release copies in repo root)
 /crack-agent

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thijs Vos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # crack-orchestrate
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/thijsvos/password-crack-orchestrate/actions/workflows/ci.yml/badge.svg)](https://github.com/thijsvos/password-crack-orchestrate/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/thijsvos/password-crack-orchestrate)](https://github.com/thijsvos/password-crack-orchestrate/releases)
+
 Distributed hashcat orchestration tool. Splits cracking work across GPU workers with encrypted transport, live TUI dashboards, and multi-phase campaign support.
+
+<!-- TODO: Add TUI screenshots here
+![Coordinator TUI](docs/screenshots/coord-tui.png)
+![Agent TUI](docs/screenshots/agent-tui.png)
+-->
 
 ## Architecture
 
@@ -185,6 +194,12 @@ crack-agent run         Connect and process work
 7. **Result collection** — cracked hashes reported in real-time, stored in SQLite
 8. **Campaign advancement** — when a phase exhausts, uncracked hashes roll into the next phase
 
+## Contributing
+
+Contributions are welcome. Please open an issue to discuss proposed changes before submitting a pull request.
+
+For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use one of the following methods:
+
+1. **GitHub Security Advisory** (preferred): [Report a vulnerability](https://github.com/thijsvos/password-crack-orchestrate/security/advisories/new)
+2. **Email**: Send details to the repository owner via their GitHub profile
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Fix or mitigation**: Depends on severity, but critical issues are prioritized
+
+## Scope
+
+This policy covers:
+
+- The coordinator (`crack-coord`), agent (`crack-agent`), and CLI (`crackctl`) binaries
+- The Noise IK transport protocol implementation
+- Key generation and storage
+- The REST API
+- SQLite data storage
+
+## Supported Versions
+
+Only the latest release is supported with security updates.


### PR DESCRIPTION
## Summary

- Add MIT `LICENSE` file (was declared in README but missing)
- Add `.github/workflows/ci.yml` with `cargo fmt`, `cargo clippy`, `cargo test`, and `cargo audit` on PRs
- Add `SECURITY.md` with vulnerability disclosure policy
- Add README badges (license, CI, release) and contributing section
- Add `.env*` to `.gitignore`
- Add repository topics (hashcat, rust, distributed-computing, password-cracking, tui, noise-protocol)
- Clean up merged `chore/update-dependencies` branch

## Test plan

- [ ] Verify CI workflow triggers on this PR
- [ ] Confirm badges render correctly in README
- [ ] Check SECURITY.md renders on GitHub security tab

Closes #4