### PR TITLE
Add dictionary and dictionary+rules attack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Distributed hashcat orchestration tool. Splits cracking work across GPU workers 
 ## Features
 
 - **Distributed cracking** -- coordinate hashcat across multiple GPU workers from a single dashboard
+- **Multiple attack modes** -- brute-force/mask, dictionary, and dictionary+rules attacks
+- **Bundled rules** -- includes [OneRuleToRuleThemStill](https://github.com/stealthsploit/OneRuleToRuleThemStill) (48K rules by [Will Hunt](https://github.com/stealthsploit), MIT license)
 - **Noise IK encryption** -- all worker traffic is end-to-end encrypted (WireGuard-grade, via `snow`)
 - **Live TUI dashboards** -- real-time progress on both coordinator and agents with vim keybindings
 - **Multi-phase campaigns** -- chain attack phases together; uncracked hashes roll forward automatically
@@ -110,6 +112,34 @@ crack-agent run --server <coord-ip>:8443
 
 Workers reconnect automatically with exponential backoff (1s to 60s) if the connection drops.
 
+### Dictionary Attacks
+
+Upload a wordlist and create a dictionary task:
+
+```bash
+# Upload a wordlist
+crackctl file upload rockyou.txt --type wordlist
+
+# Dictionary attack (hashcat -a 0)
+crackctl task create --name "Dict attack" --hash-mode 1000 \
+  --hash-file <hash-id> --wordlist <wordlist-id>
+```
+
+### Dictionary with Rules
+
+The `rules/` directory includes [OneRuleToRuleThemStill](https://github.com/stealthsploit/OneRuleToRuleThemStill) -- an optimized rule set of 48,439 rules by [Will Hunt (@stealthsploit)](https://github.com/stealthsploit), MIT licensed. Upload it and combine with a wordlist:
+
+```bash
+# Upload rules file
+crackctl file upload rules/OneRuleToRuleThemStill.rule --type rules
+
+# Dictionary + rules attack
+crackctl task create --name "Dict+OTRTS" --hash-mode 1000 \
+  --hash-file <hash-id> --wordlist <wordlist-id> --rules-file <rules-id>
+```
+
+Wordlist and rules files are transferred to workers over the encrypted Noise channel and cached locally. Files are sent in ~40KB chunks and only transferred once per worker.
+
 ## TUI Dashboard
 
 ### Coordinator
@@ -203,7 +233,9 @@ Tasks:
     --name <name>                  Task name (required)
     --hash-mode <mode>             Hashcat hash mode (required)
     --hash-file <id>               Hash file ID (required)
-    --mask <mask>                  Attack mask, e.g. '?a?a?a?a' (required)
+    --mask <mask>                  Attack mask for brute-force (mutually exclusive with --wordlist)
+    --wordlist <id>                Wordlist file ID for dictionary attacks
+    --rules-file <id>              Rules file ID (requires --wordlist)
     --charset1..4 <chars>          Custom charsets for ?1..?4
     --priority <1-10>              Task priority (default: 5)
     --extra-args <args>            Additional hashcat arguments

--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -338,6 +338,62 @@ async fn connect_and_run(
                         info!(worker_id = %wid, "received duplicate Welcome");
                     }
 
+                    CoordMessage::TransferFileChunk {
+                        file_id,
+                        filename,
+                        chunk_index,
+                        total_chunks,
+                        data_b64,
+                    } => {
+                        use std::collections::HashMap;
+                        // Decode chunk data
+                        let data = base64::engine::general_purpose::STANDARD
+                            .decode(&data_b64)
+                            .context("failed to decode file chunk")?;
+
+                        // Use a simple approach: accumulate chunks in cache dir as partial files
+                        let cache_dir = config.cache_dir();
+                        tokio::fs::create_dir_all(&cache_dir).await?;
+                        let part_path = cache_dir.join(format!("{file_id}.part{chunk_index}"));
+                        tokio::fs::write(&part_path, &data).await?;
+
+                        // Check if all chunks received
+                        let mut all_received = true;
+                        for i in 0..total_chunks {
+                            if !cache_dir.join(format!("{file_id}.part{i}")).exists() {
+                                all_received = false;
+                                break;
+                            }
+                        }
+
+                        if all_received {
+                            // Reassemble
+                            let final_path = cache_dir.join(&file_id);
+                            let mut full_data = Vec::new();
+                            for i in 0..total_chunks {
+                                let p = cache_dir.join(format!("{file_id}.part{i}"));
+                                let chunk_data = tokio::fs::read(&p).await?;
+                                full_data.extend_from_slice(&chunk_data);
+                                let _ = tokio::fs::remove_file(&p).await;
+                            }
+                            tokio::fs::write(&final_path, &full_data).await?;
+                            info!(
+                                file_id = %file_id,
+                                filename = %filename,
+                                size = full_data.len(),
+                                chunks = total_chunks,
+                                "file transfer complete"
+                            );
+                        } else {
+                            debug!(
+                                file_id = %file_id,
+                                chunk = chunk_index,
+                                total = total_chunks,
+                                "received file chunk"
+                            );
+                        }
+                    }
+
                     CoordMessage::AssignChunk {
                         chunk_id,
                         task_id,
@@ -346,15 +402,22 @@ async fn connect_and_run(
                         hash_file_id,
                         skip,
                         limit,
-                        mask,
-                        custom_charsets,
+                        attack,
                         extra_args,
                     } => {
+                        use crack_common::protocol::AssignChunkAttack;
+
+                        let mask_display = match &attack {
+                            AssignChunkAttack::BruteForce { mask, .. } => mask.clone(),
+                            AssignChunkAttack::Dictionary { .. } => "dictionary".to_string(),
+                            AssignChunkAttack::DictionaryWithRules { .. } => "dict+rules".to_string(),
+                        };
+
                         info!(
                             chunk_id = %chunk_id,
                             task_id = %task_id,
                             hash_mode,
-                            mask = %mask,
+                            attack = %mask_display,
                             skip, limit,
                             "received chunk assignment"
                         );
@@ -363,7 +426,7 @@ async fn connect_and_run(
                             task_id,
                             chunk_id,
                             hash_mode,
-                            mask: mask.clone(),
+                            mask: mask_display,
                         });
 
                         // Decode hash file from the message and cache locally
@@ -373,16 +436,56 @@ async fn connect_and_run(
                         let outfile_path =
                             config.cache_dir().join(format!("out_{chunk_id}.txt"));
 
-                        let run_config = HashcatRunConfig {
-                            hashcat_path: config.hashcat_path.clone(),
-                            hash_file_path,
-                            hash_mode,
-                            mask,
-                            skip,
-                            limit,
-                            custom_charsets,
-                            extra_args,
-                            outfile_path,
+                        let cache_dir = config.cache_dir();
+                        let run_config = match attack {
+                            AssignChunkAttack::BruteForce { mask, custom_charsets } => {
+                                HashcatRunConfig {
+                                    hashcat_path: config.hashcat_path.clone(),
+                                    hash_file_path,
+                                    hash_mode,
+                                    attack_mode: 3,
+                                    mask: Some(mask),
+                                    skip,
+                                    limit,
+                                    custom_charsets,
+                                    wordlist_path: None,
+                                    rules_path: None,
+                                    extra_args,
+                                    outfile_path,
+                                }
+                            }
+                            AssignChunkAttack::Dictionary { wordlist_file_id } => {
+                                HashcatRunConfig {
+                                    hashcat_path: config.hashcat_path.clone(),
+                                    hash_file_path,
+                                    hash_mode,
+                                    attack_mode: 0,
+                                    mask: None,
+                                    skip,
+                                    limit,
+                                    custom_charsets: None,
+                                    wordlist_path: Some(cache_dir.join(&wordlist_file_id)),
+                                    rules_path: None,
+                                    extra_args,
+                                    outfile_path,
+                                }
+                            }
+                            AssignChunkAttack::DictionaryWithRules { wordlist_file_id, rules_file_id } => {
+                                HashcatRunConfig {
+                                    hashcat_path: config.hashcat_path.clone(),
+                                    hash_file_path,
+                                    hash_mode,
+                                    attack_mode: 0,
+                                    mask: None,
+                                    skip,
+                                    limit,
+                                    custom_charsets: None,
+                                    wordlist_path: Some(cache_dir.join(&wordlist_file_id)),
+                                    rules_path: Some(cache_dir.join(&rules_file_id)),
+                                    extra_args,
+                                    outfile_path,
+                                }
+                            }
                         };
 
                         // Only run one hashcat at a time to avoid GPU contention.

--- a/crates/crack-agent/src/runner.rs
+++ b/crates/crack-agent/src/runner.rs
@@ -34,10 +34,13 @@ pub struct HashcatRunConfig {
     pub hashcat_path: String,
     pub hash_file_path: PathBuf,
     pub hash_mode: u32,
-    pub mask: String,
+    pub attack_mode: u32,
+    pub mask: Option<String>,
     pub skip: u64,
     pub limit: u64,
     pub custom_charsets: Option<Vec<String>>,
+    pub wordlist_path: Option<PathBuf>,
+    pub rules_path: Option<PathBuf>,
     pub extra_args: Vec<String>,
     pub outfile_path: PathBuf,
 }
@@ -53,8 +56,8 @@ impl HashcatRunner {
     pub fn start(config: &HashcatRunConfig) -> anyhow::Result<Self> {
         let mut cmd = Command::new(&config.hashcat_path);
 
-        // Attack mode 3 = brute-force / mask
-        cmd.arg("-a").arg("3");
+        // Attack mode
+        cmd.arg("-a").arg(config.attack_mode.to_string());
 
         // Hash mode
         cmd.arg("-m").arg(config.hash_mode.to_string());
@@ -62,8 +65,26 @@ impl HashcatRunner {
         // Hash file
         cmd.arg(&config.hash_file_path);
 
-        // Mask
-        cmd.arg(&config.mask);
+        // Attack-specific positional argument
+        match config.attack_mode {
+            0 => {
+                // Dictionary: wordlist is the positional argument
+                if let Some(ref wl) = config.wordlist_path {
+                    cmd.arg(wl);
+                }
+                // Optional rules file
+                if let Some(ref rules) = config.rules_path {
+                    cmd.arg("-r").arg(rules);
+                }
+            }
+            3 => {
+                // Brute-force: mask is the positional argument
+                if let Some(ref mask) = config.mask {
+                    cmd.arg(mask);
+                }
+            }
+            _ => {}
+        }
 
         // Keyspace range
         cmd.arg("--skip").arg(config.skip.to_string());
@@ -121,7 +142,10 @@ impl HashcatRunner {
         info!(
             hashcat = %config.hashcat_path,
             hash_mode = config.hash_mode,
-            mask = %config.mask,
+            attack_mode = config.attack_mode,
+            mask = ?config.mask,
+            wordlist = ?config.wordlist_path,
+            rules = ?config.rules_path,
             skip = config.skip,
             limit = config.limit,
             "starting hashcat process"

--- a/crates/crack-common/src/models.rs
+++ b/crates/crack-common/src/models.rs
@@ -72,6 +72,13 @@ pub enum AttackConfig {
         mask: String,
         custom_charsets: Option<Vec<String>>,
     },
+    Dictionary {
+        wordlist_file_id: String,
+    },
+    DictionaryWithRules {
+        wordlist_file_id: String,
+        rules_file_id: String,
+    },
 }
 
 // ── Chunk ──

--- a/crates/crack-common/src/protocol.rs
+++ b/crates/crack-common/src/protocol.rs
@@ -10,6 +10,16 @@ pub enum CoordMessage {
     Welcome {
         worker_id: String,
     },
+    /// Stream a file to the worker in chunks. The agent reconstructs
+    /// the file from ordered chunks and caches it by file_id.
+    TransferFileChunk {
+        file_id: String,
+        filename: String,
+        chunk_index: u32,
+        total_chunks: u32,
+        /// ~40KB of raw data, base64-encoded (fits in a single Noise frame).
+        data_b64: String,
+    },
     AssignChunk {
         chunk_id: Uuid,
         task_id: Uuid,
@@ -19,8 +29,7 @@ pub enum CoordMessage {
         hash_file_id: String,
         skip: u64,
         limit: u64,
-        mask: String,
-        custom_charsets: Option<Vec<String>>,
+        attack: AssignChunkAttack,
         extra_args: Vec<String>,
     },
     AbortChunk {
@@ -30,6 +39,23 @@ pub enum CoordMessage {
         hash_mode: u32,
     },
     Shutdown,
+}
+
+/// Attack-specific fields for chunk assignment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum AssignChunkAttack {
+    BruteForce {
+        mask: String,
+        custom_charsets: Option<Vec<String>>,
+    },
+    Dictionary {
+        wordlist_file_id: String,
+    },
+    DictionaryWithRules {
+        wordlist_file_id: String,
+        rules_file_id: String,
+    },
 }
 
 /// Messages sent from worker to coordinator over the Noise-encrypted channel.

--- a/crates/crack-coord/src/api/tasks.rs
+++ b/crates/crack-coord/src/api/tasks.rs
@@ -42,6 +42,33 @@ pub async fn create_task(
             ApiError::BadRequest(format!("hash file not found: {}", req.hash_file_id))
         })?;
 
+    // Validate referenced files in the attack config.
+    match &req.attack_config {
+        AttackConfig::Dictionary { wordlist_file_id } => {
+            db::get_file_record(&state.db, wordlist_file_id)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::BadRequest(format!("wordlist file not found: {wordlist_file_id}"))
+                })?;
+        }
+        AttackConfig::DictionaryWithRules {
+            wordlist_file_id,
+            rules_file_id,
+        } => {
+            db::get_file_record(&state.db, wordlist_file_id)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::BadRequest(format!("wordlist file not found: {wordlist_file_id}"))
+                })?;
+            db::get_file_record(&state.db, rules_file_id)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::BadRequest(format!("rules file not found: {rules_file_id}"))
+                })?;
+        }
+        AttackConfig::BruteForce { .. } => {}
+    }
+
     let task = db::create_task(&state.db, &req).await?;
     state.emit(AppEvent::TaskCreated { task_id: task.id });
 

--- a/crates/crack-coord/src/campaign/engine.rs
+++ b/crates/crack-coord/src/campaign/engine.rs
@@ -163,6 +163,10 @@ async fn find_next_subtask(
 ) -> Result<Option<NextSubTask>> {
     let completed_mask = match &completed_task.attack_config {
         AttackConfig::BruteForce { mask, .. } => mask.clone(),
+        // Dictionary and DictionaryWithRules are single-task phases; no sub-task chaining.
+        AttackConfig::Dictionary { .. } | AttackConfig::DictionaryWithRules { .. } => {
+            return Ok(None);
+        }
     };
 
     match &phase.config {
@@ -419,9 +423,40 @@ async fn start_phase_inner(
             db::set_phase_task_id(&state.db, phase.id, task.id).await?;
         }
 
-        PhaseConfig::Dictionary { .. } | PhaseConfig::Hybrid { .. } => {
+        PhaseConfig::Dictionary { wordlist_file_id, rules } => {
+            let attack_config = if rules.is_empty() {
+                AttackConfig::Dictionary {
+                    wordlist_file_id: wordlist_file_id.clone(),
+                }
+            } else {
+                // For campaigns with rules, use the first rules file.
+                // Future: support multiple rules files.
+                AttackConfig::DictionaryWithRules {
+                    wordlist_file_id: wordlist_file_id.clone(),
+                    rules_file_id: rules[0].clone(),
+                }
+            };
+
+            let req = CreateTaskRequest {
+                name: format!("{} — {}", campaign.name, phase.name),
+                hash_mode: campaign.hash_mode,
+                hash_file_id: hash_file_id.to_string(),
+                attack_config,
+                priority: campaign.priority,
+                extra_args: campaign.extra_args.clone(),
+            };
+
+            let task = db::create_campaign_task(&state.db, &req, campaign.id).await?;
+            state.emit(AppEvent::TaskCreated { task_id: task.id });
+            db::set_phase_task_id(&state.db, phase.id, task.id).await?;
+
+            info!(campaign_id = %campaign.id, phase = phase.phase_index,
+                task_id = %task.id, "created dictionary task for campaign phase");
+        }
+
+        PhaseConfig::Hybrid { .. } => {
             warn!(campaign_id = %campaign.id, phase = phase.phase_index,
-                "dictionary/hybrid attacks not yet implemented, skipping phase");
+                "hybrid attacks not yet implemented, skipping phase");
             db::update_phase_status(&state.db, phase.id, PhaseStatus::Skipped).await?;
             advance_phase(state, campaign.id).await?;
         }

--- a/crates/crack-coord/src/monitor.rs
+++ b/crates/crack-coord/src/monitor.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use base64::Engine;
 use chrono::Utc;
 use tracing::{error, info, warn};
 
@@ -80,6 +79,7 @@ async fn prepare_pending_tasks(state: &AppState) -> anyhow::Result<()> {
             &state.hashcat_path,
             task.hash_mode,
             &task.attack_config,
+            &state.files_dir(),
         ).await {
             Ok(ks) => ks,
             Err(e) => {
@@ -215,34 +215,17 @@ async fn reassign_abandoned_chunks(state: &AppState) -> anyhow::Result<()> {
             // Send the chunk to the worker if connected
             let conns = state.worker_connections.read().await;
             if let Some(conn) = conns.get(&worker_id) {
-                // Read hash file and encode for transfer
-                match crate::storage::files::read_file(&state.files_dir(), &task.hash_file_id) {
-                    Ok(file_data) => {
-                        let hash_file_b64 = base64::engine::general_purpose::STANDARD.encode(&file_data);
-                        let (mask, custom_charsets) = match &task.attack_config {
-                            crack_common::models::AttackConfig::BruteForce {
-                                mask,
-                                custom_charsets,
-                            } => (mask.clone(), custom_charsets.clone()),
-                        };
-
-                        let msg = crack_common::protocol::CoordMessage::AssignChunk {
-                            chunk_id: chunk.id,
-                            task_id: chunk.task_id,
-                            hash_mode: task.hash_mode,
-                            hash_file_b64,
-                            hash_file_id: task.hash_file_id.clone(),
-                            skip: chunk.skip,
-                            limit: chunk.limit,
-                            mask,
-                            custom_charsets,
-                            extra_args: task.extra_args.clone(),
-                        };
-
+                // Transfer wordlist/rules files before assigning the chunk
+                if let Err(e) = crate::transport::handler::send_attack_files_via_tx(state, &task, &conn.tx).await {
+                    error!(task_id = %task.id, error = %e, "failed to transfer attack files for dispatch");
+                    continue;
+                }
+                match crate::transport::handler::build_assign_chunk_msg(state, &task, &chunk) {
+                    Ok(msg) => {
                         let _ = conn.tx.send(msg).await;
                     }
                     Err(e) => {
-                        error!(task_id = %task.id, error = %e, "failed to read hash file for chunk dispatch");
+                        error!(task_id = %task.id, error = %e, "failed to build assign chunk msg for dispatch");
                     }
                 }
             }

--- a/crates/crack-coord/src/scheduler/chunker.rs
+++ b/crates/crack-coord/src/scheduler/chunker.rs
@@ -1,6 +1,10 @@
+use std::path::Path;
+
 use anyhow::{bail, Context};
 use crack_common::models::AttackConfig;
 use tracing::info;
+
+use crate::storage::files;
 
 /// Compute the total keyspace for an attack configuration.
 ///
@@ -12,6 +16,7 @@ pub async fn compute_keyspace(
     hashcat_path: &str,
     hash_mode: u32,
     attack_config: &AttackConfig,
+    files_dir: &Path,
 ) -> anyhow::Result<u64> {
     match attack_config {
         AttackConfig::BruteForce {
@@ -24,7 +29,64 @@ pub async fn compute_keyspace(
             info!(mask = %mask, keyspace, "computed base keyspace via hashcat --keyspace");
             Ok(keyspace)
         }
+        AttackConfig::Dictionary { wordlist_file_id } => {
+            let wordlist_path = files::resolve_file_path(files_dir, wordlist_file_id)?;
+            let keyspace = compute_dictionary_keyspace(
+                hashcat_path, hash_mode, &wordlist_path.to_string_lossy(), None,
+            ).await?;
+            info!(wordlist = %wordlist_file_id, keyspace, "computed dictionary keyspace via hashcat --keyspace");
+            Ok(keyspace)
+        }
+        AttackConfig::DictionaryWithRules { wordlist_file_id, rules_file_id } => {
+            let wordlist_path = files::resolve_file_path(files_dir, wordlist_file_id)?;
+            let rules_path = files::resolve_file_path(files_dir, rules_file_id)?;
+            let keyspace = compute_dictionary_keyspace(
+                hashcat_path, hash_mode, &wordlist_path.to_string_lossy(), Some(&rules_path.to_string_lossy()),
+            ).await?;
+            info!(wordlist = %wordlist_file_id, rules = %rules_file_id, keyspace, "computed dictionary+rules keyspace via hashcat --keyspace");
+            Ok(keyspace)
+        }
     }
+}
+
+/// Run `hashcat --keyspace` for a dictionary attack (mode 0).
+async fn compute_dictionary_keyspace(
+    hashcat_path: &str,
+    hash_mode: u32,
+    wordlist_path: &str,
+    rules_path: Option<&str>,
+) -> anyhow::Result<u64> {
+    let mut cmd = tokio::process::Command::new(hashcat_path);
+    cmd.arg("-a").arg("0");
+    cmd.arg("-m").arg(hash_mode.to_string());
+    cmd.arg("--keyspace");
+    cmd.arg(wordlist_path);
+
+    if let Some(rules) = rules_path {
+        cmd.arg("-r").arg(rules);
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .with_context(|| format!("failed to run hashcat --keyspace (dict) at '{hashcat_path}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "hashcat --keyspace (dict) failed (exit {}): {}",
+            output.status.code().unwrap_or(-1),
+            stderr.trim()
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let keyspace: u64 = stdout
+        .trim()
+        .parse()
+        .with_context(|| format!("failed to parse hashcat --keyspace output: '{}'", stdout.trim()))?;
+
+    Ok(keyspace)
 }
 
 /// Run `hashcat --keyspace` to get the exact restore-point count.

--- a/crates/crack-coord/src/storage/files.rs
+++ b/crates/crack-coord/src/storage/files.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
@@ -66,6 +66,32 @@ pub fn read_file(files_dir: &Path, file_id: &str) -> Result<Vec<u8>> {
                 if name.starts_with(&prefix) {
                     return std::fs::read(entry.path())
                         .with_context(|| format!("reading file {}", entry.path().display()));
+                }
+            }
+        }
+    }
+
+    anyhow::bail!("file not found: {file_id} in {}", files_dir.display())
+}
+
+/// Resolve a file_id to its full path on disk.
+///
+/// Tries the bare file_id first, then falls back to any file whose name starts with the file_id
+/// (to handle files stored with an extension).
+pub fn resolve_file_path(files_dir: &Path, file_id: &str) -> Result<PathBuf> {
+    // Try exact match first
+    let exact = files_dir.join(file_id);
+    if exact.is_file() {
+        return Ok(exact);
+    }
+
+    // Fall back: look for file_id.* (with extension)
+    let prefix = format!("{file_id}.");
+    if let Ok(entries) = std::fs::read_dir(files_dir) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with(&prefix) {
+                    return Ok(entry.path());
                 }
             }
         }

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -8,14 +8,16 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+use std::collections::HashSet;
+
 use base64::Engine;
 use crack_common::auth::{build_responder, encode_public_key};
 use crack_common::models::*;
-use crack_common::protocol::{CoordMessage, WorkerMessage, MAX_MESSAGE_SIZE};
+use crack_common::protocol::{AssignChunkAttack, CoordMessage, WorkerMessage, MAX_MESSAGE_SIZE};
 
 use crate::scheduler;
 use crate::state::{AppEvent, AppState, WorkerConnection};
-use crate::storage::db;
+use crate::storage::{db, files};
 
 /// Maximum Noise transport message payload (just under the 65535 limit to
 /// leave room for the 16-byte AEAD tag that snow appends).
@@ -191,6 +193,9 @@ async fn run_connection(
     // We track the worker_id once the Register message arrives.
     let mut worker_id: Option<String> = None;
 
+    // Track which files have been transferred to this worker so we don't re-send.
+    let mut transferred_files: HashSet<String> = HashSet::new();
+
     // Reusable buffers.
     let mut read_buf = vec![0u8; 65535];
     let mut write_buf = vec![0u8; 65535];
@@ -232,6 +237,7 @@ async fn run_connection(
                     &pubkey_b64,
                     peer_addr,
                     &mut worker_id,
+                    &mut transferred_files,
                 ).await {
                     error!(%peer_addr, error = %e, "error handling worker message");
                 }
@@ -315,6 +321,7 @@ async fn handle_worker_message(
     pubkey_b64: &str,
     peer_addr: SocketAddr,
     worker_id: &mut Option<String>,
+    transferred_files: &mut HashSet<String>,
 ) -> anyhow::Result<()> {
     match msg {
         WorkerMessage::Register {
@@ -333,6 +340,7 @@ async fn handle_worker_message(
                 os,
                 devices,
                 worker_id,
+                transferred_files,
             )
             .await
         }
@@ -438,6 +446,7 @@ async fn handle_worker_message(
                 if let Some((task, new_chunk)) =
                     scheduler::assign_next_chunk(state, wid).await?
                 {
+                    send_attack_files(state, &task, outbound_tx, transferred_files).await?;
                     let msg = build_assign_chunk_msg(state, &task, &new_chunk)?;
                     let _ = outbound_tx.send(msg).await;
                 } else {
@@ -479,7 +488,7 @@ async fn handle_worker_message(
 
             // Try to assign next work to keep the worker busy.
             if let Some(wid) = worker_id.as_deref() {
-                try_assign_work(state, wid, outbound_tx).await?;
+                try_assign_work(state, wid, outbound_tx, transferred_files).await?;
             }
             Ok(())
         }
@@ -489,7 +498,7 @@ async fn handle_worker_message(
                 db::upsert_benchmark(&state.db, wid, *hash_mode, *speed).await?;
 
                 // If the worker was idle, try to give it work now.
-                try_assign_work(state, wid, outbound_tx).await?;
+                try_assign_work(state, wid, outbound_tx, transferred_files).await?;
             }
             Ok(())
         }
@@ -535,6 +544,7 @@ async fn handle_register(
     os: &str,
     devices: &[DeviceInfo],
     worker_id: &mut Option<String>,
+    transferred_files: &mut HashSet<String>,
 ) -> anyhow::Result<()> {
     // Look up or create the worker record by public key.
     let worker = db::get_or_create_worker(&state.db, pubkey_b64, worker_name).await?;
@@ -587,7 +597,7 @@ async fn handle_register(
     .await?;
 
     // Try to immediately assign work to the newly registered worker.
-    try_assign_work(state, &wid, outbound_tx).await?;
+    try_assign_work(state, &wid, outbound_tx, transferred_files).await?;
 
     Ok(())
 }
@@ -595,20 +605,33 @@ async fn handle_register(
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Build a CoordMessage::AssignChunk with the hash file data embedded.
-fn build_assign_chunk_msg(
+pub(crate) fn build_assign_chunk_msg(
     state: &AppState,
     task: &Task,
     chunk: &Chunk,
 ) -> anyhow::Result<CoordMessage> {
-    let (mask, custom_charsets) = match &task.attack_config {
+    let attack = match &task.attack_config {
         AttackConfig::BruteForce {
             mask,
             custom_charsets,
-        } => (mask.clone(), custom_charsets.clone()),
+        } => AssignChunkAttack::BruteForce {
+            mask: mask.clone(),
+            custom_charsets: custom_charsets.clone(),
+        },
+        AttackConfig::Dictionary { wordlist_file_id } => AssignChunkAttack::Dictionary {
+            wordlist_file_id: wordlist_file_id.clone(),
+        },
+        AttackConfig::DictionaryWithRules {
+            wordlist_file_id,
+            rules_file_id,
+        } => AssignChunkAttack::DictionaryWithRules {
+            wordlist_file_id: wordlist_file_id.clone(),
+            rules_file_id: rules_file_id.clone(),
+        },
     };
 
     // Read the hash file and base64-encode it for transfer over the Noise channel.
-    let file_data = crate::storage::files::read_file(&state.files_dir(), &task.hash_file_id)
+    let file_data = files::read_file(&state.files_dir(), &task.hash_file_id)
         .context("reading hash file for chunk assignment")?;
     let hash_file_b64 = base64::engine::general_purpose::STANDARD.encode(&file_data);
 
@@ -620,24 +643,109 @@ fn build_assign_chunk_msg(
         hash_file_id: task.hash_file_id.clone(),
         skip: chunk.skip,
         limit: chunk.limit,
-        mask,
-        custom_charsets,
+        attack,
         extra_args: task.extra_args.clone(),
     })
 }
 
+/// Stream a file to a worker in ~40KB chunks via TransferFileChunk messages.
+///
+/// Skips sending if the file has already been transferred to this worker
+/// (tracked via `transferred_files`).
+async fn send_file_to_worker(
+    state: &AppState,
+    file_id: &str,
+    outbound_tx: &mpsc::Sender<CoordMessage>,
+    transferred_files: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    if transferred_files.contains(file_id) {
+        return Ok(());
+    }
+
+    let file_data = files::read_file(&state.files_dir(), file_id)
+        .with_context(|| format!("reading file {file_id} for transfer"))?;
+
+    // Look up the original filename from the DB (best-effort, fall back to file_id).
+    let filename = match db::get_file_record(&state.db, file_id).await? {
+        Some(record) => record.filename,
+        None => file_id.to_string(),
+    };
+
+    const CHUNK_SIZE: usize = 40 * 1024; // ~40 KB
+    let total_chunks = ((file_data.len() + CHUNK_SIZE - 1) / CHUNK_SIZE).max(1) as u32;
+
+    for (i, chunk_data) in file_data.chunks(CHUNK_SIZE).enumerate() {
+        let data_b64 = base64::engine::general_purpose::STANDARD.encode(chunk_data);
+        let msg = CoordMessage::TransferFileChunk {
+            file_id: file_id.to_string(),
+            filename: filename.clone(),
+            chunk_index: i as u32,
+            total_chunks,
+            data_b64,
+        };
+        outbound_tx
+            .send(msg)
+            .await
+            .context("sending file transfer chunk to worker")?;
+    }
+
+    transferred_files.insert(file_id.to_string());
+    info!(file_id = %file_id, filename = %filename, size = file_data.len(), chunks = total_chunks, "transferred file to worker");
+    Ok(())
+}
+
 /// Try to assign the next pending chunk to a worker and send it via the
-/// outbound channel.
+/// outbound channel. Transfers any required files first.
 async fn try_assign_work(
     state: &Arc<AppState>,
     wid: &str,
     outbound_tx: &mpsc::Sender<CoordMessage>,
+    transferred_files: &mut HashSet<String>,
 ) -> anyhow::Result<()> {
     if let Some((task, chunk)) = scheduler::assign_next_chunk(state, wid).await? {
+        send_attack_files(state, &task, outbound_tx, transferred_files).await?;
         let msg = build_assign_chunk_msg(state, &task, &chunk)?;
         let _ = outbound_tx.send(msg).await;
     }
     Ok(())
+}
+
+/// If the task uses a dictionary or dictionary+rules attack, transfer the
+/// wordlist and rules files to the worker before sending the chunk assignment.
+async fn send_attack_files(
+    state: &AppState,
+    task: &Task,
+    outbound_tx: &mpsc::Sender<CoordMessage>,
+    transferred_files: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    match &task.attack_config {
+        AttackConfig::Dictionary { wordlist_file_id } => {
+            send_file_to_worker(state, wordlist_file_id, outbound_tx, transferred_files).await?;
+        }
+        AttackConfig::DictionaryWithRules {
+            wordlist_file_id,
+            rules_file_id,
+        } => {
+            send_file_to_worker(state, wordlist_file_id, outbound_tx, transferred_files).await?;
+            send_file_to_worker(state, rules_file_id, outbound_tx, transferred_files).await?;
+        }
+        AttackConfig::BruteForce { .. } => {
+            // No extra files needed for brute-force.
+        }
+    }
+    Ok(())
+}
+
+/// Transfer attack files (wordlist, rules) to a worker via a raw `Sender`.
+/// Used by the monitor which doesn't track per-worker transferred files.
+/// The agent caches files, so duplicate sends are harmless.
+pub(crate) async fn send_attack_files_via_tx(
+    state: &AppState,
+    task: &Task,
+    tx: &mpsc::Sender<CoordMessage>,
+) -> anyhow::Result<()> {
+    let mut dummy = HashSet::new();
+    send_attack_files(state, task, tx, &mut dummy).await
 }
 
 /// Send AbortChunk to every connected worker that has running chunks on the

--- a/crates/crack-coord/src/tui/views/tasks.rs
+++ b/crates/crack-coord/src/tui/views/tasks.rs
@@ -72,6 +72,8 @@ pub fn render_task_detail(f: &mut Frame, area: Rect, state: &mut TuiState) {
     let status_str = task.status.to_string();
     let attack_str = match &task.attack_config {
         AttackConfig::BruteForce { mask, .. } => format!("Brute Force: {mask}"),
+        AttackConfig::Dictionary { wordlist_file_id } => format!("Dictionary: {}", &wordlist_file_id[..8.min(wordlist_file_id.len())]),
+        AttackConfig::DictionaryWithRules { wordlist_file_id, .. } => format!("Dict+Rules: {}", &wordlist_file_id[..8.min(wordlist_file_id.len())]),
     };
 
     let progress_pct = if let Some(ks) = task.total_keyspace {

--- a/crates/crackctl/src/display.rs
+++ b/crates/crackctl/src/display.rs
@@ -126,6 +126,15 @@ pub fn print_task_detail(task: &Task, chunks: &[Chunk]) {
                 }
             }
         }
+        AttackConfig::Dictionary { wordlist_file_id } => {
+            println!("  Attack:      dictionary");
+            println!("  Wordlist:    {wordlist_file_id}");
+        }
+        AttackConfig::DictionaryWithRules { wordlist_file_id, rules_file_id } => {
+            println!("  Attack:      dictionary + rules");
+            println!("  Wordlist:    {wordlist_file_id}");
+            println!("  Rules:       {rules_file_id}");
+        }
     }
 
     if let Some(ks) = task.total_keyspace {

--- a/crates/crackctl/src/main.rs
+++ b/crates/crackctl/src/main.rs
@@ -72,9 +72,17 @@ enum TaskAction {
         #[arg(long)]
         hash_file: String,
 
-        /// Brute-force mask (required)
+        /// Brute-force mask (for mask/brute-force attack)
         #[arg(long)]
-        mask: String,
+        mask: Option<String>,
+
+        /// Wordlist file ID (for dictionary attack, from `file upload`)
+        #[arg(long)]
+        wordlist: Option<String>,
+
+        /// Rules file ID (for dictionary+rules attack, from `file upload`)
+        #[arg(long)]
+        rules_file: Option<String>,
 
         /// Custom charset 1 (-1)
         #[arg(long)]
@@ -288,6 +296,8 @@ async fn handle_task(client: &Client, action: TaskAction) -> Result<()> {
             hash_mode,
             hash_file,
             mask,
+            wordlist,
+            rules_file,
             charset1,
             charset2,
             charset3,
@@ -295,14 +305,42 @@ async fn handle_task(client: &Client, action: TaskAction) -> Result<()> {
             priority,
             extra_args,
         } => {
-            // Build custom charsets list from the individual --charset flags
-            let custom_charsets = {
-                let slots = [charset1, charset2, charset3, charset4];
-                let charsets: Vec<String> = slots.into_iter().flatten().collect();
-                if charsets.is_empty() {
-                    None
-                } else {
-                    Some(charsets)
+            // Determine the attack config based on which flags were provided.
+            let attack_config = match (mask, wordlist) {
+                (Some(m), None) => {
+                    // Brute-force / mask attack
+                    let custom_charsets = {
+                        let slots = [charset1, charset2, charset3, charset4];
+                        let charsets: Vec<String> = slots.into_iter().flatten().collect();
+                        if charsets.is_empty() {
+                            None
+                        } else {
+                            Some(charsets)
+                        }
+                    };
+                    AttackConfig::BruteForce {
+                        mask: m,
+                        custom_charsets,
+                    }
+                }
+                (None, Some(wl)) => {
+                    // Dictionary attack (optionally with rules)
+                    if let Some(rf) = rules_file {
+                        AttackConfig::DictionaryWithRules {
+                            wordlist_file_id: wl,
+                            rules_file_id: rf,
+                        }
+                    } else {
+                        AttackConfig::Dictionary {
+                            wordlist_file_id: wl,
+                        }
+                    }
+                }
+                (Some(_), Some(_)) => {
+                    anyhow::bail!("Cannot specify both --mask and --wordlist. Use --mask for brute-force or --wordlist for dictionary attacks.");
+                }
+                (None, None) => {
+                    anyhow::bail!("Either --mask or --wordlist is required.");
                 }
             };
 
@@ -314,10 +352,7 @@ async fn handle_task(client: &Client, action: TaskAction) -> Result<()> {
                 name,
                 hash_mode,
                 hash_file_id: hash_file,
-                attack_config: AttackConfig::BruteForce {
-                    mask,
-                    custom_charsets,
-                },
+                attack_config,
                 priority,
                 extra_args: extra,
             };

--- a/rules/ATTRIBUTION.md
+++ b/rules/ATTRIBUTION.md
@@ -1,0 +1,52 @@
+# Credits and Attribution
+
+## hashcat
+
+**Author:** Jens "atom" Steube ([@hashcat](https://github.com/hashcat))
+**License:** MIT
+**Source:** https://github.com/hashcat/hashcat
+**Website:** https://hashcat.net/hashcat/
+
+This project orchestrates [hashcat](https://hashcat.net/hashcat/), the world's
+fastest and most advanced password recovery tool. hashcat is developed and
+maintained by Jens "atom" Steube and the hashcat team. All password cracking
+is performed by hashcat -- this tool provides distributed coordination,
+scheduling, and monitoring on top of it.
+
+---
+
+## Bundled Rules Files
+
+### OneRuleToRuleThemStill.rule
+
+**Author:** Will Hunt ([@stealthsploit](https://github.com/stealthsploit))
+**Version:** 1.3
+**Rules:** 48,439
+**License:** MIT (custom rules); incorporated rules retain their original licenses
+**Source:** https://github.com/stealthsploit/OneRuleToRuleThemStill
+**Blog post:** https://in.security/2023/01/10/oneruletorulethemstill-new-and-improved/
+
+OneRuleToRuleThemStill is an optimized hashcat rule set for password cracking,
+refined by testing against real breach datasets to remove non-performing and
+duplicate rules. It is the successor to OneRuleToRuleThemAll.
+
+### Upstream Credits
+
+The rule set incorporates rules from the following sources (as credited by the author):
+
+- [hashcat](https://github.com/hashcat/hashcat) default rules (including `generated2` by [evilmog](https://github.com/evilmog))
+- [Hob0Rules](https://github.com/praetorian-inc/Hob0Rules) by Praetorian
+- [KoreLogic rules](http://contest-2010.korelogic.com/rules-hashcat.html)
+- [NSA-RULES](https://github.com/NSAKEY/nsa-rules) (`NSAKEY.v2.dive.rule`)
+- [duprule](https://github.com/mhasbini/duprule) (optimization tool)
+
+### Usage
+
+Upload the rules file to the coordinator, then reference it when creating
+dictionary+rules tasks:
+
+```bash
+crackctl file upload rules/OneRuleToRuleThemStill.rule --type rules
+crackctl task create --name "Dict+OTRTS" --hash-mode 1000 \
+  --hash-file <hash-id> --wordlist <wordlist-id> --rules-file <rules-id>
+```

--- a/rules/OneRuleToRuleThemStill.rule
+++ b/rules/OneRuleToRuleThemStill.rule
@@ -1,0 +1,48439 @@
+##################################################################
+# ***              OneRuleToRuleThemStill                    *** #
+#       							 #
+#    An optimised revamp of OneRuleToRuleThemAll                 #
+#								 #
+#    ~5% rules reduction with 0% performance loss  		 #
+#    against Lifeboat and LastFM data breaches            	 #
+#                                                     		 #
+#    Updates:                                               	 #
+#    - De-duplication of resulting candidate generation     	 #
+#      (previously literal strings only)                	 #
+#    - Added LastFM breach dataset (~21m unique hashes)   	 #
+#    - Common non-matching rules removed (Lifeboat and LastFM) 	 #
+#    - Ordered by frequency against LastFM                     	 # 
+#                                                              	 #
+#    Blog: https://in.security/2023/01/10/                       #
+#          oneruletorulethemstill-new-and-improved/              #
+#                                                              	 #
+#    Discord:  https://discord.gg/5VpwE9YJ9R             	 #
+#    Twitter:  @Stealthsploit                            	 #
+#    Mastodon: @Stealthsploit@infosec.exchange 			 #
+#    Web:      https://in.security                      	 #
+#                                                      		 #
+# ***                   v1.3 22/12/23                        *** #
+##################################################################
+:
+,7 ]
+,8 $9
+,6 $1
+,7 -4
+,7 +6
+,8 -7
+,6 *45
+,7 $0
+,6 D3
+,9 +5 {
+,6 *30
+,6 $1 $2 $3
+,7 ,8
+,6 Z1
+.6 $2
+,6 $8
+,6 u
+,6 o1o
+,8 i6s
+Z1 c D7
+,7 +6 Y2
+,5 o41
+,5 ,6 ,7
+.6 c
+Y5 '8
+,4 K
+,7 E $3
+,2 ,1 *02
+.6 -9 -5
+,2 ,6
+Y4 x26
+suo $1
+.8 s26
+,3 +3
+,3 .5
+,5 k
+ss7 $7
+,7 .5
+,2 *01
+T7 $1
+,5 *52
+,8
+Z4 '7 }
+.7 o64
+.6 *56 +2
+$V c '9
+.6 i63
+,5 -2
+,4 *30
+.6 +4
+Z1 o75
+.6 +7
+,4 }
+,6 ,7
+ss5 $3
+,3 r
+.6 K [
+.3 $J '4 y4
+so0 si1
+ss5 si1 se3
+,6 $e
+ss5 $6
+ss5 $4
+ss5 se3 so0
+.7 o1e *02
+,3 o4i
+Z2 '8 u
+.4 +5
+ss1 $2 $3
+,3 *02
+,5 i54
+,1 -0
+,4 k
+Z3 *58 '8
+ss9 $8
+,4 *53
+.5 -3
+,3 o4a
+[ T8 +7
+.7 ] -7
+Z1 -8
+,1 +0
+$! T0
+,3 o4e
+,5 i5s
+,3 o4y
+,3 *12
+,4 ,5 ,6
+,2 +1
+ssz $2
+u sSZ
+.4 -5
+,5 z1
+sue -0
+ss1 $0 $1
+,6 *76
+,4 +5
+,4 +1
+ss5 $5
+,4 ]
+,5 $1
+Z1 p2 'A
+T0 TA
+,5 *56
+,5 o0d
+Y1 *6B '9
+Z1 +7
+,5 ]
+@u o53
+$s @y
+Z1 ssz
+@t ^c
+,3 $1
+ss0 $0 $7
+@u +2 [
+sko K
+,4 o6t
+.4 p2 'A
+ss7 $8 $9
+T6 o0f
+so0 $!
+.6 c ]
+ss9 $0
+,7 ,5
+,3 o4o
+@y ^i
+ss3 $2 $1
+^t ^s ^a ^l
+,3 $7 sU;
+Z2 s27
+s26 }
+,4 $1
+,1 ,5 r
+,1 ,5
+.3 +4
+.4 $7
+,7 stG +8
+T8 o70
+.4 }
+,1 ,2
+.3 -3 D1
+.7 +9
+,4 $2
+,4 o51
+,1 {
+.7 o4r K
+,4 *04 .1
+.1 +2
+,3 .4
+^- s-m
+,1 ,4
+Z1 o80 T0
+,6 -2 .1
+so0 $1 $2 $3
+,2 sw2 {
+T0 ,8 $7
+,1 ,3
+Z1 o52
+Y2 *72 '4
+,2 ,5
+,6 ]
+.4 [
+Z1 $7
+$z @s
+,3 ,4
+T6 o56
+.4 *43
+slp +7
+,3 o2k
+.3 k *23
+Z1 o59
+,3 $3
+ss7 $7 $7
+Z1 s12
+ssO D2 D2
+.2 +3
+s14 $4
+,2 ,3
+,3 $8
+,3 *52
+,3 D4
+l $6 $9
+,3 ,4 ,5
+siy $7
+so0 sa4
+skg +0
+,6 i6d
+,1 +3 *12
+.2 *20
+,2 ,4
+sou r
+Z1 -6 [
+.1 k
+Z1 D3 +5
+Z2 *79 o70
+,3 }
+T7 T0
+stm +A
+Y3 x35
+@u o3c
+.4 ]
+} z1
+.3 *45
+ss1 $0 $0
+[ ^w
+.1 *32
+so0 se3 si1
+T0 d
+ss3 $4 $5
+,3 $4
+ss5 sa4 sl7 si| so0
+,3 ^s
+,3 $s
+,6 o71
+l ^1
+Z1 o54
+.5 i5e
+,3 $1 $2
+Z1 o5k
+std *B5
+skr o0d K
+.7 o4j
+sq+ o2b sD&
+.6 o4p
+syi
+^y ^m
+slr +9
+so0 E
+r D2 r
+Z1 o6t
+,1 ,3 ,5
+srn *20
+soa $8
+,1 ,2 D4
+Z2 p5 +7
+y3 '6
+[ Z1 +5
+,3 +0
+,5 i5b
+,6 *46
+s18
+ss5 sa@ se3 si1 so0
+so0 $2
+sHW seo s25
+Z1 +7 D4
+s)2 Z1 }
+,4 o5a
+T6 o2m
+slf *12 [
+.5 .4
+z1 o0a }
+,1 ,4 r
+s&$ o2k
+sck
+.6 Y1 *20
+,3 Z3 D3
+@v o5g
+,1 *41
+,5 o61
+,2 $1
+Y2 o72
+l $8 $6
+,3 $1 $1
+,3 D5
+ss9 $9 $9
+ss5 $1
+l $8 $7
+,2 $7
+Y1 s19 TB
+,1 D2
+sue k
+Y5 k '8
+soa
+p1
+stm i3e
+u sOE
+ss1 $2 $3 $4
+K } }
+smd o1a
+,3 o2f
+se3 $3
+.5 i3a -6
+T6 T0
+.7 E $3
+se3 sa4
+T0 $9
+.7 o0H
+.4 k +0
+Z1 sou
+,4 *36
+,2 $5
+s19
+,3 o1e
+,1 i1i
+y2 smv [
+Z1 i80
+,3 [ {
+$y oB7 -7
+y3 D6 -B
+s25 -6
+,4 $1 $2
+Y4 o9s 'A
+Z1 -6 +4
+s17 oA&
+z1 i1a
+,3 o1a
+,3 D1
+.2 *10 *21
+sae scg
+siy $5
+,4 o5y
+,3 o5a
+,3 E $2
+,3 $1 $0
+,2 $2
+,3 $1 $3
+$f $m
+ss9 $9
+srl
+} T1 -0
+,4 o5i
+u $a
+,4 o3w
+z2 o1o
+y2 o0m
+.5 D3
+ss5 $5 $5
+sae D6
+sx, ssz o9M
+l $8 $2
+] $t
+,2 $4
+.4 r
+T7 o49
+,3 $2 $1
+stl
+.2 *21
+,3 ]
+.3 D2
+l ^3 ^2 ^1
+s16
+l $8 $5
+T5 o48
+ssl
+ssb
+^T o0s D5
+l $9 $2
+T0 i82
+u r
+s27
+,4 i4a
+^t o1r
+$2 $0 $1 $0
+.2 -5 *20
+si1 o60
+.4 Z1 *57
+,2 r
+Z1 i81
+T5 D4
+] suo
+T0 o68
+.4 *56
+,3 o4u
+sea
+,5 l
+Z2 +8
+$r '9
+Z1 o5c
+,3 +4
+Z1 i74
+Z2 o76
+l $9 $3
+@t
+s?Z i4k
+siy
+.3 D6
+Y1 -7 $3
+,3 $0 $0
+,3 c $4
+sei
+z1 } k
+s'i c +7
+syC T7 ssg
+Y1 -5
+.2 [
+s$v l i6n
+,1 E *15
+.2 *52
+,1 r
+$u $s
+l $7 $9
+,2 k *30
+so0 sa@
+,2 D3
+@t +3 o2t
+ss- $m $a $n
+l $8 $3
+s29
+Y1 -5 -5
+T0 T8 T4
+o92 $6
+srw o2u
+,2 D4
+s28 *23
+R7 o0M l
+.2 $0 $1
+l $9 $1
+,2 i2c
+Y2 o78
+,1 ,3 .4
+Z1 i71
+,2 -3
+,3 d 'A
+l $9 $4
+,4 i4k
+soa [
+^r ^m
+soi sy%
+,3 i4e
+,2 +3
+^x ^e ^l ^a
+} } } } c
+sau $3
+z1 -2 -1
+,3 $2 $2
+so0 $1
+Z1 t -6
+Z1 o7i
+[ srv
+Z2 s19
+@y i4-
+Z1 o6p
+^t o1h o2e
+,3 $1 $2 $3
+,2 $3
+sai
+l $8 $4
+l $7 $6
+T0 T3 T8
+,3 i4a
+Z1 i79
+s85 +9
+soe
+sl1
+] ] $y
+,2 $8
+y5 DA
+[ z2 +1
+Z1 $2
+,1 ,2 ,4
+i01 i19
+l $9 $6
+Z3 } }
+,3 i4y
+Z2 -6
+sou '8
+T0 $1 $1
+ssz +3
+y5 '8
+sye
+Z1 *35
+l $0 $8
+T2 T0
+,2 }
+l $9 $5
+,5 i61 i72 o83
+z1 +3 *12
+ssf [ *35
+$y @n
+.5 o6o
+z1 D5 *13
+z1 *31
+Z1 u +6
+.5 o4h
+st6 +4 *45
+l $!
+] T0 D7
+ss4 $m $e
+Z1 *25 D3
+Z1 $5
+T1 T0
+l $9 $0
+Z2 o67
+^u k *6A
+T0 r
+,3 $7 $7
+] y4
+o77 o0d
+] ] ] Z1
+^x ^a ^m
+sio
+Z1 s26 p5
+l $8 $1
+sua
+stp
+.2 $0 $9
+si1 o50
+^r ^e ^p ^u ^s
+T5 o40
+l $7 $5
+y4 D7 D7
+s15
+sae -2
+Z1 D3
+.5 $2
+y3 K D6
+s14 -7
+^u ^l
+Y1 +5 *64
+Z1 i69
+z1 *06
+sgo +2
+se3 $1 $2 $3
+D2 ^b
+,4 ,5
+Z2 +6
+T6 o3f s4b
+} } } } } } Y4 '4 d
+.5 *45
+$6 Z2
+^s o1t
+ss1 $9 $8 $4
+$2 $0 $0 $9
+s18 Z1
+.2 o0f
+l $6 $6
+i01 i12
+,2 $1 $2
+siu
+ssc ]
+,2 D5
+stR l
+.3 D5
+.2 o0g
+s24
+l $7 $8
+,3 $9 $9
+,1 ,2 ,5
+l $4 $2
+ss1 $9 $8 $6
+^o ^g
+,1 K
+.1 i2m
+so0 se3
+.4 c
+^e ^v ^o ^l ^i
+l $7 $4
+,2 y2 *45
+l $9 $7
+^y ^b ^a ^b
+$W l
+ssj K i0b
+u sL1
+l $8 $0
+,3 *30 k
+$u @k
+Z2 +7 +5
+,3 $0 $2
+s08 $3
+Y2 D7 K
+ss2 $0 $0 $1
+.3 i48
+.2 o1i
+s08
+s14 o1o
+Y2 o74
+ss1 $9 $8 $5
+,3 $0 $5
+Z2 o68
+s25 K
+@s six
+l $7 $2
+Z2 -5
+Y3 o94 ]
+t $6
+sdk *74 +5
+T0 ^7
+s_c $0 $0
+T6 i47
+Y1 $4
+.4 +7
+l $7 $3
+Z1 *60 {
+Y1 $8
+Z2 T0 -7
+,7 i7u
+Y2 D7
+$y o5t
+$T l
+ss1 $9 $8 $2
+l $2 $6
+^y ^m T2
+l $8 $8
+^s o1h o2a
+,6 o1x
+.4 t
+ssn
+Y1 $6
+Z2 +5
+,2 '7
+^t o1h
+$s $1
+[ ^v D1
+o60 ^a
+T0 D8 D5
+$x @c
+Y2 o79
+Z1 snl
+} z2 c
+,5 ,6
+y4 Z4 '8
+,2 o3k
+.4 K y2
+siy $2
+l $2 $7
+T7 T6 T5
+z1 *03
+@r -7 D3
+ss1 $9 $8 $1
+{ snm [
+,3 $0 $3
+.2 $2 $3
+s17 *34
+Z2 +7 o50
+Z1 o0k
+i02
+,2 +4
+^t smt *21
+T0 std
+ss2 $0 $1 $2
+sa4 so0 si1
+l $4 $7
+z1 *31 *34
+i04
+T4 +3
+} x04
+.4 k
+,2 $0 $1
+T0 T5
+Y2 slp
+s07 ^5 sS'
+,1 -2
+Z1 +7 o0a
+ss1 $2 $3 $4 $5
+.2 $8 $8
+Y1 +5
+o7.
+.4 $8
+,2 *34
+z1 i1i
+y2 o0d
+ss1 $9 $8 $3
+Y1 i90 -8
+,1 +2
+.3 i4m
+syj
+smh D6 *31
+szs
+Z1 i62
+,2 o3p
+.4 k .3
+$m $u $s $i $c
+l $6 $5
+^t o1h i2e
+l $5 $6
+^s o1p
+} r l
+soE o68 [
+x14
+$z D4
+^Z l
+y1 .9 *21
+Z1 o0b
+s36
+l $5 $7
+se7 i65
+s1k
+T0 i86
+sae D2
+Z1 o4a
+$x D6
+.4 *68 *57
+z1 l *16
+^t o1o
+Z3 o70 +6
+$x D5
+r '6
+^u ^m
+$! Z1
+,2 ^b
+Z1 +9 i85
+Z1 $1
+l $2 $8
+,1 -3
+.3 r
+sg5 k r
+p4 x5A '6
+,1 D3
+Z1 *50
+Y1 $3
+o76 o89
+T4 o0s
+s16 -5
+s07
+o78 o87
+,3 $a
+l $1 $8
+,2 Y1
+] ] ] $y
+o66 $9
+ss2 $0 $0 $8
+l $9 $8
+,1 D4
+l $5 $9
+l $3 $1
+z2 o1u
+Z1 $a
+y2 o0k
+ss1 $9 $7 $9
+,2 i53
+sao r
+T4 { {
+i0t i1h i2e
+o72 o61
+Z1 T0 $9
+,2 $1 $1
+l $1 $6
+sep *12
+Z1 o43 l
+^R l
+,4 *06
+R1 o01
+l $7 $1
+Z1 i64
+,2 *62 r
+,1 +3
+s35
+,2 $9
+,4 i4p
+s79
+l $6 $8
+o90 $7
+sdx *53 s4]
+stz o4z
+s10 i83
+ss2 $0 $0 $0
+l $2 $5
+ss1 $9 $9 $0
+T0 i89
+^w ^e ^n
+ss1 $9 $7 $4
+[ ^W
+$2 $0 $1 $1
+o8.
+l $6 $7
+Y2 K D5
+si1 TA
+ss- $b $o $y
+i9.
+,1 $1
+z2 *40 +1
+l $2 $9
+Y2 o53
+T5 o0M
+so0 o41
+ss1 $9 $7 $8
+smo *45 -3
+,2 $1 $0
+s32 +5
+^u D5 }
+s09
+,2 i04
+l $1 $7
+$*
+] Z2
+$s $t
+^u ^j
+] spb
+^y ^m ]
+.4 { r
+.2 $9 $0
+ss1 $9 $7 $5
+sau *57
+Z1 o49
+Y2 *89 +6
+l $1 $9
+o71 o89
+.2 $9
+Z2 *50 [
+sld
+,2 $1 $3
+ss1 $9 $8 $9
+s18 *40
+l $3 $7
+[ p4 '8
+ss1 $9 $7 $6
+s14
+} z1 }
+,2 i2z
+u sI1 $1
+sge o4n
+u $m
+T0 -7 +5
+s13 K
+Z1 $9
+r k
+[ Z1 ,5
+p5 i44 ]
+o9i $e
+Y2 o62
+smg
+l $5 $8
+^s o1l
+l $2 $0 $0 $7
+s13 Z1
+,4 i51 i62 o73
+l $8 $9
+srh *27
+Y1 [ +4
+l $6 $4
+Z1 o7p
+T0 T1 T2
+ss1 $9 $9 $2
+T0 *58 *56
+ss1 $9 $7 $2
+l $0 $6
+s15 -2
+so0 ]
+Y2 o55
+s93
+} } y2
+s46
+^v ^u ^l ^i
+seu *02
+l $4 $0
+s1- swf
+l $3 $6
+^t ^o ^h
+smk
+sa@ $1 $2 $3
+s8D ^d -6
+$o $n $e
+y2 o0j
+T3 sbP
+,1 -4
+ss0 $9
+s06
+[ y5 c
+sS1 i12 i23
+u sE3 +1
+z1 K
+^z D3
+$t $e
+Z2 s18
+srs saj
+ss1 $9 $9 $1
+s)a i2d
+s75
+s1i s0o
+,3 $4 $4
+sym
+^P l s.y
+s58
+T1 o01
+l $6 $2
+y2 o2t
+.5 .2
+ss1 $9 $7 $1
+l $3 $0
+T4 *53 r
+l $5 $0
+,2 z1
+t T3 T1
+^t o1i
+t sOA
+Z1 ,8
+^s o1h o2i
+^z D2
+sio K
+,2 sC+ t
+Y1 -0 +5
+,5 $1 $2 $3
+r ] K
+sas o1k
+^r ^a ^m
+stp ]
+$y $a
+l $2 $0 $1 $2
+Z1 i63
+ssn i59
+^t ^a ^c
+y3 D5
+l $3 $4
+o6i o0c
+y2 o0s
+s69
+Z1 o0l
+^r ^d
+skc
+seu
+R0 { ^k
+] Y3 ]
+Y2 o84
+.4 Y1
+l $2 $0
+l $5 $2
+.4 o68
+l $6 $3
+Z1 i56
+R6 L6 o55
+si! se3
+T4 sau
+,4 $1 $2 $3
+z1 ^a
+$z -5
+.2 ^c
+u o62 o7K $6
+l $4 $8
+t D2
+Y2 o59
+,2 $a
+Z1 z1
+i8.
+o76 o62
+Y2 o56
+l $5 $1
+^y k
+Z1 E $5
+ss$
+spf i63
+^t D3
+y3 -1 [
+l $4 $9
+[ sez o51
+c $2 $0 $1 $0
+u $j
+Z1 o6R c
+r D3 i01
+Z1 sc@ D5
+^t ^a ^f
+,1 D3 ]
+p1 D3 '9
+sli sU. *86
+.1 +0
+s24 T0
+s12
+T5 o0S
+$t $h
+$s ^2
+l $5 $3
+^v o1i
+[ ^r
+} y5 '7
+^u ^j ]
+r $6 $9
+s20
+ss1 $9 $9 $4
+o67 o79
+ss5
+s13 c
+o95 +8
+^m ^a ^i
+Z1 E *45
+s13
+ss1 $9 $9 $3
+^s ^i ^r ^h ^c
+i76 i86 i96
+ss1 $9 $7 $0
+z2 D6 *14
+l $5 $4
+z1 i1e
+i02 i13
+l $3 $2
+^s ^e ^m ^a ^j
+Z2 saE E
+^o ^n
+,1 ]
+l $6 $0
+,2 $2 $2
+} } } c
+^w
+Y3 *97
+^y ^a ^j
+^s o2a
+] Y2 o79
+.2 K -5
+^o ^e ^l
+t ^s
+$Z t
+ss2 $0 $1 $1
+o72 o89
+o60 o78
+^s ^a ^l
+^s ^a
+] ] $s
+.6 $9
+^s o1i
+[ sgs o3p
+seo *54
+[ ^p
+^t ^s
+l $4 $6
+.2 $1 $9
+Z1 D3 k
+p3 o68
+i01 i13
+^u ^k
+z1 t +5
+s{! o24 *25
+Z3 s15
+ss1 $9 $9 $6
+u o62 o7K $7
+Y1 +8 $0
+r ] ^k
+l $4 $3
+Y1 i66 -5
+,2 .0
+$4 $2 $0
+y4
+^t D2
+^s o1h
+.2 $1 $4
+s1l
+o66 o79
+^o ^j
+Z1 i58
+y2 o2k p4
+ss2 $4
+s04
+y3 [
+$. Z1
+^o ^i ^d ^a ^r
+^l i1a
+.1 .0 +0
+^u ^s
+sp> *68 o26
+i02 i10
+.2 i2a
+,2 i2w
+.2 $2 $7
+s05
+^y ^z ^a ^r ^c
+sln
+r o0g
+l $4 $1
+sC7 stj
+Z1 s93
+t $1
+z2 +2
+] stf
+y2 o0p
+.4 Y2
+y2 *35 -2
+Y2 [ o44
+ss2 $0 $0 $6
+E se3
+ss1 $9 $9 $5
+smp
+s21
+o1f [
+Y5 ]
+$r $u $l $e $s
+^R l ^a
+,3 $1 $2 $3 $4
+s06 }
+s03 l
+o77 o88
+,2 ^s
+.3 o0p
+Z1 t
+.3 -6
+sae $1
+^c ^i ^s ^u ^m
+$r $o $c $k $s
+$V l
+l $6 $1
+$s $o $n
+t s17
+^w *21
+,2 ]
+$y $1
+p4 i4i
+,6 o7e
+st- *34 o3c
+ss2 $0 $0 $5
+i01 i10
+Y4 ] ]
+ss6 $9 $6 $9
+l $3 $5
+.3 Y1
+[ s2f o3a
+Y3 D7 +5
+.2 $3 $3
+y2 o0h
+o80 o99
+i6-
+T0 *45
+[ ^s
+l $3 $8
+^o ^b
+T0 T7 T5
+.3 -5
+T3 o59
+ss4 $l $i $f $e
+sS1 $2 $3 $4 $5 $6
+T0 T4
+s49
+^t D4
+,6 i71 i82 o93
+t o11
+Z2 o68 -4
+R0 sea {
+^u D2
+T4 o0L
+$* i0*
+r o0b
+p4 o7l o6a
+^u ^g
+.3 o51
+u $2 $3
+o73 o85
+$l $o $v $e
+o5.
+o77 o69
+[ r D0
+^u ^d
+Y3 D4
+u $S
+$v -5
+Z1 o4m
+l i7.
+^o ^m
+oA5 -9
+l $7 $0
+l $2 $4
+r D5
+,2 $1 $2 $3
+o82 o94
+$v T0
+$t } D5
+ss2 $5
+l $4 $4
+u $1 $0
+o74 o85
+o70 $9
+Y2 s15
+^t *03
+o79 -6
+Z2 sth D2
+,2 o3b
+s&v [ -7
+^x y1 {
+^m ^f
+.2 Y2
+Y1 $8 *65
+o81 o98
+^s o1h o2e
+s23
+snp -4
+sls
+o68 o75
+,2 *64
+y2 slp
+^v
+Z2 '4 q
+T6 T8 T7
+.2 $5 $5
+ss1 $3
+^o ^k
+,5 o0L
+.2 +0
+$x D4
+^u D4
+scs
+Z1 *56 ssu
+^t ^s ^u ^j
+z2 t o24
+u o40
+u o33
+sau +0
+o7o $2 D2
+.4 i75
+$v $a
+$r $o $c $k
+o81 $5 -5
+o1l [
+,3 o0M p3
+Z2 l +A
+z2 o1y
+o5i D4
+,7 i8e
+c so0 se3 si1
+] p3 '9
+y4 K
+x23
+ss2 $0 $0 $3
+^y ^r ^a ^m
+t D4
+p5 i4s ]
+smf
+[ r *20
+smj
+$s o0b
+^y ^d ^a ^l
+$s $2
+u o45
+u '6 $5
+o8o ] ]
+o68 o74
+z1 { $s
+o0k sea
+Z2 *45
+ss1 $9 $9 $7
+i03
+^y ^d ^n ^a
+Y2 *93 [
+,3 $m
+$y D1
+r $8 $6
+$y $o $u
+^y ^a ^m
+$t $e $r
+^w D2
+$x Z1
+y2 o0t
+u $6 $9
+s87 E -0
+[ srp
+u i34
+Y2 -8 D6
+T0 o44
+$y $o
+o61 i72 o83
+} x13
+^s o3r
+} Z1
+p5 *24 [
+$o sbf
+p2 ] ]
+,1 o2s
+ss2 $0 $0 $4
+r $8 $4
+Z1 o4n o3a
+y2 o2m
+o68 o77
+o64 $0
+sa4 si1 se3
+ss1 $9 $6 $5
+sg_ +4 *64
+Y1 *12 D0
+} u }
+stx s[) i8i
+[ Y3 ]
+^y r
+^y D2
+i0b i1i i2g
+Z1 s90
+[ y2 +1
+} t
+o67 o75
+o67 $8
+] ] ] $s
+c *78 $*
+ss2 $0 $0 $2
+Z2 oA! E
+o67 o74
+r $1 $2
+Y2 o45 -5
+Z2 k +6
+r $8 $5
+r $1
+o76 E
+@s i1H o1n
+^s ^e
+o79 o88
+$x D2
+si1 $1
+Y2 +7
+srf
+^l ^e
+u o0M
+l $3 $9
+[ $t
+o77 $8
+u $2 $0
+y2 T0 *42
+p4 o3z
+o91 oA2
+r D0
+Y1 o4e
+$2 $0 $0 $8
+] sio
+Z1 o4n
+.2 +1
+i5-
+] u r
+^o ^c
+t D1
+u $q
+i66 i76 i86
+o84
+z2 *51 D4
+ss1 $9 $6 $4
+,3 o0v
+u o0B
+^y ^e ^k ^n ^o ^m
+[ r d
+o69 o74
+o69 o72
+s>' sis
+y2 o2s
+^s o2i
+u o43
+T6 ,5 *43
+$s -6
+o10
+,3 i3g
+sau *20
+r $7 $9
+s0. *86
+^u ^e
+^s ^s ^i ^m
+$u [
+$s r
+Z1 i41
+u k +0
+s26 $1
+r $8 $7
+^y ^e ^h
+Z1 o3t
+s2#
+o13
+Z1 i42
+^p o1l
+Y2 +8
+u i49
+o60 o79
+u i45
+z2 l -0
+$l $f
+ss8 $8
+r $a
+o69 o76
+o2l [
+^t ^t ^a ^m
+o3f [
+T0 T1 T2 T3
+] Y3 *8A
+$x -5
+o54 i62 o70
+$r $o
+i07
+^t o2i
+$* Z1
+^v ^u ^l
+.2 i3r
+c $2 $0 $1 $1
+^s i1o
+u $1 $2
+^z ^a
+^s D4 *20
+^r ^j
+u D5 D1
+.2 l D4
+u $0 $9
+ss1 $9 $6 $7
+s1. i43
+.5 o0T
+r D1
+] o8j o2d
+Z1 { {
+Y4
+o96 $4
+o68 o72
+^u ^h
+$y D8
+p2 '9 -7
+o62 o74
+] Z1 -2
+Y4 [
+^s o2e
+$z $1
+si1 ]
+p5 *78 -8
+$?
+u $2 $5
+,6 o7i
+o56 $9
+s30
+$s $a
+$s $1 $2
+r $1 $3
+$z $a
+s1o
+y2 o2v
+o82 $5
+u $1 $3
+^j $d }
+.2 o55
+o7m D6 ,9
+^y D3
+r o14
+o67 o76
+s52
+r *53
+$u $n
+$s D1
+o69 o75
+Y1 *72 *36
+o7!
+y4 E
+^u ^f
+u $b
+sr1 D6 c
+o21 [ [
+Y2 -6
+srz
+o5k D3
+sec {
+s65
+u $5 $0
+o62 o78
+^t ^a ^m
+^r ^e ^t ^s ^a ^m
+^w o1h
+] sau
+^s o3n
+^k ^c ^u ^f
+^r ^a ^c
+^k ^c ^a ^l ^b
+u $0 $8
+u $0 $7
+o7m D8
+s3$ .3 o4e
+o75 i72
+Y2 k D4
+.3 $s
+o62 o75
+^y ^x ^e ^s
+^s D3
+y2 +3 +2
+o63 i72 o81
+Z1 i48
+,3 i4n
+^y ^l ^i
+$t i7a
+ser
+Z2 +6 }
+T2
+syt
+o79 D6
+o68 o79
+^w D3
+o83
+o60 o76
+i08
+^y ^t
+^s o2o
+u $3 $0
+$v D5
+r $0 $9
+.2 ] r
+,1 .3
+y2 o0f
+ss1 $9 $9 $8
+o70 +6
+u $k
+o69 o71
+$y sQi *52
+u d '7
+T0 i6_
+y2 D6
+o4k D0 D0
+^u ^r
+^o ^d
+o78 $4
+Y1 E $7
+r o37
+^y ^k ^s
+.4 $1
+o88 +6
+o67 o78
+r $9 $4
+i01 i14
+o61 i70 o81
+^y ^p ^p ^a ^h
+$t $1
+o0r ^b
+o0d o1j
+Z1 seu
+] Y2 [
+o61 o73
+o3l [ *01
+slg +7 ,A
+sdg
+T4 T6 T5
+sas
+r $0 $8
+^s ^a ^c ^u ^l
+.3 $a
+snf
+ss1 $2
+o69 o70
+slt
+o69 o73
+.3 o13
+o67 o72
+] Y5 E
+Y1 ^2 }
+.2 r
+u T1
+so0 $s
+o77 -6
+o7@
+o61 o70
+^y ^k ^c ^u ^l
+Y1 +2 [
+.5 $s
+o2d [
+$o $k
+y2 +2 -0
+o71 +6
+^p ^j
+Z2 } ,1
+$s $h
+o58 o66
+] Y1
+y3 D4
+u i33
+r *30
+o65 [
+,2 .4
+o63 o79
+[ siy
+r o35
+c $2 $0 $0 $9
+y2 -2
+u i48
+r $8 $2
+o13 o01
+l ^g ^n ^i ^k
+seo '9 $n
+sdt
+z2 K +0
+sa4 se3 so0
+u $0 $3
+o71 i82 o93
+^w o1i
+sbd
+Z1 t $2
+Y2 } r
+T4 T0 D2
+$$ o80
+r $8 $3
+i01 i18
+^e ^v ^o ^l
+[ T3 ^D
+Y2 -7
+u o51
+o59 i57
+,3 $o
+r $9 $2
+o1h [
+l $3 $3
+^x D2 D3
+i01 i17
+Z2 -7 *52
+u +8 +0
+o88 ,9
+o65 o79
+u [ *20
+u i43
+u $0 $6
+l $2 $0 $0 $6
+y2 } }
+s28 Z1
+^y ^m l $1
+t $9 -7
+o0r ^g
+i01 i15
+Z1 o3i
+t $0
+Y3 *40 [
+o62 o77
+o58 o69
+[ y3 D4
+o44 [
+o73 -6
+o58 [
+^m ^i
+R3
+r *02
+^9 ^6
+r ^k
+T0 snv s-I
+o65 o76
+^u D3
+.2 *47 o0l
+u d '9
+^t ^r ^a
+.2 -5
+r $9 $3
+o60 { ]
+$u $p
+u D0 +2
+o77 i64
+[ z1 -4
+o1@ T0
+^y p4 D7
+^u ^t
+^o ^l ^l ^e ^h
+spt
+o66 o74
+[ y3
+u D4 +5
+u $0 $1
+^z s&5 +1
+^y ^t ^r ^e ^w ^q
+^y ^c ^u ^l
+^o ^l
+T0 +8 +4
+y2 +2
+sV> i1i *13
+.2 ^5
+ss1 $9 $6 $0
+o71 -6
+r $7 $5
+$u $k
+$t $i
+syf
+ss1 $9 $6 $2
+ss5 se3
+s81
+Y1 +4 $3
+,6 i6s
+{ { { { r
+o66 o78
+Z1 *34
+] Y2
+,1 o0D
+r $9 $0
+l $0 $9
+u $1 $6
+t *12
+o8k D6
+^t o2o
+r *53 *42
+o57 o69
+r $7 $6
+o5a D3
+o58 o67
+T0 scK
+$q s/q
+r $9
+r $1 $0
+^s ^u ^s ^e ^j
+o68 o73
+o5a D6
+u $1 $5
+^p o1i
+u $c
+u $1 $7
+ss2 $0
+sbg
+^s ^r ^m
+Y1 o0h
+T0 $n
+$x $1
+o55 o44
+^t ^o ^n
+^r ^o ^f
+Y1 i62 ,5
+,1 .4
+u $0 $5
+i00 i11
+Z1 o5_
+Y1 o2j *20
+^s ^m
+] smb
+$r $a
+Y2 o0m
+T4 T3
+^s D4
+Y1 o0f
+Y2 +9
+u o31
+r $7 $4
+^t ^e ^g
+T0 i68 *48
+u *31 s;`
+o67 o73
+$1 ^1
+si1 o6@
+o0f i1r
+T0 o4r
+i3-
+^t ^a ^k
+^y ^l ^i ^m ^e
+t $0 Z1
+o86 i1o
+o7a s+, s\G
+y2 *42
+ss0 $5
+se3 ]
+^s r
+o71 D3
+Z2 o6o
+s7e *21 *04
+^f ^l
+o75 smt
+o64 i75 o86
+Y1 o4b
+$s ^3
+skd
+[ y2
+ss1 $9 $6 $1
+T0 s9$ *57
+,3 $d
+u i32
+r $9 $5
+sae i2m
+r i15
+^t o2e
+r $9 $7
+r $8 $0
+o2c D0
+$o o6g
+o63 i76 o80
+o57 o65
+^o ^m ]
+ss4 $e $v $e $r
+^s o2u
+@p -2 i2l
+t *20
+syI c
+i4.
+Z1 t [
+^t ^n ^a
+y2 *35
+o7e o8r
+Y2 -5
+R4 R5
+$x $3
+o60 o72
+u $2 $4
+i02 i17
+i00
+@y ^G
+} r {
+o65 o72
+Z1 o2s
+y4 D0
+u i42
+u $6 $0
+r $7 $8
+o57 o63
+o57 o61
+^k ^r ^a ^d
+.1 r
+o58 o63
+o58 o62
+T2 o3i *02
+u $2 $8
+r $2 $4
+,3 i4k
+o68 i70 o88
+s31
+o8s o5n
+r $2 $3
+r $2 $0
+o69 K
+o61 o78
+$s $u $c $k $s
+$1 $9 $8 $7
+o9_ *78 i6f
+o5e $1 $2
+.2 *41
+o4l D3
+T0 i3s
+.4 $s
+r $5
+o58 o60
+,3 $i
+$t $o $n
+o56 o69
+r ^3
+^! T1
+ss1 $9 $5 $8
+s2d
+^v D2
+Z1 *46 *12
+$S ssP c
+r o32
+o58 o65
+o54 sS2 $0
+i01 i11
+ss0 $4
+o4k [
+^u ^c
+T5 o0A
+$s D7
+u o1A
+u $0 $4
+sac ,B
+r $5 $7
+^v D3
+y2 +0
+s6s i1g
+o2b *02
+^n ^e ^e ^r ^g
+u $9 $0
+r o30 l
+o1a $0 $9
+Z2 *42 -5
+szs ^a ^t
+o57 $8
+o3v [
+T7 T8
+o70 o88
+l $0 $7
+^t i0a
+z1 $1
+r i26
+o3n D2
+u $5 $2
+o61 o76
+o2k [
+Z2 o7s
+Z1 *42 +3
+u $0 $2
+o65 o78
+,3 o0L
+z2 T2
+u $7 $8
+u T8 $!
+y2 *40 +2
+t $5
+Z1 o31
+Y2 o6l
+$1 $9 $9 $1
+r $6
+r $8 $1
+o67 o70
+Z1 -0 -0
+.2 D5
+,1 ,2 .4
+$p $a $s $s
+r $7 $3
+Y2 sio c
+o60 o75
+$@ R7
+u $2 $1
+t T5 T4
+o14
+o58 o64
+^y ^n ^o ^t
+^o ^l ^a ^h
+^s ^o ^l
+.1 *13
+u $1 $8
+ss1 $4
+o53 D3
+[ t D2
+Z1 $e
+o61 o9S c
+i02 i11
+,1 .2
+^x D4
+Z1 o3o
+^s ^i ^u ^l
+u o41
+o6c o7o
+o54 o69
+o67 o71
+o65 o77
+$s o5m
+s51
+o45 o56
+z2 *31
+u $2 $9
+o0i o1a i2m
+i02 i14
+^u ^p
+Y2 r +3
+Y2 o77 *61
+} su7 i25
+^x D2
+u sI1
+o51 o62 o73
+o00 ^1
+r $6 $5
+s9{ ] o7n
+o71 o80
+o0l o1a
+u i51
+o64 o72
+l $1 $4
+o4s [
+y2 *26
+^o ^j ]
+r $2 $5
+sUI [ ,2
+o86
+o66 o77
+o62 o70
+i2- i5-
+.3 $1
+l ^d ^e ^r
+u $1 $4
+o69 $8
+$t $a $r
+ss1 $5
+o59 o68
+,1 i2e
+o65 i70 ,8
+Y2 o0l D3
+o2b [
+i06
+u D5 $1
+o59 [
+o47 o55
+[ Z2 k
+ssg
+r i56
+o60 o74
+^t
+u i41
+r [ o3d
+o3i [
+] Z1 ^f
+o7k o2j
+o67 +5
+u $4 $7
+s31 c
+o66 o75
+o5a $1 $0
+o3l D0
+o0M $1
+Z2 o0b
+} R0
+o7k o8a
+o57 o68
+Z1 {
+ss3 $0
+o6k o7a
+o54 D2
+o0f i1l
+o45 o57
+ss0 $3
+o87 ,9
+o5o $1 $0
+p3 T0 'A
+$x Z2
+y2 o23
+t D3 $4
+ss1 $0
+snz
+o3m *03
+say
+p1 *96 '9
+Y1 -4 *74
+sbp
+$s $1 $3
+z1 ^e
+ssy
+sad
+s90 T0
+r $8 $9
+u $7 $0
+l $7 $7
+^p o1a
+$1 $9 $8 $4
+u $4 $5
+^p o1o
+$s i6e
+l $f $a $n
+^y ^M
+.2 i4i
+o2c o3k
+u $8 $7
+o92
+o59 o65
+^y ^l ^i ^l
+^l ^e ^i ^n ^a ^d
+E } }
+y2 D6 +4
+l $a $b
+i00 i10
+^t ^s ^o ^l
+$1 $9 $8 $9
+$1 $9 $8 $6
+o65 o70
+o50 i69 o78
+Y2 o42
+r $8
+o41 o0g
+o57 o60
+z2 o0m
+s90 +0
+r $a *13
+r $3 $6
+p5 *68 $0
+T0 T2 T4 T6 T8
+^s D2
+z1 u $0
+y2 u o32
+r $6 $4
+^w ^e ^r ^d ^n ^a
+oA! c }
+$t $i $m $e
+r $5 $9
+i09
+Z1 u $3
+$r $e $d
+s1<
+o3-
+^t ^a ^p
+.2 $3 $5
+$v D3
+t D6
+i31
+Y2 *94 *45
+$t $o $m
+y1 $5 *14
+s25
+r $2 $8
+z1 *31 *20
+o3h D2
+Z1 o3n
+i02 y1
+^x ^o ^f
+^x D3
+u $8 $9
+o3h [
+^w ^o ^d ^a ^h ^s
+r $2 $7
+o66 ,7
+^u o2i
+y2 o2p
+u o0A
+r $5 $8
+[ o3s D2
+$! o6o
+o57 o64
+o4u o5s
+o3g *30
+o0l ^a
+^u i0a
+^r ^e ^l ^l ^i ^k
+o5e [ D2
+o58 +4
+,2 i3b
+$1 $9 $9 $2
+sae c
+o3c D1
+Z2 o0d
+u [ ]
+r i67
+r i58
+Z2 *64
+$+
+u i53
+o6e o7r
+o54 o65
+sf> ,2 *41
+o3u D2
+z1 *02
+^y ^a ^k
+$u $r
+o61 o75
+o66 o70
+o63 o74
+si1 o40
+r $3
+o45 o50
+[ Z3 D4
+u i31
+l $d $o $g
+r $2 $6
+o64 E
+o5G l *50
+o57 o66
+o3k o4a
+^y ^d ^o ^c
+T4 i4_
+y4 o3a l
+u $g
+r $4 $0
+^s o1u
+} } } } }
+Y3 *72 ]
+T0 T5 T8
+y2 -1
+ss2 $0 $1 $4
+r $6 $8
+o68 o70
+[ o54
+^r ^e ^f
+Y2 r T4
+o4m [ *32
+^z *30 -1
+u sS1 $A
+s2# *31 i1e
+o42 i50 i61 o70
+u $6 $4
+t $5 -8
+r $6 $3
+o63 o70
+saf
+o65 o74
+u i64 o7U
+u $3 $1
+o93
+o66 o73
+$w { [
+$s $0 $1
+u $5 $6
+ss3 $4
+o0B $1
+^s ^i
+u $6 $8
+Y3 *48 D6
+u [ +4
+s0m
+r *34 [
+c $6 $6 $6
+r $0 $1
+o68 -5
+ss1 $6
+o68 o71
+R4 o54
+$s o5p
+s93 o0L
+s90
+^u ^o ^y
+Z1 t D4
+.4 o0S
+o6f { [
+o0S $1
+^p D2
+u *34
+r $0 $6
+^r ^g
+o4s D5
+^s D6
+o65 K
+^6 z2
+z1 t i29
+o7b
+o61 -5
+Z1 o0s
+T4 o0R
+{ Z1 i53
+u $1 $9
+o5r $1 $2
+^r ^a ^b
+o54 i51
+Z1 o0t
+o6b D4
+Y2 -8
+.2 o4i
+} z2 +0
+o7e o5i
+^s i0j
+^s ^t ^i
+u $3 $2
+r $9 $8
+o97
+o72 o84
+o54 o40
+.8
+$1 $9 $9 $0
+o0C $1
+T7 [ o0J
+u $2 $6
+o59 o63
+c $8 $7
+$r $1
+t k
+r $7 $2
+Y3 t D3
+T1 k -2
+T0 R5
+u sCK
+u $4 $2
+l $e $r
+Y2 -5 *34
+,4 i4x
+r $5 $6
+o71 o82 o93
+o46 o54
+o18
+o0b i1l
+.2
+o11
+Z1 o2p
+$a $b $c
+o64 o78
+o5-
+o4e D5
+Z3 -6 -9
+y2 o2j
+o56 i52
+[ $s
+sbh
+o31
+^y ^k
+Z2 *26
+$1 $9 $8 $5
+ss2 $9
+sb8
+sa@ si1
+r $2
+^w D5
+r ] ^p
+o48 D0
+y5 [
+y2 $8 [
+r $1 $8
+o58 o61
+Z1 i6k
+x14 p2
+o6i o7n
+o66 o72
+o55 i66 o77
+^u *04
+Y2 *84 D8
+T4 T1
+o64 o77
+o45 o58
+o4k o5a
+^t ^m
+Z2 u +9
+o6m Z1 '8
+o58 K
+o0l o1i
+r $1 $4
+o77 o2h *12
+o63 o76
+o48 o54
+o3k D0
+$2 ^1
+r +0
+[ Y1 o1b
+r $1 $7
+o63 o75
+o53 o66
+o4a $1 $2
+i09 i19
+ss6 $7
+^s ^a ^m
+Z2 { +4
+Y2 Y2
+R5 i66
+snx
+r $5 $3
+r $4 $8
+o6e o5l
+o5j *50
+^z ^z ^a ^j
+^y ^r ^r ^a ^h
+^o ^r
+Y4 D7
+Y2 *35
+T0 T4 T3 T2 T1
+o4m o5a
+^y ^l ^f
+T0 i7e
+t r D2
+r $3 $4
+o23
+u $4 $6
+o6s $h
+o58 i60 o78
+i02 i16
+,2 .3
+u *46
+r +5
+r $7 $1
+o0m o1i
+o61 o77
+o33
+o0m o1a
+Z2 *06
+r o3k
+o56 -0
+^s ^o ^l ^r ^a ^c
+o63 o77
+$9 $8 $7
+o65 -5
+o60 $1
+t D3 *02
+o7c o8o
+^@ T1
+o6k [
+o2g D1
+$. Z2
+y2 +3
+l ^e ^e ^r ^f
+r *64
+o91 K
+o4c o5h
+o4a $1 $3
+^d ^i ^v ^a ^d
+Z1 i43
+T0 T8
+$r L8
+z2 *60
+u $9 $8
+o55 o67
+o59 o41
+R0 z1 D2
+$w $o $r $l $d
+$1 $9 $8 $8
+o61 i72 i83 o94
+o50 o69
+o04 i02
+$v $e
+$t $o $r
+$1 $!
+r $5 $0
+y3 o2n
+^s ^d
+^q
+Z1 o1u
+@s
+o6h '8
+z1 } }
+o54 o67
+l $0 $5
+[ y2 t
+o68 ,7
+R5 $4
+R1
+u +3 *30
+r ^5
+o57 o62
+^o ^h
+T3 T5 T4
+$l $o $l
+r z1 D6
+o47 o54
+o3e [
+^u ^r ^b
+} } z2
+o98
+o58 i69 o70
+o45 o52
+o04
+l i89
+u $5 $4
+o5l D6
+o3t o0b
+^u ^n ^a ^m
+^u ^a ^l
+$s $2 $3
+o46 o50
+y1 ^3 *27
+u $2 $7
+r $4 $9
+o52 ss0 $1 $0
+^m ^a ^d ^a
+.1 +3
+$1 $9 $8 $0
+u $3 $5
+o5i $1 $2
+o4f *04
+o3f *03
+T0 o5j
+$1 $9 $9 $3
+r *21 *05
+o63 i80 [
+o62 o73
+Y2 i43 D8
+Y1 i5* o51
+,1 o2c
+r +3
+o5k i6a
+o4o D2
+o37
+] $s
+.3 .0
+$s $e
+$r $i
+y2 k D4
+$w $o $o $d
+$s $1 $0
+$1 $9 $8 $3
+$1 $9 $8 $2
+r $1 $6
+o66 p5 *57
+o62 o44
+o61 o74
+o4a $1 $0
+y2 *04
+r $0 $2
+$s $1 $2 $3
+s52 c
+o56 o68
+so0
+l $j $r
+[ Y2 *43
+Z1 o4I c
+u '6 $3
+se1 ]
+o48 o55
+^u ^h ^c
+z2 r
+t T1
+o03
+] siy
+o97 T0
+o5a $1 $2
+o48 o57
+o48 o56
+c $8 $9
+$w $a
+y4 o4b
+o1C c
+$z
+o63 o78
+i8_
+^p D3
+^o ^c ^o ^c
+o71 o83
+o6l o7a
+o5i o6n
+.3 ,5
+$s $4
+^s ^i ^m
+r $0 $7
+o45 o54
+^z ]
+^u ^o ^y ^e ^v ^o ^l ^i
+Y2 s2l
+T1 T6
+$s Z1
+$s $k $i
+ss2 $0 $1 $5
+s2g
+^u ^y
+^u ^n
+.2 $8
+o64 +5
+o3a $1 $3
+o2c i3k
+Z1 ^s
+T0 i3k
+$w [
+x14 d p2 '6
+o47 o56
+^v D4
+^n ^i
+T0 i5@
+$s $i
+r $4 $2
+o6c o7h
+o0c i1l
+c so0 si1
+^l ^e ^g ^n ^a
+R5 D4
+} ^r '8
+r $0 $4
+p1 '9 [
+o63 i70 ,8
+o2n [
+t o54
+o45 o59
+o1h k
+^s ^c
+.2 $5
+u $3 $8
+r $6 $7
+o59 o61
+Y3 T0
+c $8 $5
+T0 i85
+} r +0
+o81 i92 oA3
+i02 i15
+^r i0e
+[ Z1 o2u
+R3 o46
+$x $2
+$p $o $w $e $r
+l ^@
+Z1 o24
+z1 *54 -2
+y2 u }
+o59 o62
+o3a [
+o12
+o47 o58
+^n ^h ^o ^j
+[ o2d
+^l ^i ^l
+o54 o68
+z1 *43 *02
+o44 o57
+R4 o53
+,1 o0C
+c $8 $6
+Z1 *74
+.2 $7
+$z Z1
+r $2 $9
+o53 i62 o71
+o1m o0d
+o6l $l
+o53 i65 o77
+^y ^o ^s
+^t o1u
+.1 o0w
+ss1 $9 $6 $6
+r $3 $9
+o6k o7u
+o6k ]
+o65 o73
+Z1 i6t
+$! Z2
+r ^j
+r $1 $5
+o56 o64
+^x T1
+[ $y
+o59 o66
+R6 $5
+} r Y1
+srh
+o56 o60
+ss1 $9 $5 $9
+s45
+r ^1
+r $3 $7
+^y ^l ^l ^o ^m
+se3 $1
+r o5s
+o46 o55
+o3u o4s
+^x *20
+o69 o78
+o54 o66
+.3 *60
+o55 o63
+o47 o52
+o41 o0d
+^y ^m ^m ^i ^j
+$z $o
+ss3 $3
+r $0 $3
+o94
+o21
+s26
+r $7 $0
+r $3 $0
+o3i $0 $9
+Y1 o5y
+T0 i42
+,1 o2j
+$z [
+$u $l
+y2 *36
+t T3
+t *76
+ssi o3_
+sqA o6a E
+r $4 $7
+o0l o1e
+i08 i18
+Y1 [ o2k
+sou
+r $4
+o5u o6s
+Z1 $i
+T2 T3
+$t *57
+$s $8 Z1
+sol
+r $m
+r $i
+^w *03
+$.
+y2 *51
+r o3g
+r $0 $5
+o5k o6a
+o57 i62 o70
+o48 D1
+o2r [
+l $. $c $o $m
+Z2 o0j
+^y ^l ^l ^i ^b
+[ o1f
+T3 o05
+ser +2
+o9c $s *57
+o62 o79
+o54 k
+o2e k [
+o4d o5a
+^y ^m ^a
+o4f [
+i41
+T4 T5 T6 T7 T8
+o52 o65
+Y2 o4l
+$X t
+slv
+o52 o60
+o46 o52
+o1e $0 $8
+c $8 $4
+Z1 *03
+T0 i7_
+{ Y1 *45
+o58 -4
+o3n D1
+l ^a ^n ^a
+Z3 } z2
+T4 '8 s7t
+.4 ,6
+.1 -3
+$a Z1
+o32
+^r ^a ^k
+Z2 sPb +3
+^n ^e ^b
+$s $7
+r $2 $1
+o64 o76
+o4t D5
+^p o2o
+u $n
+o43 o55
+o0b o1e
+^x ^e
+^o ^m ^a
+Y2 -9
+$u o4o
+ss1 $2 $3 $4 $5 $6 $7 $8 $9
+^s *30
+^l ^a
+o71 -5
+c $.
+^w ^j
+[ r *43
+R3 o47
+r $6 $2
+o60 o73
+o46 o58
+o0D $1
+i70 i80 i97
+y3 [ o0t
+o5l [
+o52 $5
+^v ^e
+o71 $7
+o63 o72
+i4a i5n i6d
+Z1 $o
+.2 ]
+$w *45
+o52 *56 -4
+o51 i60 o71
+o2i [
+o1a $1 $3
+u sE3
+o2g D3
+^x
+sae
+r $8 $8
+o50 o66
+o43 o50
+$u $x
+o7d o8o
+o55 o69
+o4.
+^r ^i ^a
+] ^v
+T0 ,7
+$w D1
+z1 i1j
+o6j o7o
+o4m o5e
+[ ^p $1
+Z1 o29 ,5
+Y2 *40 D4
+$w $o $l $f
+o72 o87
+o3n [
+z2 { -3
+sn, E *78
+o64 o70
+o3a $0 $9
+o2c i3h
+^r o1i
+$s $a $n
+o2I l D1
+o0d o1e
+^u ^l ^b
+^m i1a
+'3 p2
+u $3 $4
+sos ]
+o54 o60
+o2d -0
+o4l o5a
+o3j [
+o05 ^2
+^z ^i ^l
+Y2 u D2
+y2 +4
+y1 ,B *23
+i62 i70 o81 o90
+^s ^e ^d
+^l ^o ^o ^c
+Z4
+T1 [ +4
+$1 $9 $9 $4
+r $o
+o72 o80
+o49 o54
+o2t D1
+d 'C
+$t k
+o45 o53
+o42 o55
+o0c o1h
+$< $3
+u $4 $3
+o51 o60
+o44 o56
+$4 $e $v $e $r
+o6a o7n
+o4e o5r
+^u ^o ^l
+Z2 o0f -8
+Y2 Y2 D2
+$1 $9 $8 $1
+o6e o7n
+o0r ^k
+^! $!
+,1 o2h
+} } } }
+y2 *43
+u $6 $7
+o56 o63
+^x ^o ^b ^x
+^r D2
+u '6 $9
+ss1 $7
+o59 o60
+o58 T0
+o03 ^1
+^o k '6
+^k ^c ^a ^j
+sSb o46 c
+r $1 $9
+o90 oA1
+o46 o59
+.1 D4
+,1 o2f
+,1 i2m
+o52 D1
+i03 i10
+^p ^a
+^o ^i ^b
+R2
+ssz
+o6!
+c $1 $!
+Y2 *30 *21
+r *24
+r $6 $6
+o63 o71
+[ $v
+r -4 [
+o7a ]
+o45 o51
+Z1 ^c
+R4 o59
+.1 i2o
+$k $i $n $g
+o68 $8
+o54 o62
+o52 ss0 $0 $8
+o34 sN!
+^y ^e ^l ^h ^s ^a
+u o76
+u $7
+o5e o6n
+^w ]
+^t ^e ^n
+o4r D5
+^r ^c
+R4 D2
+$1 $9 $9 $5
+y3 o1i
+o64 o79
+o5c [
+^6 ^1
+o5o [
+^r ^e ^d
+Y4 Y4
+$s $t $a $r
+o7i '8
+o61 $9
+l ^a ^g ^e ^m
+i5.
+c $8 $8
+Z1 i5t
+o59 o67
+o0d o1a
+y4 E D8
+^r ^e ^t ^e ^p
+Z1 o4h
+y3 o0b
+o0b o1l o3e o2u
+y2 t {
+o46 o53
+^y ^a ^g
+ss4 $4
+o70 o86
+o50 $8
+} ^v
+o52 o64
+o49 o55
+o28
+^q o1u o2i
+$4 $u
+y1 o27
+u o54 o6U
+saq
+r $3 $2
+o51 i62 o73
+o43 o56
+$r $t
+y2 -3
+o0h o1a
+o2n ^c
+o53 ss2 $1
+o40 o57
+[ t K
+[ o01
+$z $e
+$u $2
+smw
+o7h
+o73 o81
+o5e o6k
+o0e i1l
+^y ^n
+^o ^g ^e ^i ^d
+ss3 $2
+ss2 $3
+o5e [
+o43 o54
+^s o3e
+[ ^T
+$1 $9 $7 $9
+o4p c
+o6b o7o
+o55 o61
+o40 o55
+o0a i1d
+^w ^o ^n ^s
+o0d @s
+^y ^n ^n ^a ^d
+^x ] }
+^e ^l ^t ^t ^i ^l
+o51 o63
+o4c o5a
+^o ^e ^n
+y5 } }
+o60 *23 $1
+o59 o64
+o59 i60 ,7
+o4a $1 $1
+u $1 $1
+o5l o6a
+o47 o53
+o43 o57
+o43 o51
+o40 o58
+o3t o0c
+^y ^l
+o72 o88
+o4i o5n
+^t ^e ^e ^w ^s
+^l ^a ^t ^e ^m
+$s $k $y
+y3 o2i
+y1 i34
+^t ^r ^e ^b ^o ^r
+Z1 o38
+r $3 $1
+o42 o54
+o22
+^y ^a ^r
+r $k
+r $5 $2
+o53 o60
+o4p D1
+^6 ^0
+Z1 $l
+z1 i67 -2
+r $5 $4
+o52 o69
+o2c o3h
+$m $a
+o63 ,7
+o46 o57
+o44 o58
+o1a $2 $2
+^y ^e ^k
+Z2 D2 +7
+$n $o $w
+u +2 ]
+o1a $3 $3
+o0A $1
+^r ^a ^t ^s
+^o ^y
+[ o2g
+R6 ,7
+$z o0k
+o60 o71
+o5f ]
+o56 $5
+o51 ss2 $3
+o47 o50
+^t ^s ^e ^b
+r $0
+p1 o7n '9
+o83 i92 oA1
+{ Z1 *31
+r }
+o5n D3
+o49 o50
+^y ^l ^o ^h
+^p ^m
+[ y2 {
+Y2 +4
+$s $m
+o5o o6n
+o56 $7
+o4j o5a
+o0e o1l
+^r *20
+^n ^a ^d
+o74
+o51 o69
+^x o1i
+[ o2c
+Z1 i27
+r $6 $0
+o78
+o0c sea
+$r D3
+o51 $6
+o4w o5a
+o4h o5a
+o4c o5o
+o2d D3
+$s $3
+r $b
+i00 i18
+^s ^m T2
+^o s1d D4
+$t $s
+y3 x25 +0
+r $3 $5
+o52 o63
+o4f D6
+o3s D4
+o0f o1u
+o0c i1h o2e
+Y2 o3a
+$r $o $s $e
+o3.
+Y2 *50
+o60 .5
+o56 o62
+Y2 +5
+} y1 ^3
+p3 o76 i83
+o4f D2
+o4b o5a
+o3e $1 $1
+o36
+o1m o0e
+o0m ^i
+^w *13
+K T0
+r $4 $6
+[ o02
+y2 -4 p4
+u D3 T1
+sep
+^r D3
+o6c o7k
+o62 ,7
+o5d o6u
+o49 o56
+^p *12
+.2 o4a
+r y1
+r $4 $1
+o0d i1j
+c so0 sa4
+T0 o3v
+y1 r
+o72 o86
+o3a $1 $0
+Z1 i38
+o47 o59
+o44 o52
+o33 k D0
+^t ]
+^l ^o ^l
+R5 i60
+z1 i1n
+y1 i44
+o70 o89
+c ^1 'A
+Y2 o7r
+$w $a $y
+o51 i62 o78
+o37 k
+^y i0c
+Z1 *56 i5m
+D4 [ p1
+soe E
+i7_
+i03 i14
+^y ^t ^r ^i ^d
+o3a D4
+o3a $1 $1
+^y
+^t ^o ^g
+^* T1
+Z1 ^k
+R0 {
+o4e o5n
+^y ^b ^u ^r
+^l ^l ^a
+$u $1
+{ o74 k
+o0L $1
+T0 T3
+u o74 o8U
+o52 o68
+o4g *24
+o49 o57
+o3c i4h
+siy E
+o4f D1
+o4e $1 $2
+o47 o51
+o42 o56
+i00 i14
+^o ^r ^p
+Y2 T0 *67
+sy6 oB`
+sa4 o41
+o53 o65
+o53 i66 o70
+.2 $2
+y4 o4p
+o5a [
+o50 o67
+o3i $0 $8
+o3e D4
+^r ^k
+^o ^m ^e
+T3 t T2
+o4o $1 $3
+i00 i13
+c $8 $3
+[ t }
+o5l D1
+o4l o5e
+y2 o4c
+o50 D3
+o48 o53
+^r ^e ^b ^m ^a
+^5 ^0
+T0 i4e D7
+$z $x
+l $g $i $r $l
+[ o1j
+sbj
+o8s o7u
+o0b o1u
+l $1 $3
+i7@
+o61 o79
+o0d o1i
+l $a $s
+^w ^m
+^t ^a ^n
+^o ^n ^u ^r ^b
+^. $.
+y3
+r $3 $8
+o8d o7o
+o5e o6r
+o5a o6n
+o3t D4
+o1e $0 $9
+^z T1
+,1 i2b
+y1 *04 z1
+o52 sS0 $0 $4
+o46 o51
+c $8 $2
+Z1 $9 Z1
+.2 o4y
+,2 i3y
+s83 +2
+o6l o4d
+o5e o4r
+o52 sS0 $0 $3
+o4b o5e
+o2m D3
+R7 o0K
+r $6 $1
+o5d o6a
+o0m ^a
+o0j o1a
+y3 D8 ,7
+y2 o3e
+u sE3 $1
+o5f o7o
+o54 o61
+o36 +2
+i7-
+^m i1c
+.2 $3
+$y +5 K
+r $4 $5
+o5b o6u
+o55 i60 o75
+^r ^e ^v ^l ^i ^s
+[ o33
+R4 *45 R4
+y2 o4t
+o53 i60 o75
+l ^e ^d
+^a ^n ^n ^a
+[ u ^K
+T1 o3a k
+o02 o11
+i4_
+o4t o5o
+o1e $8 $8
+o8e o9r
+o55 o66
+o3i D4
+^v i0a
+^s o2m
+Z2 o0h
+o52 sS0 $0 $2
+o3e $1 $0
+l $4 $5
+i8-
+[ o2x k
+$y $s
+u o2S
+ss1 $0 $2 $9
+o85
+o52 sS0 $0 $5
+o3i i4n
+o3i $1 $0
+^s ^b
+Y2 r *32
+,1 .4 r
+$p $a
+o56 *43
+o41 o57
+^u ^d ^e
+Z2 ,7
+Y2 *51
+o5i o6s
+o56 ss6 $6
+o4o o5n
+o1a ^g
+^y ^m ^e ^v ^o ^l ^i
+Y2 *06
+o44 o50
+i72 i80 o91 oA0
+^y ^e ^n ^o ^h
+Z2 *48 D4
+ss1 $8
+sa4 ]
+o6c [
+o5k o6i
+o54 o63
+o4a o5n
+o42 ss0 $0 $9
+o3i $1 $3
+i0b i1o i2b
+^9 ^2
+^. ^r ^m
+$s $h $i $t
+$s $2 $1
+o40 o56
+^y ^t ^t ^i ^k
+p2 D8 'A
+o6o c [
+o6d o7e
+o2f ,3
+o0m o1e
+c $2 $0 $0 $8
+Y2 sex *56
+y5
+o3j D1
+^u
+y3 *40 [
+p5 y2 o2r
+o5u D1
+o5m K
+o10 o20
+^z }
+^t ^e ^j
+y4 o3o
+o6d o7o
+o67 ,7
+o24
+l $l $a
+@a @e @i @o @u
+u '6 $7
+o54 *02
+o4r o5o
+o20
+^o ^t
+Y2 u -6
+$s $d
+$s $6
+y2 -6
+c so0 sa@
+] Y1 *56
+o75 o84
+o1f D3 D3
+i8$
+] o61
+[ o1m
+$y $u
+o8@
+o51 o65
+l ^e ^r ^i ^f
+^r ^o ^c
+^o ^i ^r ^a ^m
+s85
+o3n D4
+o3e *30
+o2s [
+^y i0b
+Y2 o4t
+u $8
+o3i *31
+Z2 *07
+$t *13
+{ y2 +0
+ss2 $0 $2 $0
+s1s RC
+o81 o92
+o56 o67
+i2/ i5/
+^s ^i ^r ^c
+[ o2t
+T0 T5 T3
+$s $c
+o53 o69
+o4g o5o
+o43 o59
+o17
+^w i1i
+R0
+sl7
+r -0 c
+o68 .5 K
+o41 o56
+c $7 $7
+^y ^s ^i ^a ^d
+^w ^e ^r ^d
+$p $r $o
+ss1 $1
+o6a ]
+o48 o50
+o11 T0
+l ^d ^a ^e ^d
+Z1 o2j
+i07 i17
+^e ^t ^a ^h ^i
+Z1 o2o
+z1 ,3 *25
+y2 o1c
+o8e '9
+o6# o71
+o56 o65
+o4m o5i
+o0a i1b
+^y ^s
+^s ^e ^l
+Y2 *7A -3
+$s $o
+y3 ]
+p1 x28 Y4 '4 d
+o6n D7
+o49 o53
+$s *56
+$Y +3 l
+o53 o68
+o50 o63
+o2g k
+^y ^m ^a T3
+^w ^a
+Y2 -0
+$s $p
+$1 $9 $7 $8
+{ t
+u sRP T5
+o4l o5i
+o0m i1a
+o0c ^a
+^y ^r ^n ^e ^h
+^o ^g ^u ^h
+$u $e
+s1) ^(
+r $7 $7
+o8j D7
+o4d o5e
+Z1 ^e
+u $3
+t o0F
+t '6
+o90 +8
+o64 o75
+o5l o6i
+o5@
+o4g o5a
+Z1 i4s
+$- ^-
+u o52 o6U
+r $h
+o71 o88
+o70 o85
+o5r i5a
+o5m ]
+o49 o58
+o48 o59
+o2i i3n
+^v -1 @5
+$u $s $a
+o53 o61
+o4i o5s
+o3o D1
+^y ^e ^n ^o ^m
+y3 E
+o89 ,9
+o57 i60 ,7
+i80 i90 iA7
+$p $i $e
+o4k o5i
+o4b i5o o6y
+o01 sd2
+^y ^d ^d ^u ^b
+^o ^l ^f
+$z $e $r $o
+o99 ,A
+o61 *20
+o5a o7o
+o3m D4
+^l ^e ^a ^h ^c ^i ^m
+} z3
+{ Y1
+y2 *32
+$x [
+$w $e $b
+$t *25
+$s ^1
+$,
+ss1 $9
+o3g D4
+^p D4
+Z1 o0v
+z3 { {
+^s ^s ^a ^b
+T5 $1
+$v D1
+$# K E
+r t f
+o5l $1 $2
+o4e o5l
+R5 i53
+r o3z
+o88
+o6c ]
+^y ^l ^n ^o
+$1 $9 $9 $6
+{ o75 *65
+u ] -3
+t .6 +5
+o5x D2
+^r D4
+D3 l d
+$t $m
+o4k o5o
+o35 -0
+o1a k
+i09 i18
+^y ^o ^j
+^u ^a ^m
+^s ^o
+^q o1u o2e
+^l ^l ^i ^k
+Z2 ,6
+y2 sia
+^y ^l ^l ^o ^h
+^y ^l ^l ^e ^k
+.1 $1
+o4f o5a
+o2i o3k
+^y ^d ^n ^a ^c
+Z1 o2u
+o7a $a
+o5u -4
+o55 o62
+o4t o5a
+o4a o5l
+o0b o1a
+y2 *64
+o5m o6e
+o35
+^y ^o ^b
+^r ^e ^l ^y ^t
+d 'B
+$s $2 $2
+ss2 $2
+o6i o7t
+o60 o77
+o5d ]
+o55 o60
+o3d D4
+o0l p5 K
+i60 i70 i87
+[ o1g
+si!
+p1 'A *54
+o52 o67
+o51 o66
+o4m o5o
+$x $d
+$v $a $n
+o51 i55
+o0a o1l
+i0.
+^t i0k
+^r ^a ^d
+,2 $1 $2 $3 $4
+o3o [
+o2n o3g
+^o o2e
+.3 o5i
+o41 o54
+o0f o1a
+o08
+^p ^l
+o4i $1 $2
+o1a $1 $1
+o02
+] f
+.1 ]
+o4j o5o
+o40 o59
+^t ^s ^e ^w
+^o ^c ^r ^a ^m
+$u $t
+z2 o1k
+y2 +7
+oB{ { $3
+o7d D8
+o70 o82
+o5c o6h
+o4t o5h
+o4o D1
+o41 o50
+o0c o1o
+y2 o5e
+y1 i47
+o6e o7t
+i9@
+^u K
+^s ^s ^a ^p
+$w $i $n
+o6_ D5
+o55 $4
+o50 o62
+o2b -0
+^y ^a ^l ^p
+^n ^i ^v ^e ^k
+] q sqj
+$7 ^7
+t -5 -4
+o55 o64
+o1f D3
+o0H $1
+^a ^i ^r ^a ^m
+[ t *42
+T4 $1
+u o62 o7K
+u $h
+t D1 -3
+r i6e
+o53 o67
+o50 o64
+o4c i5h o6i
+o4c i5h o6e
+i8@
+c $9 $0
+.2 o4o
+r T0
+r $4 $3
+o41 o55
+o41 o53
+o0m o1b
+^y ^r ^a ^g
+^t ^i
+^s ^i ^e ^m ^a ^n ^y ^m
+Z3 T0
+o49 o52
+l $c $c
+i00 i19
+^r ^o ^m
+^r ^e ^b
+$s $1 $4
+sa@ so0 si1 se3 su4
+o3h D4
+^p D5
+Y2 +2
+$t $e $n
+$1 $9 $7 $6
+u $2 $2
+o5j o6a
+o51 i62 i73 i84 o95
+o4v o5i
+o3k o4e
+o1m D2
+c $9 $2
+^v ^e ^k
+^l ^i ^v ^e
+Y3 D3 p4
+$r $u
+$o $s
+o51 *53
+o2f D3
+^t ^i ^h ^s
+Y3 Y3
+Y2 o1o
+$1 $9 $7 $3
+z1 ^i
+r $e $r
+o7k ]
+o55 o68
+o48 o52
+o2f -0
+oAU *64 *21
+o70 -5
+o4a o5d
+o40 o51
+i04 i14
+^t o1h o2u
+^t ^s ^o ^h ^g
+] o73
+$f $c
+o6e ]
+o5m o6u
+o53 o62
+o4r o5a
+o0c o1a
+i3_
+^t ^h ^g ^i ^n
+^s ^p
+t $2 i61
+o51 o68
+o4g o5u
+o0h o1i
+^y ^b ^b ^o ^b
+[ $r
+o8a o9n
+o7o D8
+o2s o3h
+l $j
+i5a i6n i7d
+^t ^a ^e ^r ^g
+o6j o7a
+o56 o61
+o0m $9 $0
+o0f o1i
+o0d i1b
+^y ^e ^o ^j
+Z1 o0B
+Y2 *25
+.4 c Y2
+y4 *71 *06
+o76 o84
+o5a o6l
+o4a o5s
+o45 ,5
+o27
+o0k ^a
+i8#
+T5 o4_
+E $0
+$2 $0 $0 $0
+u o2C
+ss4 $5
+^s ^a ^m ^o ^h ^t
+y2 o4k
+u $8 $8
+siA E
+r $j
+o71 o84
+o6d o7a
+o4e o5k
+o48 ,5
+o47 i42
+o3i $1 $1
+o2d o3e
+^e ^u ^l ^b
+$v $i $l $l $e
+$t Z1
+$m $c
+o79 i73
+o5c o6a
+o50 $4
+o4k -0
+^t ^s ^a ^f
+$1 $9 $7 $7
+y1 r ^3
+u ^3 ^2 ^1
+o71 i82 i93 iA4 oB5
+o3a $8 $8
+r $2 $2
+o7e ]
+o77 o80
+o74 .6
+o5e o7i
+o0k o1l
+^t +3
+^r ^e ^b ^y ^c
+$o D4
+o5k o6y
+$r $u $l $e
+$1 $9 $7 $5
+z1 $a
+r $d
+o40 o53
+l $2 $3
+^r ^e ^h
+[ o41
+T0 i3m
+.3 .2
+$o $u
+$k $i $d
+o5l K
+o0m i1e
+^y ^r
+$t $w $o
+o62 $1
+o5r o6e
+o5b i6o o7y
+o3a $2 $2
+o1e $1 $6
+^x ^i ^l ^e ^f
+^t ^e
+T1 T2 T3 T4 T5 T6 T7
+D2 d
+$y D2 r
+y4 o3i
+o6d ]
+d '9 $1
+^t ^h ^g ^i ^l
+Z3 -7
+soU E
+o5d o6e
+o4i o5k
+o47 ,5
+o3s -0
+o0l k
+i04 i12
+^r ^a ^w
+,1 o2w
+o85 $0
+o73 $2
+o44 o53
+^t ^a ^e
+^s ^a ^c
+^e ^k ^i ^l ^i
+u $7 $7
+o73 *65
+o60 ,7
+o3c o4h
+l ^d ^a ^b
+] { r
+Z1 .6
+R6 i3a
+$y $e
+u $1 $2 $3
+o8k s3n
+o5o $1 $2
+o4a o5b
+o0d o1u
+c $6 $6
+^x ^e ^s
+Y4 ]
+$p $a $r $k
+y1 C ^9
+u $6 $6 $6
+sbn sfF
+o5m o6a
+o0G $1
+^u ^l ^u ^l
+@o i1s
+o4i i5s
+^9 ^8
+Z1 c +3
+.2 .0
+,1 i2p
+$m Z1
+s8a T6
+o0j y1
+o0g i1l
+[ o1h
+[ T3 i0N
+$y $1 $2 $3
+$s *53
+$0 ^0
+o5c K
+o4v o5a
+^0 ^1 ^0 ^2
+y2 o3a
+o6e $1
+o50 o61
+o4s o5a
+o35 o46
+Y2 o4d
+$k K
+u o52 o6K $6
+u $2
+o3@
+i03 i13
+^t ^d
+^p *20
+] u
+Z2 *64 o4a
+Y2 *02
+o4s o5e
+o4o $1 $0
+o4b o5o
+o47 K
+o1o $1 $3
+o1c D2 D2
+o0m o2c
+l $f
+l $c
+^w ^d
+t i1J [
+r o2w
+o48 o51
+^t o1y
+^r l }
+[ Y3 E
+$t $a $n
+o5h o6a
+o4u o5m
+o43 o58
+i42
+[ ^P
+Y1 $6 *56
+$r $s
+z1 } z1
+o57 ,6
+o51 .4
+o4d o5o
+o43 o52
+o34 o45
+o33 -2
+Y1 i6n
+o81 o90
+o7f
+o4s -0
+^u ^o ^y ^k ^c ^u ^f
+$u r
+r $f
+o5z D2
+o54 .4
+o35 o40
+o1b *01
+o0d o1o
+c $7 $9
+^z -1
+^t o1h i2i
+^s ^g
+$s $1 $2 $3 $4
+y2 o0e
+s01 ]
+o59 -4
+o4j o5u
+o4h o5o
+d r
+^s ^i ^d
+^o D2
+$w $e
+$1 $9 $9 $7
+u $4 $5 $6
+o5p D3
+o52 R6
+o2t k
+o2m o3a
+o2. D1
+o0l o1u
+c $7 $8
+^y ^k ^n ^u ^f
+^!
+c $9 $4
+^n ^a ^d ^r ^o ^j
+$y $1 $2
+$o s1h
+$3 $6 $0
+o93 +8
+o6e o7k
+o5u o6n
+o5r o6a
+o53 o64
+o50 .4
+o42 o58
+o3i i4s
+o0b D1
+c $9 $3
+^d ^r ^o ^l
+o3v D4
+o2g o3a
+o0F $1
+^w ^p
+o7# o81
+o6l o7e
+o61 *32
+o5a *54
+o42 i50 i61 ,7
+o3k o4o
+o2k o3e
+o2-
+o1c k +2
+^n ^a ^u ^j
+T2 T3 T4 T5
+s2z +A
+o7s o6o
+o61 ,7
+o53 i64 o75
+o4a o5r
+o07
+^n ^a ^m
+u $6
+o4w s\2 [
+o42 o53
+o3j o4a
+i01 i10 i20
+^o ^r ^d ^e ^p
+^o D3
+r o2j
+o4d o5i
+o40 D1
+^w ^o ^w
+[ o1x
+$z $i
+$q Z1
+u o52 o6K $7
+u o2B
+o73 o84
+^y ^h
+^7 ^0
+$t *03
+$s o7s
+$s $o $n $g
+$! Y1 E
+san
+o76 o87
+o40 o52
+o0h o1e
+^r ^p
+^p ^i ^r
+$z *43
+y5 o5p
+y1 }
+o6u o7s
+o4r o5i
+o2r -0
+o0j o1b
+o0P $1
+^a ^m ^m ^e
+@o i5z
+z1 ^j
+s25 Z1
+o7l D8
+o59 $3
+o0c i1b
+^t ^e ^m
+^e ^k ^i ^m
+$z u
+o53 E
+o4a $1 $5
+o3w *32
+o2n -0
+o1e $2 $0
+o1a $0 $5
+o0m $2 $4
+^s ^i ^w ^e ^l
+R5 -6
+srN E
+o4b o5i
+o2i o3n
+^s ^i ^r ^k
+.1 Z1
+y5 o5b
+y2 k *24
+r $1 $1
+o5t K
+o44 o59
+o44 i52 o60
+o3e o4n
+o0m o1o
+o0d o1r
+i11 i32 i53 i74 o95
+^q D3
+^o o2i
+Z1 o3a c
+o0i i1d
+o0b o1o
+^t ^n ^o ^d
+^r ^e ^w ^o ^p
+^o ^n ]
+Z1 i7t
+$y ^e }
+o4f o5e
+o4Y D2 l
+^s ^l
+^r K
+] $u $i
+[ o3d
+Z1 +7 .2
+T3 T4 T5 T6 T7
+y3 *53
+r $7
+o52 o61
+o2p D4 D0
+o2c D3
+o0d o2g
+i09 i11
+^s ^s ^e ^j
+^o ^e ^g
+$w $o $r $d
+o64 $1
+o50 *34
+o0f o1e
+o0d i1r
+^r ^a ^h
+p3 o1o +7
+o0k i1l
+^y ^k ^c ^o ^r
+Y3 $1
+s;4 c +5
+r $0 $0
+o64 *67
+o50 o68
+o2t D3
+o0j i1b
+o0g o1o
+^t ^a ^e ^b
+[ t *14
+y3 o2d
+r $3 $3
+o87
+o30 o45
+o0e i1d
+i6_
+^s ^n ^a ^h
+^s ^a ^b
+[ o5a
+[ o4d
+o42 o59
+o2n o3d
+^p ^c
+^n ^i ^t ^r ^a ^m
+Z1 $k
+o71 o85
+o6b D9
+o5g ]
+o5e o6l
+o4l o5o
+o41 o52
+o3a $2 $7
+o33 o44
+i03 i15
+^z *13
+^t ^e ^p
+$1 $8 $2
+y3 o0l
+u o61
+o7M R2 D3
+o43 E
+^n ^o ^g ^a ^r ^d
+[ o2s
+o51 o67
+^y ^a ^h
+slp
+o70 o84
+l ^i ^n ^i ^m
+i5_
+i0l i1e
+^y ^b ^o ^t
+^y ^a
+Z1 *06 ^5
+$s $o $u $l
+o5a i61 i72 o83
+o4d *34
+o4a o5m
+o1a $0 $2
+o0k o1e
+l $j $b
+i79 i88 i97
+i2-
+^h ^t ^a ^e ^d
+[ o4m
+[ o2w
+R4 o38
+,1 i2d
+$m $a $n
+$9 $7 $3
+r ]
+o7c K
+o5d o6o
+o3y [
+$J $C l
+r $l
+o0K $1
+^v ^e ^d
+o5g *53
+o54 i63 i72 o81
+o0j o1d
+i04 i15
+{ o66
+ss?
+o6g o7a
+o51 sS9 $9 $1
+o3k o4i
+i03 i16
+Y2 -2
+$v $1
+o73 o82
+o6t ]
+o6l o7i
+o5n -3
+o48 r
+o2a o3n
+^t -3
+Y2 *71
+sa5
+^y ^n ^n ^h ^o ^j
+Z2 u +0
+$s $b
+$o $l $a
+$d $j
+u $r
+o76 ,8
+o4g o5e
+o42 i50 i60 o79
+o41 i52 o63
+o3e $1 $2
+o39 o40
+z2
+o62 o71
+o4s o5i
+o2l o3a
+o09 ^0
+Y2 *13
+.1 o3f
+$u $d
+} } $z
+o71 o86
+o50 $5
+o4t o5e
+o4t -0
+o4o $1 $2
+o3b o4a
+o2p [
+i09 i15
+^o o2a
+Y1 -7 .5
+$r
+spB c
+o6i o7s
+o6i o3z
+o4t o5i
+o0i o1n
+^s ^i ^l
+$t $1 $2 $3
+soI c
+o6c o7a
+o3e o4r
+o1e $1 $3
+^y ^n ^o ^h ^t ^n ^a
+^r ^i ^s
+^r ^e ^v ^e ^r ^o ^f
+$t $i $g $e $r
+$1 $9 $7 $4
+o6S i2s
+o64 o73
+o4p o5a
+o31 o40
+o2l ,3
+l $5 $5
+c $9 $9
+^y ^e ^r ^g
+^t -3 -3
+[ D4 d
+Z3 +9
+.2 i4y
+$m L6
+ssz E
+o5u o6m
+o1v [ i0e
+Y2 o1u
+.4 o0G
+$o $n *48
+r $9 Z1
+o3i o4n
+o2k D3
+l $1 $5
+f
+Y1 +4
+,1 .2 ,5
+$w $a $r
+$s $u
+$+ o70
+o5r o6i
+o4w o5e
+o34 r
+o0l o2s
+o0d i1c
+c $8 $0
+^y ^s ^a ^e
+[ o4s
+Y2 K
+p2 i5n '9
+o5s i6h
+o2t i3h
+o0g o1u
+i09 i13
+Z3 o82
+Z3 -8
+R5 D7 .4
+o4b *42
+o4a o5g
+o37 *20
+i03 i11
+c $2 $0 $1 $2
+^4 ^3 ^2 ^1
+$p D3
+o6o $1
+o6i ]
+o62 .5
+o53 ,6
+o2i k
+o0k o1i
+o0b $2 $4
+o0a o1b
+[ y1 ^3
+[ o0i
+T0 i2t
+$y $e $s
+u o1R
+o6g ]
+o5c o6u
+o43 ,5
+o42 o57
+o2l D3
+o1i $1 $3
+o0a o1n
+$s $1 $1
+$p $l
+r $t
+o6e o7l
+o5d o6i
+^s ^a *63
+u $9 $9
+o5R l *35
+o2t o3h
+o0a i1g
+^t ^r ^a ^e ^h ^i
+^r ^e ^g ^i ^t
+Y3 *26 D5
+R6 $0
+u o61 o7A
+o5c o6o
+o4f o5i
+o47 +2
+o43 sS1 $6
+o32 o44
+o0T $1
+l $e $n
+^n ^o ^s ^a ^j
+Z3 +6
+Z2 *47
+o5h o6u
+o30 o49
+c $8 $1
+^s o2y
+^r ^o ^m ^a
+^r ^a ^c ^s ^o
+^m ^a ^i ^l
+Y2 t
+ss1 $9 $8 $0
+p1 x26
+o6o o7n
+o4w
+o2k +6 [
+o0j o2m
+l $h
+i32
+i11 i32 i53 i74 i95
+i03 i12
+^t ^b
+^s i1p
+] E ^1
+[ o4k
+[ o1c ^l
+Z1 $4 $5
+$y $1 $3
+o81 [
+o78 ,8
+o3m o4a
+l ^e ^b
+^r ^m $1
+^o ^o ^b
+$@ Z1
+o4e o5d
+o41 i52 i63 o74
+o3o o4n
+o3i $2 $5
+o3e o4k
+o36 +0
+^s ^a ^j
+Y2 *04 {
+E $$
+$t $u
+p3 o5y ]
+o6_ o71
+o30 o48
+o0j o1u
+o0h o1u
+o0a o1d
+^r ^e ^m
+^i ^t ^n ^a
+o3a $1 $4
+o3X l
+o31 o43
+$s ^a
+$q $w
+o7l o8y
+o6n o7e
+o4l o5u
+o4b o5u
+o39
+o37 o48
+o0m i1c
+^r ^e ^t ^n ^i
+^p ^d
+^i ^l ^a
+u $7 $8 $9
+o4c i5h o6a
+o46 ,5
+i0m i1a i2d
+y1 *35 *20
+u o3S
+o6n o7a
+o6k o7e
+o3a $1 $2
+^t -2
+[ o4r
+[ ^x ] $x
+Z3 +7
+$r $o $a $d
+$r $m
+o8u D7
+o7j o8a
+o5m -3
+o5b o6a
+o5!
+o4u o5r
+c $9 $1
+Z2 o1o
+$s *68
+ss! i6z
+o96
+o82 o91
+o5j ]
+o4r o5u
+o2z D3
+o1a $0 $4
+o0h o1o
+i32 i31
+^r ^e ^t ^s ^n ^o ^m
+^o ^f
+Z2 o0s
+u sO0
+o6k $1
+o5h ]
+o4s o5h
+o4i o5e
+o1b
+c T5 $1
+^s z1
+y2 *14
+o5i o6k
+o4m D6
+o3i $1 $4
+o2l o3e
+o0m o2g
+o0f K
+l $c $h
+l $b $a $b $y
+^@ $@
+[ Z2 *12
+T0 i2d
+$r $k
+o7t ]
+o73 *57
+o4m *24
+o4k o5e
+c $7 $6
+^n ^o ^d
+^8 $8
+T2 ^A
+o44 sS5 $6
+o32 o41
+o0f o2r
+i33
+^y ^n ^n ^e ^j
+^u ^r ^t
+$s +4
+p1 D8 'B
+o4s o5k o6i
+o44 o51
+i34
+^y ^d
+^o ^r ^e ^z
+T0 i3u
+D4 p2 'A
+y2 o2i
+o6a o7m
+o3t o4h
+o3l o4a
+o34 *20
+c $0 $0
+^y ^l ^u ^j
+^w ^o ^l ^l ^e ^y
+$u $n $a
+$: $)
+t o72
+so9
+o32 o43
+o2m ^d
+o0m o2r
+o0j i1m
+^t ^a ^r
+^e ^k ^a ^j
+,1 i2c
+o5k $1
+o45 +3
+o3i $2 $2
+o3a $1 $8
+o2w D3
+o1m .0
+o0j o1o o2e
+o0d o2c
+o0c o2l
+^r ^e ^g
+.1 .4
+$p $o $p
+t o0S
+o5m o6i
+o3i -0
+o0j i1c
+c $9 $5
+[ o1v
+$c $a $t
+{ Y2 -7
+y5 o5m
+u $5 Z1
+o87 i97 ,A
+o5c o6k
+o3i o4s
+o3h +2
+o2w k
+^a ^m ^i
+[ o1w
+Z3 ^J '7
+$v $i $c
+$r $c
+o92 i91
+o5u $s
+o3e o4l
+^n ^a ^y ^r
+Y2 o4g
+Y1 i5r
+o6d $1
+o4p o5e
+o47 i58 o69
+^w ^k
+^s ^i ^u ^o ^l
+Y2 oA6
+$1 $9 $7 $2
+$# ^#
+o5c i6h o7u
+o4o o5r
+o0m $7
+o0g o1a
+i0a i1b i2c
+i06 i17
+^t $s
+^r ^e ^s
+[ o3u
+Y2 s5* c
+Y2 *26
+$9 $6 $3
+p3 '8
+o6k o7i
+o6a o8a
+o5i $1
+o50 o65
+o4u o5n
+o38 o45
+o0k o1a
+o0j o1c
+o0b o1i
+^s -1
+Z1 i3s
+Y1 o0L +7
+o7_
+o4a $0 $2
+o0g o1i
+^t ^i ^m
+^r ^u
+[ [
+Y2 o2l -A
+$u $l $a
+o6l o7y
+o5u ]
+o4a o5k
+o3y [ k
+o35 ,4
+o0c $0 $9
+i09 i12
+^r o1u
+] ^u
+$t $i $n
+$o $v $a
+y2 o0M
+o6a $s
+o43 sS4 $5
+o43 R3
+o3D sD. D2
+o33 o47
+o0k o1o
+o0k i1n
+o0j i1d
+o0g o1e
+i0#
+[ o4t
+Y2 o5v
+o44 +1
+o3l -0 -0
+o1u -0
+o1l o2a
+c i7.
+^o ^m ^a ^e ^t
+^O l
+$1 $9 $7 $0
+$. $1
+q
+o6b ]
+o51 i65 ,7
+o3z .2
+o3f D4
+l i7b o8o o9y
+l $r $d
+i04 i10
+c T4 $1
+Z2 $1
+Z1 *56
+Z1 $n
+Y1 ^9
+$s +5
+y2 ]
+o6p o5l
+o5k ]
+o4w o5i
+o4b D6
+o3v *23
+o3t o4o
+o0b $2 $5
+l $g $u $y
+^r ^a ^t ^i ^u ^g
+$y +0
+$p Z1
+$o $r
+t i4_
+o6i o7a
+o5t o6a
+o5g o6o
+o39 o44
+o30 o44
+o0d D1
+^r ^e ^t ^n ^u ^h
+[ [ [
+$o *75
+$2 ^2
+$2 $4 $7
+si1 ss5
+s>y srm E
+o0c o2r
+l i5s
+^a ^c ^i ^s ^u ^m
+ss8 $9
+o72 o83
+o5c ]
+o3r o4a
+o1a i2n
+Y2 } +3
+$s $5
+} ^s
+z2 i1o
+o6j D8
+o6f ]
+o6a o7t
+o5k o6e
+o5i o6t
+o4u o5l
+o46 i56 ,6
+o3o o4l
+o0h i1e
+i72 i80 i91
+^y ^e ^s ^a ^c
+^x ^m ^b
+Z1 i1o
+.2 ,5
+$j $a
+o53 o33
+o4a o5t
+o3o $1 $3
+o2d o3i
+^y ^t ^i ^c
+^w ^e ^h ^t ^t ^a ^m
+^a ^r ^u ^a ^l
+^8 ^2
+[ o2r
+$s -2
+$p $o
+$$ ^$
+o7i o8e
+o48 K .9
+o23 o34
+o1-
+o0k o1b
+o0a i1n
+c $0 $9
+$1 $.
+snk c
+o5t ]
+o5i ]
+o3i $2 $0
+o3b *02
+o2i i3s
+o2a i3n
+o27 *23
+l $d $a $y
+i05 i10
+^t ^t ^o ^c ^s
+^r ^e ^t ^s ^i ^m
+Y1 ,9
+$z $o $e
+$s $1 $7
+y2 *65
+r $g
+o80 o92
+o5a $1
+o4p o5i
+o4m -2
+o4l sr&
+o4h o5i
+o3v o4a
+o3a $1 $5
+o38 ,4
+o1e o2n
+o1a -0
+o0b i1d
+l $a $m
+^w ^o ^l
+$y o4f
+$1 $*
+y1 { $y
+o70 o87
+o5r o6o
+o5k o6o
+o5e ]
+o4e o5s
+o3x *23
+o3o o4u
+o38 o44
+o0j o1m
+c $9 $6
+^o ^c ^i ^n
+r y1 i49
+o7i $e $s
+o6b o7a
+o4h o5e
+o3u o4n
+o3t o4e
+o3r D4
+o3o i3b
+o3h o4a
+o3c D4
+o39 o45
+o32 o48
+o1m *24 [
+l $j $m
+^y ^a ^b
+^v ^m
+[ y2 y2
+T0 i5p
+$w $e $s $t
+$t $r $e $e
+$Z c
+$3 $6 $9
+{ Y2 *31
+o5j o6u
+o5i o6l
+o5c i6h o7i
+o4@
+o33 ,4
+Y2 o5g
+$s ^k
+p2
+o3t *12
+o3d o4a
+o30 o46
+o0m D2
+o07 ^9
+^y ^m ^m ^o ^t
+^v ^j
+^t ^s ^a ^e
+^c ^i ^r ^e
+^( l $)
+Z2 $7
+Y1 ^b
+$x *45
+$4 $m $e
+u $0 $0 $7
+o6a i7d o8a
+o5m o6o
+o52 $1
+o4o o5l
+o4n o5e
+o3o i3k
+o2z *21
+o0h o2l
+o0I $1
+i05 i16
+^y ^d ^n ^a ^s
+^w ^m ^b
+^*
+] ^x
+[ o5i
+$w +4
+y3 y3
+sa@ so0 ss$
+o2u o3s
+o1i o2n
+o0g D2
+l $j $p
+i09 i16
+^u ^i ^l
+^t +1
+^s ^u ^m
+$v $o
+$9 i0u o09
+o5o o6r
+o3a i4s
+o2k *01
+o2f o3e
+o1a i2m
+o0m o1c
+o0j o2n
+l ^d ^o ^o ^g
+^z i0e
+^t -1
+^s +1
+$s $e $x
+o2r *21
+o2l o3i
+o0c o2d
+l ^h ^s ^a
+i05 i15
+L4 L5
+$p $e
+z1 i1s
+o4m o5b
+o49 ,5
+o41 i59 i68 o77
+o3e -0
+o3c i4h o5a
+o33 o45
+o2g +0
+Y3 o0m
+K c -7
+$1 $9 $6 $9
+z1 ^5
+y3 o0j
+y2 +5
+o3d o4e
+o3a o4n
+^y ^b ^a ^g
+^s ^a ^d
+[ o5e
+[ o3c
+$s $8
+$1 $9 $7 $1
+r +0 .4
+o5v D0
+o46 sS6 $6
+o3m *21
+o2i o3s
+o1a $0 $3
+i03 i17
+^s ^s ^a
+^r ^e ^v
+^9 ^0 ^0 ^2
+Y2 o0r
+T0 *47 ^#
+$y k
+$r $a $y
+$3 Z2
+o77 o56
+o6.
+o56 ,6
+o3a o4r
+o31 -0
+o0l i2s
+o0j i0b
+o0g o2l
+^s -3
+Z2 -A T0
+E ^2
+$o $v
+o79
+o6n o7o
+o2e o3l
+o1a $1 $0
+^v ^a ^d
+^s ^u ^g
+^j z1
+^h ^s ^o ^j
+] o4G l
+[ o3g
+Z5
+Z1 i3i
+r $r
+o50 *12
+o42 -0
+o31 o45
+o25
+o12 .0
+^o o1b
+^n ^o ^r ^a ^a
+Z3 [
+s0O c
+o77 ,8
+o62 i70 i80 o92
+o4n o5o
+o0e o1d
+c $7 $5
+c $3 $3
+^n ^o ^r ^i
+^S o1h
+'4 f
+$y $n
+$u $r $a
+$u $a
+o6t o7e
+o45 $0
+o1f +0
+o0i ^b
+i31 i72
+^n l
+$z -4
+$t $e $a $m
+{ { { { { c
+o4i o5t
+o3t o4a
+o2a o1w
+o1u $2 $4
+o0m $2 $7
+o0l i1a
+^o ^l ^o ^s
+^o ^j ^o ^j
+^m ^a ^s
+^e ^k ^u ^l
+R7
+$x $p
+$p $a $u $l
+s7R ^C
+o6i o7l
+o5u -0
+o42 o50
+o2k o1u
+o2a o3d
+o1o $2 $2
+l $a $l
+$w $o
+o6v o7e
+o58 $8
+o4e o3p
+o4a o5c
+o3o $0 $9
+i39 i36
+D1 p1
+$s $9 $9
+$p $c
+$l $o $v $e $r
+$a $l $e $x
+r $e
+o6u $s
+o64 o71
+o64 i73 i82 o91
+o4o o5k
+o4f +0
+o33 +0
+o0d o2l
+^y ^t ^a ^k
+$k Z1
+$g $o $d
+{ Y1 y1
+r K ^0
+r $e $n
+o72 Z1
+o4f o5u
+o2r o3e
+o10 E ]
+o0o i0d
+i82 i90 iA1
+Z3 o73
+Z1 i1h
+o72 o81
+o4g *34
+o2p +0
+o0c $2 $4
+[ o3l
+$u $g
+$X c
+o77
+o69 Z1
+o5c i6h o7e
+o59 ,6
+o4j o5e
+o43 i55 o67
+o4-
+o3l o4i
+o3g -0
+o37 ,4
+o30 o47
+o1o o2l
+o0m i1j
+o0m i1g
+o0g o2b
+o0a i1j
+c $2 $7
+Y2 r
+Y2 o6d
+,1 i2g
+$r $g
+o6i $s
+o65 Y1
+o53 i63 ,7
+o51 i69 i76 o88
+o4n o5a
+o4d o5u
+o41 o58
+o3m o4e
+o30 o41
+o2t o3e
+o2s ^k
+o1a $9
+o0b $1 $8
+i06 i15
+^s ^i ^s ^i ^h ^t
+^r ^o ^i ^n ^u ^j
+^m i1d
+Y2 $a
+$z $o $n $e
+o62 c ]
+o5a o6t
+o2c o3a
+i31 i42 i53
+^t ^n ^o ^m
+^p ]
+^l
+] t +4
+Y2 o2n -6
+u ^D
+u $3 $3
+o5t o6e
+o4n o5i
+o49 o51
+o3i $1 $5
+o3i $0 $6
+o3i $0 $5
+o30 +2
+o2r o3k
+o1d D2
+o16
+o0j i1o i2e
+o0b $1 $7
+^x ^x $x $x
+^s ^s ^i ^k
+} k
+sae o0v
+o80 o94
+o7-
+o32 o45
+o2v -0
+o1o o2n
+o0l o1o
+o0L l D4
+[ o3i
+Y2 {
+T6 o0$
+.2 o0S
+slv ]
+o72 o85
+o6i $1
+o5u o6r
+o46 $9
+o2s o3k
+o1u $1 $3
+o0k o2l
+i05 i14
+^u ^q
+^p ^o ^t
+R4 .3
+@l ^f
+$w $h $i $t $e
+{ Y2 *43
+o4o *24
+o1u o2b
+o1o $1 $1
+l $2 $2
+i35 '8
+^t ^e ^b
+^8 ^7
+T6 $1
+$4 $l $i $f $e
+$# $1
+o80 o95
+o3e o4s
+o0m D3
+o0m $8
+o0d o1g
+o0b i1b
+o0b D2
+i0a i1b
+^x ^e ^l
+[ o2q
+T5 ^I
+oA2
+o95
+o6n $1
+o6e +5
+o5o $1
+o5e K
+o4h o5u
+o4e o5m
+o3k +0
+o3i $0 $2
+o2o [
+o0j o1k
+i04 i17
+c $9 $7
+^y ^e ^k ^i ^m
+^t $1
+^s ^a ^n ^o ^j
+.3 i3v
+$* Z2
+t +3
+r
+o4o o5s
+o3s o4u
+o31 i42 o53
+o0g o2r
+o0f o2c
+o03 ,1
+i0d i1a
+^r ^e ^g ^n ^i ^g
+^o ^t ^u ^a
+^o ^a ^o ^j
+^e ^s ^o ^j
+Y2 o0t
+T0 i4l ,7
+z2 } *A5
+o81 $4 p4
+o5l +4
+o4. o51
+o3o o2c
+o3e i4s
+o1f D4
+o1f *20
+o1e $1 $4
+o0d o2r
+$o $w
+{ y2 {
+y3 o0p
+r $5 $5
+oA7
+o6a o7s
+o5l o6o
+o5b o6o
+o51 ,6
+o4S l
+o3i $2 $8
+o3g *20
+l ^d ^l ^o ^g
+^s ^o ^j
+^n ^i ^t ^s ^u ^j
+^k ^r ^a ^m
+o8A o0o
+o6a o7r
+o48 $6
+o40 i50 o67
+o3s o4h
+o3o $1 $0
+o1@
+o0b $0 $9
+^y ^r ^r ^e ^h ^c
+^q o1u
+^p ^a ^c
+^n ^a ^i
+^k ^c ^o ^r
+^i ^m
+E $6
+$t c
+y2 o2x
+o8b
+o82 o90
+o5s $1
+o4p o5o
+o46 $8
+o2n ^e
+l $b $o $b
+l $6
+o91 oA0
+o4u o5k
+o42 o51
+o2p o3e
+o0m o1u
+o0k o1u
+o0f D4
+o00
+^u ^e ^m
+^t ^r ^a ^m
+[ o4u
+[ o2z
+T0 i2m
+z3 -2 -1
+o7n o8t
+o67 Z2
+o5n o6e
+o4t o5u
+o3l o4e
+o3l *21
+o38 o47
+o32 o46
+o31 o46
+o2s o3e
+o2r o3d
+o0c i1d
+l $d $d
+^y ^e ^l ^i ^a ^b
+^w ^t
+^s ^a ^k
+^n ^a ^i ^r ^b
+[ o2u
+T4 o0H
+o73
+o5d $1
+o3a o4l
+o36 ,4
+o32 o49
+o2r D3
+o0m o2k
+^u ^j ^u ^j
+^r ^i ^m
+Z1 i1e
+$p D2
+o71 o87
+o5t o6o
+o4o *03 ssl
+o43 i56 o60
+o3i $0 $3
+o2d o3a
+o23 ,3
+o0m $0 $9
+o0l i1e
+o0d o1k
+^l o1i o2l
+^a ^i ^l ^u ^j
+[ o0m D2
+[ o0a
+$y $0 $1
+$s o2b
+$s $o $l
+o6u ]
+o3a $0 $5
+o2e o0f
+[ o1z
+K $0
+,1 i2s
+z2 ] -0
+u o4S
+o7w
+o6g o7i
+o69 ,7
+o5o o6l
+o5e o6t
+o4a o5h
+o49 *02
+o3o $1 $1
+o3d D5
+o0i i1n
+o0e i1m
+^r ^o ^g ^i
+$Y c
+u $3 $2 $1
+o70 o81
+o6l o7o
+o47 sS7 $7
+o3b o4i
+o2p ,3
+o0k o2r
+c $7 $4
+^s ^u ^b
+^% ^0 ^0 ^1
+$z -2
+$x } z1
+$m $b
+o8a ]
+o6l ]
+o4s $1
+o3u o4m
+o3o o4r
+o32 o47
+o1i $2 $2
+o1f r
+o1c D2
+o0m {
+i0m i1a i2c
+^s ^o ^r
+^n i0a
+^n ^e ^d ^l ^o ^g
+^9 ^7
+[ [ [ [
+@m i0d
+$o $g
+z1 ^c
+o6n o7t
+o33 K
+o2v o3e
+^t ^t ^u ^b
+^s ^i ^x ^e ^l ^a
+^m ^o ^t
+Z1 o0K
+Y2 *76
+$z $y
+$k $a
+o81 o93
+o6l ,7
+o5t o6h
+o4k +0
+o3m o2u
+o2v k
+o2b D4
+o1k D2
+^z ^a ^q
+^y ^e ^l ^i ^r
+^o ^l ^i ^m
+$u $b
+ss0 $7
+p1 o8o 'A
+o6k o7o
+o4o $2 $2
+o4f o5o
+o33 o42
+l ^e ^r
+l $c $i $t $y
+c $9 $8
+^x ^e ^r
+^r ^o ^k
+^o ^h ^c
+$m $e $t $a $l
+$# s#s d
+p4 k '8
+o54 i78
+o4e -0
+o31 o47
+o2a D3
+o0k o1c
+o0g i1u
+l ^e ^c ^i
+] sU2 ^E
+[ o0m o1c
+Z2 o2s
+o8m
+o42 sS0 $0 $3
+o1w D2
+o1e $2 $2
+l i5h
+i06 i16
+^v ^o ^l
+^t ^l ^a
+Y2 o0a *76
+T5 T6 T7 T8 T9
+$s ^m
+r $q
+o6W l
+o5r ]
+o51 i63 o75
+o51 i62 o70
+o4q [
+o4b r
+o33 o40
+o22 *32
+o1i +0
+o1i $1 $4
+o0k o5k
+o0k o2t
+o0a o1g
+^y ^a ^j T3
+^q ]
+$u $s $e
+$t $1 $2
+$m $e
+u ^6 z1
+r $p
+o7$ *30
+o4s -2
+o4i o5c
+o47 $8
+o44 .3
+o3i $1 $2
+o1x D2
+o0d i2n
+l $1 $2 $3 $4 $5 $6
+c $4 $4
+^p o1k
+^2 ^1 $3 $4
+] o50
+$p $i $g
+o71 Z1
+o5a o6m
+o3o o4s
+^p i0j ]
+^V ^s l
+[ o0a $1
+$r $i $a
+$3 $0 $0 $0
+y5 o0h
+u $0
+t ^J
+r -0
+o7e o8n
+o70 i77
+o5s +3
+o52 o66
+o42 +3
+o42
+o0l i1m
+^y ^n ^o ^s
+^3 $3
+[ o4w
+Z1 i4a [
+$t $1 $3
+$s $g
+$b Z1
+ss- $e $r $a
+saz *92 ]
+o5j o6o
+o5i o6c
+o54 ,6
+o4o o5f
+o3z *23
+o3v o4i
+o3t E
+o3s o4i
+o3c o4o
+o0k K
+o0g i1m
+l ^1 ^0 ^0 ^2
+c ^3 ^2 ^1
+^y ^o ^r
+^w o2f
+^s o4h
+^r ^a ^g
+^r ^a ^f
+D2 $2 $0 $1 $0
+$r $a $i $n
+$p $1
+ss- $f $r $e $e
+o44 sS2 $0
+o3l +1
+o2e o3s
+o0d $7
+i0a i1l i2e
+^s *41
+^s $1
+^r ^e ^v ^i ^l ^o
+^o ^n ^i ^d
+^o ^i ^g
+^7 ^0 ^0
+Z1 i4t
+.3 o0M
+o8z D7
+o7c ]
+o5n o6o
+o5i o6a
+o5f o6a
+o51 l
+o51 i60 i70 ,8
+o4d r
+o3s o4a
+o3m D5
+o3i +2
+o1a o2m
+o0g D3
+o0c $1 $7
+o09
+l $g $o
+i5@ l
+^x ^a ^l
+^w ^q
+Z1 o3v
+$t $i $o $n
+u $s Y1
+o43 i52 o61
+o3a o4s
+o31 o42
+o2t o3a
+o0m $9
+o0f o1o
+o0c $2 $0
+l $2 $0 $0 $5
+i90 c
+^r ^u ^b
+^q D2
+[ o1t
+o4A c
+o3a $0 $2
+i9_
+i80 i91 iA0
+^w ^g
+^s ^u
+^a ^s ^i ^l
+^a ^d ^n ^a ^m ^a
+K ]
+$1 $3 $3 $7
+o1x D3
+o0m $1
+o0i i1l
+c $0 $0 $7
+^z ^i ^u ^l
+^y ^l ^e ^v ^o ^l
+Y3 [
+z1 l i1v
+u s\h ^K
+u ^T
+o6g o7e
+o5c i6h o7a
+o3z -0
+o0k o2b
+o0c o1m
+^y ^n ^i ^t
+^y ^m ^r ^a
+^y ^e ^k ^c ^o ^h
+^w ^e ^j
+^u ^a ^p
+^t ^a ^d
+^m z1
+ss0 $1
+o7g o8a
+o54 *75
+o2i o3l
+c $4 $2
+^t ^i ^k
+K $a
+'6 d
+o81 i92 iA3 oB4
+o4a $0 $4
+o2k o3i
+o13 ,2
+o0a i1s
+l $2 $0 $1 $3
+^y ^d ^d ^a ^d
+^s ^o ^k
+^o ^l ^l ^a ^h
+Z1 i5p
+*35 *24
+$z $z $z
+$t $o $p
+o3g o4u
+o3a o4d
+l D7
+^v ^c
+^t ^r ^a ^b
+^r ^e ^t ^a ^w
+^p ^o ^p
+$m $i $k $e
+$2 $k
+o4o o5u
+o2p o3a
+o27 *45
+o1e i2l
+o0k o2k
+o0j o2k
+o0j o2b
+o02 +1
+^y ^b ^b ^a
+^u *31
+^l ^l ^e ^h
+Y1 o0a
+Y1 D6
+$t $c
+} } }
+o6n *53
+o61 i72 i83 i94 iA5 oB6
+o60 Y1
+o5t +2
+o4y o5a
+o2m o3e
+o2i D3
+o2f +0
+o1u o2r
+o0c i1c
+o0b $2
+l $c $a
+c $5 $5
+c $2 $0
+^o ^r ^c ^i ^m
+^i ^n ^a ^d
+$l $e $o
+o51 i62 ss3 $4
+o4n *40
+o46 D5
+o44 i55 o66
+o3g o4a
+o1e o2d
+o0j o2g
+o0b D3
+o04 }
+k i13 [
+^s ^e ^r ^d ^n ^a
+^o ^p
+^e ^c ^i ^l ^a
+^a ^c ^i ^s ^s ^e ^j
+^7 ^3 ^3 ^1
+o5t o6i
+o5a o6s
+o3s o4e
+o3d o4i
+o3a o4t
+o2g o3o
+o2b o3e
+o1e $1 $1
+o0f o1b
+o0f D3
+l ^h ^s ^i ^f
+^y ^a ^t
+^y ^a ^l ^c
+^o ^t ^a ^g
+^k ^c ^i ^n
+^e ^r ^d ^n ^a
+^7 z1 +0
+o8c
+o4i o5d
+o1j
+o1a $2 $3
+l ^l ^i
+i2_
+Z2 o2m
+o7c *75
+o5i o6e
+o51 o64
+o4i o5l
+o34 *45
+o2s o3a
+o0m $1 $9
+c ^9 ^1
+^t ^s ^a
+^o ^w ^t
+Z3 D2
+$z $1 $2 $3
+$s D4 c
+$s $1 $5
+$r $o $b
+$p $i
+$9 $1 $1
+o5x
+o5c o6i
+o4w ]
+o4o o5m
+o41 i55 o69
+o3a $0 $3
+o2p D4
+o1u D2
+o1m D2 D3
+o1l D2
+o1i $1 $1
+o0m $3 $0
+o0h $1
+o0d i2a
+^r ^a ^h ^c
+] E T5
+Z2 $9
+Z1 D4 .2
+.3 ^A
+$s o3y
+$r $y $a $n
+$m $s
+$j $k
+$8 $0 $8
+o74 +4
+o5a o6k
+o44 *53
+o3j o4o
+o2j o3u
+o2e k
+o28 *32
+o1h D2
+i0m i1e
+u -4
+se7 ,6
+o65 ,7
+o4g o5i
+o44 sS1 $1
+o2r o3a
+o1u o2n
+o0r k
+o0j i1k
+o0c o2m
+l K i65
+l $n $o $1
+i5- E
+c ^2 ^1
+^i ^r ^a ^m
+$w $i $l $l
+$r $b
+$p $w
+$1 $9 $6 $7
+u [ ^N
+snk i6s
+o71 ,8
+o5s +4
+o5n ]
+o5b o6e
+o5a o6d
+o4s o5u
+o3t o4i
+o1i o2m
+o19
+o0j o1e
+o0h i1a
+l ^g ^o ^d
+^z ^o
+^s ^o ^a ^h ^c
+^s ^a ^p
+Z1 +0 z1
+ss- $o $u $t
+o7a $1
+o6t o7a
+o6e
+o5u o6k
+o4u o5d
+o46 *32 +1
+o40 $6
+o3j D4
+o3g o4o
+o34 o42
+o31 o44
+o2u i3s
+o0k o2z
+o0k o2n
+o0c i1a
+i33 i31
+^t ^s ^e
+^p ^k
+^p ^e ^e ^d
+^k ^n ^a ^r ^f
+^e ^l ^p ^p ^a
+K ^a
+K $7
+$1 $9 $9 $8
+oA0
+o9a
+o5y K
+o5n o6i
+o5a o6g
+o3a -0
+o2b o3a
+^n ^o ^j
+] o45
+T0 T5 T4
+$d $u $d $e
+o6r ]
+o41 i55 o60
+o3u k
+o3k D5
+o2e o3n
+o0k o1j
+l ^5 ^0 ^0 ^2
+^s ^o ^b
+^s ^a ^g
+^n ^o ^m
+[ o3r
+[ o3e
+$s *01
+y3 o3r
+y2 *37
+u $4 $4
+se1 c
+o74 o8e $v $e $r
+o6l o7u
+o5o i61 i72 o83
+o5d '9
+o44 $8
+o42 ss0 $0 $2
+o3w o4a
+o1b D3
+l $q $w $e $r $t $y
+i21
+^s +3 skc
+^r ^e ^k
+^o ^o ^m
+^e ^i ^l ^r ^a ^h ^c
+u $t
+r i6c
+o6r +4
+o4s *12
+o4b o5a r
+o42 ss0 $0 $6
+o0m i1l
+o0k $8 $8
+^z ^a ^t
+^y ^x ^o ^r
+^j ^m
+T0 i3y
+T0 T9
+o6d o3c ]
+o5u i5l
+o5a o6b
+o3w *31
+o2u [ *20
+o2r k
+o2a o3l
+o1o $0 $4
+o1e o2r
+o0j i1p
+i09 i17
+^n ^a ^l ^a
+] ] ] d
+$o Z1
+o6_
+o5u $1
+o4k $1
+o3s D5
+o3k E
+o1u o2d
+o1e $1 $5
+o0l $0 $9
+o0j o2c
+o0j o1o
+o0f i1a
+o0d $8 $8
+^t ^r ^a ^e ^h
+^o ^l ^b ^a ^p
+Z2 o6b +7
+,1 .2 .4
+$r $i $o
+$1 $5 $9
+o7s *57
+o6e o7s
+o51 i61 i72 ,8
+o3p o4a
+o0l $1
+o0k r
+o0g $7
+o0c o1j
+o0b $7
+k o16
+^y ^e ^r ^o ^c
+^o ^g ^n ^a ^m
+] ^s
+$6 $1 $9
+} ^8
+u i61
+o6k o71
+o5s -3
+o4v o5e
+o43 $0
+o3u o4t
+o2e o3r
+c $2 $6
+^y ^d ^n ^a ^m
+^e ^l ^y ^k
+$m $d
+$1 $8 $7
+o5a i6m o7o
+o4o *23
+o48 $5
+o48
+o41 i54 o67
+o3o o4f
+o3b D5
+o2p D0 D4
+o1o o2b
+o1a $0 $1
+o1K [
+o0d i2l
+i90 iA0 iB7
+i37
+c $3 $0
+Z1 i4y
+$d $c
+y2 ,2
+o6r o7a
+o5w o4a
+o54 $4
+o4e o5t
+o45 i53
+o43 $4
+o2m o3i
+o0s ^i
+o0m o1k
+o0f r
+o0f D2
+^4 ^8
+Z2 i60
+Z1 i6x
+$l $p
+$3 $3 $7
+o6o K $s
+o40 $9
+o2n o3e
+o0k i1m
+o0d o3k
+o0d o1h
+c $6 $7
+^n ^o ^e ^l
+^T sUv D3
+[ Y1 .4
+Z1 $c
+$w $s
+$a i0a
+y3 o0h
+o7r ]
+o6o ]
+o4j -0
+o43 $2
+o42 i50 i61 o72
+o31 ,4
+o2j -0
+o1e i2e
+o0f D5
+o0c $0 $6
+l $j $o $h $n
+i38
+i04 i13
+c $9 $8 $7
+c $5 $0
+^s $7
+^o ^r ^a ^c
+K $8
+$t $2
+$j $e
+$1 $9 $6 $8
+t p5 ]
+o7a o8n
+o5w ]
+o5u o6t
+o5b $1
+o4a o5f
+o3z o4a
+o3p -2
+o0l D2
+o0a o1m
+c '9 $8
+c $2 $8
+^y ^r ^r ^e ^j
+^s i1j
+^s ^a ^k ^u ^l
+^b ^o ^c ^a ^j
+^2 ^0
+Z1 i6f
+T3 o0C
+$x *65
+$Y u
+y2 o3s
+oA1
+o8n o9a
+o5n $1
+o4a $0 $1
+o42 ss0 $0 $8
+o1j +0
+o1d .0
+o0m i2r
+o0d o2k
+^t ^s ^u ^g ^u ^a
+^s $4
+T1 o2u k
+T1 T5 T3
+R5 Z2
+$s $r
+$m $k
+o8o -9
+o6r o7o
+o4u o5t
+o48 $9
+o46 i57 o68
+o41 i59 i67 o79
+o3f o4a
+o2e o3d
+o2F *20
+o1a D2
+o0i o1m
+o0g o1b
+o06
+i47
+i0j i1o i2e
+o5t $1
+o4i *30
+o49 i53
+o43
+o2n o3a
+o1z D2
+o1e $1 $0
+o0g o2t
+o0a i1r
+^o ^r ^i ^h
+^l ^e ^i ^r ^b ^a ^g
+^e ^v ^a ^d
+T1
+R3 o2e
+.2 $1 $2
+$z Z1 E
+$9 $0 $9
+$0 $8 $1 $5
+t ^B
+r $4 $4
+o6i o7d
+o5s o6a
+o3l o4o
+o3h o4o
+o3d o4o
+o3a $0 $1
+o31 o48
+o2g o3u
+o0j o1t
+o0g r
+o0g o2n
+o0b $1
+o0a r
+^l ^u ^a ^p
+^e ^n ^o
+^d ^l ^o
+^8 ^3
+[ o4i
+$u $n $o
+$s $i $n
+$r $y
+$p *64
+$7 $8 $6
+} ^p
+o84 o0B
+o7g ]
+o6d o7i
+o5y
+o4s o5o
+o3u o4r
+o3k $1
+o1i o2g
+o0m r
+o0c o2s
+i4&
+i33 i32
+^v ^o ^l ^i
+^s ^e ^v ^o ^l
+^n ^a ^j
+Y1 c *67
+$y $2
+$s $h $a
+{ ^y
+x23 p1
+o4v '6
+o4i o5m
+o47 $6
+o3b o4u
+o3a $0 $4
+o2z o3i
+o2k o3a
+o2b ,3
+o0l i1b
+o0g o2d
+o0d $2 $4
+^v }
+^t ^u ^b
+^s i3r
+^s i0h
+^r ^u ^o ^f
+^o o4a
+^o i1m
+^i ^l
+.2 i4a
+ss2 $1
+o6i o7k
+o5w o6a
+o5n *34
+o53 $4
+o43 i56 o69
+o3s o4k
+o1v D3
+o0l $7
+o0f +2
+o0d i1a
+o0R $1
+i62 i70 o81 ,9
+^s ^n
+^r ^o ^t ^c ^i ^v
+^o ^r ^u ^e
+^o ^g ^e ^l
+$w *43
+$t $v
+s*_ ^_
+o5v o6a
+o4z o5e
+o4x
+o44 i53 o62
+o41 i59 i69 o70
+o40 $0
+o0e i1s
+o0d o1l
+o0b o2k
+^y ^a ^r ^g
+^t ^r ^u ^k
+^s ^s ^o ^b
+^s *65
+^r ^a ^l
+$p $m
+$o $t
+y2 $1
+s9#
+p5 o29 *05
+o70 o83
+o4u +2
+o3i o4k
+o2b o3i
+o1o $8
+o1i o2k
+o15
+o0l +1
+o0g o3d
+o0c o2c
+c *87 $?
+^7 ^8 ^9 ^1
+] ^r
+$p
+$&
+o73 ,8
+o3z o4i
+o32 o40
+o0m o3i
+o0m o2h
+o0d o2s
+o0c i1m
+o0b $9
+l ^0 ^0 ^0 ^2
+^t ^r ^e ^b
+^t ^i ^p
+^s { i4r
+^m ^a ^e ^t
+Z2 o2d
+$s $9
+$o $i
+o41 i52 o60
+o3m o4i
+o3k *14 [
+o2o *21
+o0b i2r
+c T3 $1
+^x o2o
+^s $2
+K $9
+o51 i62 o75
+o4s i5h o6i
+o3e o4t
+o2z o3u
+o2z o3e
+o1u o2s
+o1o $0 $3
+o0S $0 $1
+o0E $1
+i31 i41
+c i6.
+^y ^n ^n ^u ^b
+R0 ]
+D5 ^1
+$$ Z1 +8
+o5l +0
+o5i o6d
+o5i $n
+o5h $1
+o5b o4o
+o4j o5i
+o3s c
+o0j i1a
+o0i ^c
+i11 i32 i53 o74
+i0a i1a
+^s ^e ^u ^l ^b
+^o ^i ^b ^a ^f
+Z1 i2a
+$1 $9 $6 $5
+u $s
+ss1 $9 $8 $8
+o6d -0
+o5K l
+o4t o5y
+o4i o5a
+o4d $1
+o3a ^a
+o3a *31
+o2j o3a
+o2g ,3
+o0l o2k
+o0d r
+o0c $1
+o0b o4a
+o0J $1
+l $b
+^z ^a ^k
+^y ]
+^t ^s ^r ^i ^f
+] y2 y2
+[ o1a
+[ o0m
+$s $u $n
+$n $a
+y3 +2
+p4 u 'A
+o6k *64
+o6b $1
+o5s o6h
+o4e o5c
+o47 i58 o66
+o47 $3
+o44 $5
+o3y *31
+o3f ,4
+o2r c
+o0m $2
+o0c i1j
+l $1 $2 $3 $4 $5 $6 $7 $8 $9
+^s ^i ^v ^l ^e
+^s ^e ^j
+^r ^e ^k ^o ^j
+^e ^i ^d
+^1 ^#
+R3 ,4
+$s $j
+ss0 $0
+o5o o7o
+o5_
+o3a o4k
+o34 +4
+o2i i3l
+o2g o3e
+o1i o2l
+o0b r
+o0b K
+^y ^e ^l ^r ^a ^h
+^t $3
+^r ^a ^s ^e ^c
+^$ T1
+*03 *21 r
+z3
+o89
+o61 o72 o83
+o5p ]
+o42 ss0 $0 $7
+o3o $2 $0
+o30 *81
+o2l T0
+o1m o2a
+o0l r
+o0k o1s
+o0j o2d
+o0j o1f
+l $h $o $m $e
+i67 i78 i89
+^r ^i ^k
+^o ^r ^b
+$u *30
+$m +5
+$l $i
+$3 $1 $6
+$1 $4 $7
+$+ $+
+o6y
+o6i o5v
+o4c *13
+o3y D4
+o2r o3i
+o1o -0
+o0f ^a
+o0c i2r
+o0b o2r
+o0N $1
+i6@ o71
+^y ^n ^n ^u ^s
+^y ^h ^w
+^y ^d ^n ^i ^c
+^x ^i ^m
+^r ^u ^o ^y
+^o ^c ^s ^i ^d
+^n ^a ^l ^y ^d
+^8 ^6
+$m $p
+$) +6
+s2$ E
+o8d o9o
+o6t o7o
+o5a o6c
+o51 ss2 $3 $4
+o41 i50 ,6
+o3v o4e
+o3s i4k o5i
+o3i D5
+o2g o3i
+o1j D3 D3
+o0k o2d
+l ^d ^r ^o ^w ^s ^s ^a ^p
+^x ^o ^b
+^w o2d
+^h ^a ^n ^n ^a ^h
+.2 $0 $0
+$s $n $o $w
+$q D2
+$p r
+$j $o $e
+o80 o91
+o6s o7h
+o5p o7n
+o5i $s
+o5b o6i
+o4t D6
+o4s c
+o3f -0
+o3c sc3 i40
+o34 ]
+o2v o3a
+o2b o3u
+o2a o3s
+o1c i2h
+o0m $5
+o0M $0 $1
+l $i $n $g
+c $7 $3
+c $7 $2
+^v ^l
+^r ^o ^l ^y ^a ^t
+$y {
+$s *31
+$3 $5 $7
+t ^C
+o81 o97
+o7o -6
+o5u o6l
+o51 i62 i71 o82
+o4k o5u
+o48 $0
+o3u o4l
+o3t D5
+o2v o3i
+o2u o3l
+o2h o1t
+o13 o24
+o0d i1e
+o0b o63
+c $2 $0 $0 $7
+^v ^t
+^s ^r ^a ^m
+$y +6
+$x $l
+$s $h $o $t
+o72 ,8
+o6u o7x
+o6m $1
+o5v K
+o5e o6m
+o5b ]
+o5O E
+o4q D5
+o4c o5i
+o43 i50 ,6
+o3m o4o
+o30 o42
+o2f D4
+o2a -1
+^y ^l ^i ^m ^a ^f
+^o ^b ^r ^u ^t
+[ o5t
+[ o0m k
+Z1 o0F
+Y1 *36
+D4 D4
+$z {
+$s i3t
+$b $l $u $e
+oA3
+o5o o6w
+o55 ,6
+o3r o4o
+o3n
+o3i $0 $4
+o1e +0
+o1O c
+o0k o1d
+o0g o1l
+o0d i1f
+i6m i7a i8n
+^x ^i ^s
+^t ^i ^h
+^d ^e ^r ^f
+] t {
+Z4 D4
+Y3
+$y i6m
+$w $a $n
+$o $x
+u o0W
+t o0$
+r i2k
+o5a *15
+o4s o5c
+o4m o5u
+o4c o5e
+o41 i59 i67 o75
+o41 i58 o60
+o3a D5
+o0h D4
+o0h D2
+o0f i1c
+o0e i1b
+o0a o1c
+^v o3j -3
+^a ^l ^l ^e ^b
+^a ^e ^r ^d ^n ^a
+^6 ^8
+Z2 $3
+Z1 $p
+$n $e $t
+y2 o4g
+s1# T5
+r $c
+o6n o7i
+o4w i4o
+o4i $1
+o2t o3o
+o2r o3o
+o0g p2 '9
+i74 i85 i96
+i3a i4n i5d
+i2.
+^y ^t ^s ^i ^m
+^y ^n ^a ^d
+^t ^e ^r ^c ^e ^s
+^t ^e ^l
+^k ^n ^i ^p
+[ p4 o3x
+Z2 $5
+,1 $1 $2 $3
+$r $n
+o8i o9e
+o81 o96
+o4k o3o
+o4i o5g
+o42 sS0 $0 $4
+o3u D5
+o3b o4o
+o2t D4
+o2k o3u
+o2f o3a
+o1d D3
+o0m i2g
+o0g o2g
+o0b i1c
+l $t $e $a $m $o
+i32 i42
+c $6 $8
+c $4 $5
+^x ^z
+^p i0b
+^n ^o ^m ^i ^s
+R6
+$r Z1
+$r $a $m
+s1t
+o3r +2
+o3k o4u
+o39 ,4
+o1e o2l
+o0m i1o
+o0g i1b
+^l ^e ^m
+^c ^i ^g ^a ^m
+Z1 Y1 ,8
+,1 $g
+$m $o $m
+{ R5 Z2
+slN c
+r $a $n
+o5j o6o $e
+o55 +7
+o3a k
+o2z k
+o1a i1r
+o0i o1b
+o0d $0 $8
+i7#
+i58 i54
+c $6 $4
+^y ^m ^e ^r ^e ^j
+^o ^m ^o ^m
+^2 ^7
+Z2 o4d
+E '8
+$r $l
+$m o8u l
+$1 $1 $7
+sbX o1R D0
+o7h *75
+o5n o6a
+o5h o6o
+o55 i60 ,7
+o4w o5o
+o4a i5l o6i
+o1d r
+o0p i1h
+o0j i1l
+o0j i1h
+o0i o1l
+o0c $7
+^w ^a ^l
+^o ^i ^l ^u ^j
+^n ^o ^c
+^n ^a ^g ^e ^m
+K t d
+$t i4f
+$f $i $s $h
+z1 i1t
+o5s o6e
+o5A c
+o4K E
+o3c o4k
+o3P l *12
+o30 o43
+o2v i3e
+o0k $2 $4
+o0e i1r
+o0c $8
+^z ^u ^l
+^x ^i ^r ^t ^a ^m
+^t ^a ^o ^g
+^s ^o ^c
+^r ^o ^n ^n ^o ^c
+^m ^i ^j
+'9 ^1
+$t $h $e
+$s *21
+$j $s
+{ { { {
+u $2 $3 $4
+s3s i6F E
+o6n o7g
+o6l $e
+o5h
+o4f ,5
+o4O E
+o43 i54 o65
+o41 i54 o65
+o41 $2
+o40 $8
+o3z o4e
+o3o $2 $2
+o3n o4a
+o3d o4u
+o33 *34
+o2u o3d
+o2o o3n
+o2h o3a
+o1w -0
+o0d i2m
+o0b $5
+i51
+^h ^a ^r ^a ^s
+^d ^n ^a
+[ $q
+Z2 o3d
+Z1 $b
+L8 i20
+$z ^a
+$b $c
+{ $s
+o6i o7e
+o6a $a
+o5r $1
+o2l o3u
+o2c D4
+o0s i1k
+l $i $s
+^r ^e ^v ^e ^n
+^o ^c ^o ^l
+^e ^t ^i ^h ^w
+Z2 $8
+$p $s
+$=
+o6,
+o5i $2
+o42 ss0 $0 $5
+o3i $0 $1
+o1i $0 $2
+o0w i1e
+o0j o1l
+o0d o1a $1
+o0b o1r
+i38 i38
+^y ^r ^b
+^r ^e ^j
+^n ^a ^v ^i
+[ o3o
+,1 $p
+$t $i $c
+$p $a $n $t $s
+$9 $5 $1
+s17
+o7k *57
+o6i $t
+o5o o2r
+o3p o4o
+o3h o4u
+o2s ,3
+o1a o2l
+o1a $2 $1
+l $i $n
+i5m i6a i7n
+^y ^r ^o ^c
+^s ^u ^c ^r ^a ^m
+^j ^a
+^i ^u ^g
+^7 ^5
+R5
+$z $1 $2
+$v $s
+u $p
+o6i o7c
+o5w $1
+o3i o4t
+o2j D3
+o2d o3o
+o1i i2n
+o0k o2m
+o0j o2s
+o0g D4
+o0c i1h i2a
+o0b i1a
+c T5 i5_
+c $2 $5
+^y ^u ^g
+^y ^t ^s ^u ^r
+^r ^o ^l
+^e ^p ^i ^l ^e ^f
+$u $h
+$r $1 $2
+$q $u $e $e $n
+$f $u $c $k
+$d $a $d
+$3 $0 $3
+y4 [ -1
+u +6
+o6u -5
+o6s o7e
+o5i o3i
+o3r o4e
+o3a $2 $3
+o2h o0f
+o2e D3
+o0d $2
+^t ^s ^e ^t
+^n ^a ^g ^o ^l
+^d ^c
+] ] ] $m $a $n
+.2 $1 $0
+$t $w
+$r +6
+{ $P l
+z1 i1p
+y3 '8 .2
+o5h *43
+o2x K D7
+o2k i3s
+o1e i2n
+o0g o2i
+o0c o1r
+l $a $d
+l $1 $1
+i69 i78 i87
+i0a i1s i2d
+c $2 $9
+^z y1
+^e ^g ^r ^o ^e ^g
+D3 k d
+$r $p
+$r $j
+$l $u
+$@ $1 $2 $3
+t ^1 y1
+o4z o5a
+o4d ]
+o2a o3m
+o1m o2c
+i0e i1d
+^w o1y
+^s ^t
+^l ^l ^i ^w
+] o6j
+.2 ,4
+$o $e
+o81 ,9
+o7l i8l o9a
+o6f o7i
+o5s i61 i72 o83
+o4u o5p
+o49 i58 o67
+o41 i50 o61
+o2k o3o
+o2e o3t
+o1e $3 $2
+o1d o2f
+o0h o2r
+o0d o2e
+o0c o1e
+o0c i1f
+i79 i89 i99
+^y ^n ^n ^e ^k
+^y ^k ^c ^i ^r
+^v ^d
+^u ^t ^s
+^s ^o ^m
+R5 Z1
+ss1 $2 $3 $4 $5 $6
+p4 *04 o0r
+o6t o7h
+o4f ]
+o48 $2
+o2i o3d
+o2b o3s
+o1g D3
+o1I [
+o0m i2l
+o0m +2
+o0c $0
+o0b $8
+l $m $o
+i6a i7n i8d
+c so0 T4
+^y ^m ^m ^a ^s
+^s ^e ^m
+^s *35
+Z1 i7o
+Y5
+.2 $1 $1
+$x $4
+$s $f
+o7p
+o5o ]
+o5g o6a
+o51 i69 i70 o85
+o4q
+o41 i52 o68
+o3a o4b
+o2o o3l
+o2m i3i
+o2e i3s
+o2@
+o1o $7 $7
+o1o $2 $3
+o1l o2e
+o1i o2d
+o1h +0
+o0m o1y
+o0m D4
+o0m '8
+o0d }
+o0B $0 $1
+l ^g ^n ^o ^l
+i92 iA0 iB1
+c ^4
+^y ^z ^z ^i
+^v ^i ^l
+^t ^i ^r ^b
+^e ^i ^m ^a ^j
+R4 i57
+K $5
+D5 D5
+$y $e $a $h
+$r $f
+$j $d
+o5k i61 i72 o83
+o5e $r
+o4u $1
+o45 i51 o60
+o3t D6
+o0l o2r
+o0j o2h
+o0c $9
+i22
+^y ^n ^a
+^o ^g T2
+^n ^i ^t ^s ^u ^a
+^m o1i i2k
+^a ^m ^a ^m
+^a ^h ^n ^e ^s
+^0 ^8
+$r *24
+$g Z1
+y2 y2
+o81 +6
+o5s o6i
+o4o *02 p5
+o48 i50 o68
+o2r i3k
+o2m *03
+o1o $2 $1
+o0d o1s
+^u ^w
+^t ^s T2
+^t ^r ^a ^f
+^s ^a ^r
+^p ^g
+Z2 $6
+Y2 r *30
+Y1 i19
+T0 ^S
+$s $a $r $a
+$1 $9 $6 $4
+p5 oA6
+o8s D7
+o7j *57
+o6c
+o4c +3
+o2r o3n
+o1m D3
+o0m D5
+o0l $2 $4
+o0j o2l
+o0f i2r
+c $%
+^i ^h
+] Y3 *34
+[ o5u
+T4 R4
+T0 i2p
+,1 o3v
+$x +5
+$n $o
+$d $b
+$9 $5 $6
+$1 $9 $6 $3
+y5 o5d
+y2 o2w
+o6s $1
+o5a Z1
+o58 *65
+o58 $0
+o4l D6
+o2m ,3
+o2a o3t
+o24 r
+o1n D2
+o0m i1k
+o0l +3
+o0g $8 $8
+o0f i1e
+o0c o1u
+l $b $e $a $r
+c $4 $2 $0
+^z ^a ^g
+^v { $b
+^t ^a ^h
+^e ^e ^l
+[ o74
+[ o0g
+T1 *17
+R4 o7a
+$s $w
+$d $a $n
+y2 o4j
+r $u
+o6o i71 i82 o93
+o6a o7c
+o5l $l $a
+o49 $8
+o41 ss2 $3
+o3h o4i
+o2e $1 $1
+o2d D4
+o1r D2
+o1i $0 $3
+o1e $0 $2
+o0s $1 $7
+o0b o3i
+l $a $c
+i62 i70 ,8 o98
+^t ^n ^i ^a ^s
+^s ^i ^r ^i
+^l ^l ^i ^b
+[ o23 i32
+$o $p
+$j $u
+o6d
+o47 i56 o65
+o41 i50 o62
+o2u o3n
+o2e o3m
+o1o D2
+o1a o2c
+o0l o1j
+l $l
+i73 i83 i93
+^t ^s ^a ^e ^b
+^o z1 o0G
+^e ^l ^p ^r ^u ^p
+^8 ^4
+^1 ] ]
+[ o4p
+$s $u $c $k
+u o64 o7U
+u o64 o7M $E
+o7u *67
+o6a o7k
+o5i o6m
+o50 Z1
+o4z o5i
+o4m +0
+o4j -2
+o4e D6
+o4a +0
+o2n $1 $0
+o2d o3u
+o2G l $1
+o1u o2l
+c T4 i4_
+^z ^a ^j
+^u ^a ^e ^b
+^s ^i ^k
+^r ^o ^j
+^r ^e ^g ^o ^r
+^n ^e
+^k ^a
+^a ^v ^e
+^1 ^1 ^0 ^2
+[ o3j
+Z1 i3c
+$R @o c
+s20 Y2
+oA4
+o6c $1
+o5w o6o
+o5u o6z
+o2r o3t
+o29
+o1c D3
+o0m i1i i2a
+o0k $7
+o0c o2t
+o0c $1 $4
+i70 i81 i90
+^y ^t ^r ^a ^p
+^y ^d ^o ^o ^l ^b
+^w ^o ^b
+^t ^a ^g
+^s ^y ^a ^w ^l ^a
+^s *23
+^o o3r
+^o ^t ^o ^m
+T1 T5
+K $4
+.2 $a
+'5 d
+$x $1 $2 $3
+$t $5
+z1 ^A
+o6o $2
+o5o o6k
+o4e o5b
+o4b sT& -5
+o4a $1
+o3o i4s
+o3i o4e
+o2w *02
+o2g i3u
+o2f o3i
+o1u $2 $2
+o1e $0 $3
+o0k o2s
+o0j i1t
+o0g o2s
+o0b o5a
+o0b $1 $4
+i5i i6s
+i20 .1
+c $5 $7
+^r ^o ^d
+^n ^a ^r ^f
+[ o3z
+$x $y
+$3 $6 $5
+o62 i70 sS0 $6
+o5g o6u
+o5e o6c
+o4p r
+o46 i55 o64
+o41 i53 o65
+o1o o2m
+o1l i2o
+o1a o2k
+o0m o3a
+o0j o1g
+o0e o1n
+o0d $5
+l K +7
+l $l $a $n $d
+i0c i1a
+^y ^l ^l ^i ^l
+^v ^o ^n
+^u ^h ^s
+^n ^a ^s
+[ [ [ [ [
+Y2 *67 r
+T0 T3 T6
+R0 r
+$x $7
+$p $h
+$j $h
+y2 *47
+soi
+sYd z1 o59
+o9e
+o6o o7r
+o5p o6a
+o51 Y1
+o4l r
+o2n o3i
+o2k ,3
+o2a o3r
+o1t
+o1i $0 $4
+o1c D2 D3
+o0u k
+o0g i1a
+o0g $8
+o0b i1m
+o0b D5
+l $i $t
+l $e $m
+i69 E
+i63 i73 i83
+^s ^e ^w
+^6 ^4
+u '6 $2
+o6j o7e
+o6i o7m
+o5o o6u
+o4c K
+o3o $1 $5
+o34 sS2 $0
+o2g o1d
+o1r o2i
+o1B [
+o0g o1h
+o0c r
+c sl1
+c $3 $2
+c $2 $4
+^y ^e ^l ^a ^h
+^w ^a ^r
+^r ^o ^p
+^o ^w
+^o ^i ^n ^o ^t ^n ^a
+^i ^h ^c
+^8 ^0 ^0 ^2
+$w $a $r $d
+$t $h $i $s
+$s $t $o $r $m
+$3 $1 $4
+$- $1
+r $n
+o41 i52 o65
+o41 *13
+o0m *20
+o0l i1g
+o0k z1
+o0c o2p
+l $m $a $c
+i44
+i0c ^a
+^- sH4 ]
+K Z1 $0
+$l $i $v $e
+o6o o7l
+o5k D7
+o42 i50 i60 o71
+o3o o4p
+o0j i2n
+o0i o1c
+o0g o2u
+o0f $1
+^o ^r ^e ^a
+^o ^c ^a ^p
+^n ^a ^h ^t ^e
+^l ^o ^r ^a ^c
+Z1 $h
+T5 o0Z
+$x $y $z
+$? Z1
+u o2W [
+u $4
+o64 Z1
+o5o $1 $2 $3
+o51 i62 i73 i84 i95 oA6
+o48 i59 o60
+o3r D5
+o3e o4d
+o3c r
+o2t o3i
+o2p ^k
+o1s [
+o1o o2d
+o1e $0 $4
+o0k o2j
+o0k $0 $8
+o0d o1e $1
+o0b o1m
+o0b i1g
+o0b $1 $5
+l ^3 ^0 ^0 ^2
+i6@
+^y ^d ^d ^e ^t
+^y ^c ^n ^a ^n
+^y ^a ^s
+^t ^r ^a ^m ^s
+^r ^e ^v ^o
+^l ^u ^o ^s
+^c ^j
+^0 ^9
+[ o0c
+Z3 o84
+Z2 -3
+T3 o0I
+$w $e $n
+$o $d
+r $o $n
+o6x ]
+o6r o7i
+o6o K
+o5l $i
+o5a $1 $2 $3
+o4c i5h o6u
+o42 i54 o67
+o41 i59 i67 o74
+o3t o4u
+o3a o4c
+o2t o3u
+o1w D3
+o1u o2m
+o1o $0 $1
+o0m *54
+o0k o2i
+o0k o1i o2m
+o0d D2
+k i16 ^9
+i71 i80 i90
+i0c i1h
+d { '9
+^y ^e ^k ^c ^i ^m
+^t ^r ^e ^b ^l ^a
+^r ^M
+^i ^l ^e
+^d ^o ^o ^l ^b
+*40 *31 r
+$u $i
+$M l
+snG c
+sa4 o40
+o80
+o5r
+o41 i53 i63 o77
+o3p D5
+o3i o4l
+o3f -2
+o2u o3r
+o2n $1
+o1u i2n
+o1e o2b
+o0t *20
+o0k o1i i2m
+o0k i1a i2r
+o0d o2a
+o0c $1 $5
+^u ^r ^d
+^t ^r ^o ^p ^s
+^b ^m
+^a ^v ^i ^v
+T4
+T3 s0@
+K $1
+$r *78
+o6z ]
+o43 $1
+o42 i59
+o41 i52 o61
+o3u [ *31
+o2m D4
+o2k o1e
+o2c o3i
+o0g D6
+o0d $9
+l $f $f
+c ^e ^h ^T
+c $5 $6
+c $0 $2
+^u ^b ^a
+^s ^s ^e ^c ^n ^i ^r ^p
+^q z1
+^g ^m
+$v D7
+$j $o
+$9 $8 $9
+o82 ,9
+o70 Z1
+o53 i61 ,7
+o4o o5d
+o3r o4u
+o3o $2 $4
+o2u o3b
+o2m o3o
+o1u $1 $1
+o0m $1 $5
+o0l $9
+o0i i1r
+o0g i1g
+o0b $3
+l $c $m
+i36
+i0b
+^s ^u ^j
+^n ^e ^r ^u ^a ^l
+^a ^n ^u ^l
+Z2 o3u
+Y3 *53
+Y2 i0a
+T3 o0F
+$z $2
+$b $i $t $c $h
+$a $z
+{ { { { c
+o6i o7r
+o66 -8
+o4o +0
+o4o $0 $1
+o4a o5p
+o49 $0
+o43 i52 o64
+o41 i50 o69
+o3i o4c
+o2i o3m
+o2h o3o
+o0m i1p
+o0k $0 $9
+o0a i1p
+o0M $1 $2
+o0C $0 $1
+i47 [
+i14
+i12 *7A
+^y ^a ^w
+^t ^n ^e ^k
+^t ^a ^s
+^s o2s
+^r ^s
+^r ^e ^t ^s ^u ^b
+^m o1i
+$t $l +9
+$n $i $c $k
+$m $o $o $n
+$1 $9 $6 $6
+s4` .6 +0
+o5o i6m o7a
+o4u o5b
+o4i *02
+o4e o5v
+o42 ,5
+o3p ,4
+o3h *12
+o3f o4i
+o34 i45 o56
+o2g D4
+o1a o2d
+o0j o1i
+o0f $7
+o0M $1 $0
+o0B $2
+i77 i88 i99
+i55 i54
+i3@
+i39
+i37 i47
+^s ^g ^n ^i ^k
+^p +1
+^o o3o
+^6 ^7
+T1 T2 D8
+.2 o4u
+$9 $5 $7
+$0 $0 $7
+} o05
+{ Z2
+s6_
+o6e o7d
+o5g o6e
+o5e E sm/
+o51 i69 i79 ,8
+o3u o4k
+o3n +2
+o3f D5
+o3e D5
+o2p o3o
+o2a o3b
+o1a $9 $9
+o0k o1h
+o0d $2 $0
+l ^4 ^0 ^0 ^2
+i31 c
+d 'D
+^t ^S
+^r i1t
+^q +1
+$N @h '7
+t sMD
+o6u o7m
+o6f
+o4j ]
+o3u o5i
+o3o $1 $2
+o3n o4o
+o3j *21
+o3i o4a
+o2q *70
+o28 r
+o1q D2
+o1L [
+o0j k
+o0j D3
+o0e o1r
+o0d $2 $8
+o0a o1j
+i0a i1d
+c ss5
+^r ^e ^m ^m ^u ^s
+^b ^j
+^2 ^1 $1 $2
+Y2 o5y
+$b $e $n
+$9 ^6
+} o1g
+o5e $1 $2 $3
+o5a $s
+o3v o2a
+o3o o0a
+o3j o4e
+o2t T0
+o2r o3u
+o2n *02
+o2l D4
+o2i o3t
+o2f o3u
+o1j +2
+o0m i2d
+o0l +2
+o0l $5
+o0k o4k
+o0g $1
+o0f i1f
+o0d k
+c $2 $0 $0 $0
+^o ^b ^o ^b
+$o $c
+$5 $2 $0
+y3 +5
+u '6 $1
+s0o
+o7o +6
+o6@
+o5i E
+o4p o5u
+o4l o5y
+o4j r
+o4c ]
+o4I c
+o47
+o41 $6
+o3u +4 *31
+o3p +0
+o3A c
+o2t ,3
+o2f r
+o0k o3k
+o0k o3i
+o0k o1g
+o0d D3
+o0c i1g
+o0b o2u o1l
+o08 ^5
+l $b $e
+i6_ o71
+i31 i30
+i0g i1o i2d
+c T4 i4-
+^y ^l ^a
+^y ^e ^r
+^r o1y
+^o ^n ^a ^m
+^m ^a ^e ^r ^d
+^l ^a ^e ^r
+^c ^d
+] y2 c
+Z2 c D1
+Z2 *21
+$t $o $n $y
+$m $a $r $i $a
+$6 $1 $6
+s18 Y2
+o67 ,5
+o5n smh
+o5j $1
+o4c +0
+o4a o5z
+o45 i56 o67
+o3u *21
+o3o +2
+o3i o4d
+o3i $2 $3
+o3g o4h
+o3a o4m
+o2y D3
+o2i $1 $0
+o1i o2c i3h
+o0m $4 $4
+o0j i1o
+o0d $8
+o0d $1 $9
+o0a i1h
+o0A $0 $1
+i59 i54
+i57 i54
+i44 [
+c so0 si1 se3 ss$ sa@ $!
+c $6 $5
+^y ^r ^r ^a ^l
+^9 ^3
+T9 TA
+$l $u $v
+oA6 +9
+o3t o4y
+o3o o4t
+o2t +4
+o2c r
+o0l $8
+o0g o3b
+o0g o2z
+o0c o3e
+o0M $1 $2 $3
+i76 o68
+i60 c
+i48
+^n ^n ^a
+^e ^o ^l ^h ^c
+^3 ^< ^i
+$b $r
+} o0g
+{ o4b
+y4 Y1
+o8l
+o82
+o81 o94
+o5v ]
+o5o o6m
+o4k D6
+o45 i50 ,6
+o41 i50 o63
+o40 $1
+$e D4
+o3p o4i
+o2i T0
+o2d ,3
+o2d $1
+o2_
+o0t o1h o2e
+o0l ^l
+o0k o3l
+o0a o1k
+c $7 $7 $7
+c $7 $0
+^o ^h ^c ^e
+^n ^u ^s
+^l ^e ^u ^g ^i ^m
+^j ^c
+[ o3y
+T0 o5q
+$u E
+$p $a $p $a
+sa4 si1
+o6o E +9
+o51 i64 o77
+o50 Z2 ,8
+o44 r
+o3c o4a
+o2w D4
+o0s $0 $9
+o0k $9 $5
+o0h D5
+o0g i2r
+o0e o1c
+o0e *31
+^y ^v ^i
+^y ^t ^t ^e ^b
+^s ^o ^c ^r ^a ^m
+^6 $6
+,3 $5
+$t $o $o
+$5 ^5
+o6p ]
+o6a o7h
+o4i o5o
+o3z -2
+o3x ]
+o3m
+o3_ D4
+o2r i3g
+o2p o3h
+o2n D4
+o2c $1
+o1i o2s
+c $4 $7
+^y ^t ^n ^o ^m
+^k ^j
+^7 z2
+^3 ^8
+Z1 $g
+$p $i $n $k
+$? D5
+z3 o1a
+y2 i2m
+o81 i92 iA3 iB4 oC5
+o6k $e
+o5y $1
+o5w
+o50 $9
+o4h ]
+o4b ,5
+o2x D4
+o2s o3u
+o1u o3k
+o0m o2j
+o0m $7 $7
+o0j o2p
+l i5&
+i0$
+^u ^n ^a
+^u ^a ^l ^c
+^o ^k ^o ^k
+^2 ^5
+Y2 .5
+$m $l
+$7 $1 $1
+$5 $1 $5 $0
+o6a $1 $2 $3
+o5,
+o4z o5o
+o4p o3e
+o4a $9
+o46 i51 o69
+o3m +5
+o3i o4o
+o38 *13
+o33 o52
+o2j k
+o1o $1 $0
+o1j r
+o1I E D2
+o0m o1r
+o0k o1f
+o0g i1o
+o0a o1r
+i52 i60 i71 o80
+i0j i1a
+d l ]
+^z .1
+^y ^f ^f ^u ^l ^f
+^g ^n ^i ^k ^c ^u ^f
+^d ^b
+] c T4
+T0 ,5 *65
+o7c o0C
+o6s o7a
+o5v o6e
+o4u $1 $2
+o3j o4u
+o3b +6
+o2z o3a
+o2b o3o
+o0l -2
+o0k $1 $7
+o0c o3m
+o0a $1 $5
+i17
+c si!
+^x z2
+^t ^s ^o ^p
+^t ^n ^a ^w ^i
+^s $9
+^o ^c ^i ^h ^c
+^a ^h ^p ^l ^a
+^6 ^5 ^4 ^3 ^2 ^1
+^4 ^9
+Y2 o3r
+Y2 Y2 c
+K l d
+,1 $d
+$r $e $a $l
+$2 $4 $6
+$0 $9 $8
+q r '8
+p1 o0h
+o5u
+o5s +6
+o5l '8
+o47 *30
+o41 c
+o3r o4i
+o3n *03
+o3b r
+o3E c
+o1m ^c
+o1i $0 $1
+o1h D3
+o1e $9
+o0m o1s
+o0j o2v
+o0j i1f
+o0g D5
+o0d $1 $6
+o0c i1o
+o0a o1s
+o0M $8
+i41 ss1 $2
+^t ^r ^i ^d
+^s ^i ^r ^a ^p
+^r ^u ^m
+^o ^c ^e
+^a ^u ^h ^s ^o ^j
+T4 t T3
+o5p +4
+o4d -5
+o3Y l
+o37 sS7 $7
+o0m $4
+o0k o2p
+o0j r
+^y ^z ^a ^l
+^y ^v ^e ^h ^c
+^s ^e ^l ^r ^a ^h ^c
+^r ^e ^p ^y ^h
+^o ^i ^g ^r ^e ^s
+^n ^o ^m ^e ^d
+Y2 y2
+'5 D2 p1
+$r $a $t
+$2 $1 $1 $2
+$1 $0 $0 $0
+o6i $e
+o5a i6d o7a
+o51 i62 o76
+o4h r
+o4g *46
+o4U c
+o3w *30
+o3d r
+o3a o4g
+o3Q l
+o2w o3a
+o2l i3f
+o1w +0
+o1i $1 $0
+o1e o2a
+o1U c
+o0m i2s
+o0m $3 $4
+o0k i2r
+o0M $5
+k p2 'A
+c ss$
+c $7 $1
+^y ^e ^r ^t
+^s ^s ^o ^r ^c
+^r ^a ^j
+T0 ^A
+K *01 r
+$o $l $i
+$i $k
+o61 i72 ss3 $4
+o5i $t
+o5a o6r
+o5a i6m o7i
+o4s o5k
+o4n k
+o45 $5
+o41 ss9 $9 $0
+o3i E
+o2u o3g
+o2g i3e
+o2e k D4
+o2G l
+o1n -0
+o1l o2o
+o1g +2
+o0s $1 $9
+o0k y2
+o0k $7 $8
+o0b o4i
+i70 i80 i99
+c $1 $0 $0
+^y ^x ^o ^f
+^y ^t ^h ^g ^i ^m
+^y ^a ^t ^s
+^u ^d ^u ^d
+[ o1u
+Z2 o1r
+Y2 o7g
+$r +0
+$j $l
+o5x ]
+o5o o6s
+o5i o6g
+o4i $2
+o46 -6
+o41 $9
+o2s o3i
+o2m K
+o2l o3o
+o1w
+o1o o2u
+o0h r
+o0d +2
+o0b i1k
+o0b +3
+c $1 $9 $8 $7
+^y ^v ^a ^e ^h
+^s ^i ^n ^n ^e ^d
+^r ^e ^v ^e
+] l ] $a
+$j $g
+$d $m
+t o2T
+o6w o7e
+o6c $e
+o5a $n
+o51 $2
+o50 i69 i70 o85
+o4k o51
+o45 E ,9
+o44 $4
+o3t $1
+o3m i3e
+o3j o4i
+o2w K
+o0d $5 $6
+o0c i2n
+o0M D2
+l $k
+k } }
+i11
+^y ^d ^n ^a ^r
+^r ^o ^t
+^9 ^5
+^3 ^1 $1 $3
+Y1 $7 r
+$r $a $n
+o8h
+o62 i70 sS0 $5
+o5r o6u
+o4o o5p
+o4o o5g
+o41 i59 i67 o72
+o41 i50 o65
+o3w o4i
+o36 i46 ,5
+o1k D2 D3
+o1i o2c
+o0m $3 $3
+o0j D4
+o0h i1m
+o0g o3g
+o0b $4
+i5_ T6
+c T6 i6-
+^y ^t ^s ^u ^d
+^u ^l ^i
+^t ^o ^m
+^t ^a ^h ^c
+^s ^i ^n ^e ^d
+^r ^o ^n
+^r ^e ^d ^n ^u
+^n ^e ^r ^a ^k
+^i ^d
+^g ^m ^o
+.1 ,4
+$1 $9 $9 $9
+} ^x
+t ^I
+o6y o7a
+o6y D7
+o5a ]
+o5# o61
+o4k r
+o4c o5u
+o2y k
+o1r o2u
+o1j D3
+o1e $7 $7 $7
+o0m o2z
+o0b $1 $3
+c $3 $4
+^r ^a ^m ^o
+$w Z1
+$w $i
+$s -1
+$s $i $n $g $h
+$9 $8 $6
+u ^F
+p4 ,8 ,7
+o6h ]
+o6N l
+o4o o5t
+o3w o4e
+o2e $1 $0
+o1o o2r
+o1O l d
+o0e o1b
+o0B $1 $0
+c $0 $0 $1
+^y ^r ^t
+^y ^b ^a ^b T4
+^s ^a ^h
+^r ^e ^d ^i ^p ^s
+^p ^e
+^l i1c
+^e ^h ^T
+^a ^l ^o ^l
+$s $i $x
+$@ t D4
+$1 $0 $8
+u sA@
+s8g
+o5f ,6
+o4y -3
+o4e o5x
+o4a o5v
+o3y *20
+o3i o4g
+o2c o3e
+o2b r
+o2D l
+o1a o2b
+o0k o2h
+o0f o3e
+o0a i1t
+o0S $1 $2
+^o ^t ^e ^b
+^o ^r ^f ^a
+^m ^l
+^4 ^6
+^2 ^1 ]
+] ^1
+$x $c
+$3 $1 $3
+u o64 i7E i8V o9E $R
+o7o o8n
+o5i $m
+o5c o6e
+o5a o6h
+o4v o5o
+o4o $2
+o4a i5m o6a
+o44 k $0
+o3s $1
+o3a o4f
+o2k D4
+o2g o3r
+o0l o3a
+o0h o1k
+o0f i1i
+o0e o1s
+i45
+i1. l
+^s ^r ^a ^l
+^s ^o ^d
+^s ^e ^y
+^r ^o ^l ^f
+^n ^e ^k
+^m ^a ^i ^l ^l ^i ^w
+^4 ^7
+R4 ,5
+$f $o $x
+$4 $e $v $a
+sa@ se3
+s0v
+r $m $a $n
+o6q
+o4p o5h
+o4c -6
+o49 $9
+o41 i50 o67
+o3k *14
+o32 ,4
+o2z i2t
+o2q o3u
+o2f -3
+o2a o3g
+o0l o2w
+o0h $2
+o0c o3d
+o0a z1
+o0a o1f
+l $h $a
+^s +2
+^r ^e ^w
+^k ^m
+^9 ^4
+E $#
+*31 *20
+$w $i $n $g
+$a $b $c $d
+$6 $9 $6 $9
+$5 $0 $5
+$1 $9 $6 $2
+t o2R
+ss1 $9 $7 $7
+oA5 T0
+o5m
+o4s +5
+o4i +2
+o4g r
+o4d o6n
+o4a o5x
+o45 i56 i67 o78
+o3i $1
+o3d o5r
+o3a o4h
+o2s D4
+o2r o0t
+o1a o2t
+o0l i2u
+o0k $6
+o0g t
+o0f }
+o0c $1 $3
+i0b ^d
+^y ^o ^t
+^v ^i
+^t ^i ^b
+^p ^i ^l ^f
+^5 ^7
+Z2 ,4
+.1 .3
+$p $o $o $p
+$f $u $n
+$6 $6 $7
+o7a $s
+o5i o6r
+o4b $1
+o41 i59 i67 o76
+o41 i59 i67 o70
+o41 i51 o67
+o32 i40 o51
+o2i i3t
+o25 *65 *31
+o1s i0g
+o1i $1
+o1g '6
+o0j D6
+o0a $2 $2
+i57 i67
+^y ^e ^l ^r ^a ^m
+^r ^e ^t ^n ^i ^w
+^r ^e ^p ^s ^a ^j
+^r ^e ^c ^c ^o ^s
+^k ^i ^r ^e
+^e ^g ^r ^o ^j
+^5 ^8
+Y3 *75
+$x $1 $3
+$p $k
+$o $l $d
+$c $o $o $l
+y3 c ]
+o5t i5o
+o5i $a
+o54 Y2
+o3h
+o1r o2e
+o1i c
+o0m $1 $1
+o0m $1 $0
+o0l $2
+o0h o2k
+o0a o1h
+l $h $i
+i59 i56
+i27 [
+^y ^t ^t ^e ^r ^p
+^y ^k ^c ^e ^b
+^y ^j
+^t ^a ^l ^f
+^o o4i
+[ o0k
+Z3 -9
+R4 $2
+K Y2 o87
+$t $g
+$k $l
+$g $r $e $e $n
+$1 $1 $2
+u R3 t
+o7k
+o61 i70 ,8
+o5t *50
+o5l c
+o4y o5u
+o4t *45
+o43 i51 o66
+o3j D5
+o3c D5
+o3a $3 $2 $1
+o2s *30
+o1y D2
+o1o i2r
+o1i o2t
+o1c o2h
+o0l $4
+o0k o3g
+o0k i3l
+o0g i2l
+o0d i2r
+o0d $3
+o0c $5
+o0a o1v
+o0M D3
+i61 i71 i81
+i56 i54
+^o ^l ^o ^p
+^n ^o ^d ^n ^a ^r ^b
+Y2 $2
+D2 ^1
+$y $o $u $n $g
+$m $r
+o6r
+o61 i52
+o6* t
+o5f o6i
+o56 $2 Z1
+o4b o5y
+o49 i50 o69
+o48 i52 o68
+o3e o4g
+o2r r
+o2r i3m
+o2m $1
+o2d r
+o2L l $7
+o1l
+o1e o2m
+o0l i1s
+o0h -3
+o0d o2v
+o0d $0 $9
+o0b o1c
+o0a $a
+i7l *67
+i61 i79
+^y ^n ^n ^e ^b
+^v ^a ^m
+^s ^i ^r ^o ^b
+^o ^e ^l ^c
+^m ^c
+D3 $6 $6 $6
+$k $o
+o5t $a
+o5p $1
+o5a i6m o7a
+o3y o4a
+o3b
+o2o o3m
+o1o o2s
+o1l o2i
+o0j D1
+o0d o3a
+o0b D4
+o0a i1v
+^u ^x
+^o ^j ^o ^m
+^c z1
+^0 ^2 ^4
+T0 T3 T2
+.1 ,3
+$x +0
+$w $i $n $d
+$q $1
+$m ^m
+$1 $9 $6 $0
+} K k
+shy
+p2 ] [
+o9o
+o6i $o
+o5z ]
+o5q
+o4l $1
+o41 i59 i67 ,7
+o3q o4u
+o3k ]
+o2f +5
+o1t D3
+o1j -2
+o1D C D0
+o0m $0 $5
+o0h o3e
+o0h $6
+o0c $2
+o0b o2j
+o0A D1
+i57 i65
+^t ^r ^o ^p
+^t ^a ^e ^m
+^s ^a ^i ^l ^e
+^s *42
+] p2
+$r $i $d $e $r
+$;
+$9 $9 $1
+y5 o0l
+u $0 $0 $0
+t o3G D1
+o73 k
+o4h +0
+o4b ]
+o41 i59 i67 o71
+o3o o4w
+o3f o4u
+o3e $1
+o2s o0M
+o2k o3s
+o2i i3m
+o1h
+o0s $2 $9
+o0k o2e
+o0e o1g
+i84 i95 iA6
+i57 i55
+i41 i52 i63
+c $0 $4
+^y ^d ^u ^r
+^y ^d ^n ^i
+^n ^u ^f
+^n ^a ^i ^r ^d ^a
+^m ^e
+^[ $]
+^3 ^7
+^0 ^6
+$y $i
+$p $i $n
+$o $h
+$g $b
+$9 $0 $0
+$5 $0 $0
+u sS2 $K
+sa@ sc< se3 si1 so0 ss$
+o7S E *32
+o70 ,8
+o5s Y2 D6
+o5m $a
+o4n ]
+o4m ]
+o41 i52 o64
+o3r +0
+o1v +2
+o1A E
+o0k $8
+o0j o1p
+o0g o2o
+o0d o3d
+o0b o4o
+o0a D5
+i16
+i0b i1a
+^t ^o ^p
+^t ^o ^l
+^t ^o ^d
+^s ^a ^m ^o ^t
+^r ^e ^h ^t ^o ^m
+^r ^a ^s
+^o ^i
+^o ^g ^o ^g
+^n ^w ^o ^r ^b
+^e ^c ^a ^r ^g
+^a ^j ^n ^i ^n
+K $2
+D6 D6
+$p $e $r
+$a $l $l
+z2 .4 .2
+z1 ^h
+o7i o8a
+o5b D7
+o5T c
+o53 i60 ,7
+o4r $1
+o4l ,5
+o3u o4b
+o2t i3o
+o2B l *53
+o0h ,3
+o0a o2d
+o0a $0 $2
+o0C $1 $0
+l $c $a $r
+i56 i53
+^y ^z
+^t ^f ^o ^s
+^5 ^4 ^3 ^2 ^1
+^* ^* $* $*
+] i31
+[ o4y
+Y2 o7u
+$p $a $n $d $a
+$S l
+{ ^r
+y5 i5y
+o4p +0
+o4+
+o3p r
+o3h K
+o33 i46 o50
+o2v
+o2f o3o
+o2e o4e
+o2d K
+o2b $1
+o1v o2a
+o1u o2g
+o1f D3 ]
+o0s k
+o0k o2c
+o0j $0 $8
+o0h i1o
+o0e o1f
+o05
+i79 i87
+i52 o60 i71 o80
+i30 i40
+^z ^z ^u ^b
+^s *46
+^9 ^8 ^7 ^6 ^5 ^4 ^3 ^2 ^1
+^3 ^2 ^1 $1 $2 $3
+Z2 D2 c
+R8
+D7 D7
+$o $n $i
+$Z
+x13 d
+u o5D
+o5n $a
+o5e .4
+o5a o6r o7a
+o4g $1
+o42 i53 o64
+o3o o4v
+o3e o4m
+o3c o4e
+o1u D3
+o0j o1h
+o0h i2l
+o0c o1k
+o0b o2u
+o0b $2 $3
+o0K o1i
+l $a $n $a
+^w ^o ^r ^c
+^u ^r ^a ^m
+^o ^h ^c ^y ^s ^p
+^n ^a ^e ^s
+E $$ -7
+E $! $1
+$y $l
+$y $1 $0
+$s $a $r $a $h
+$n $e $w
+$d $k
+$. Z2 E
+{ { { { {
+o81 o95
+o79 Z1
+o74 ,8
+o5e o6a
+o52 *78 *67
+o51 i60 ,7
+o4o $8
+o4i D6
+o44 $2
+o3i o4m
+o3D c
+o2t $1
+o2r $7
+o2p r
+o2p o3i
+o2p +3
+o1r *12
+o1n r
+o1i $5
+o1a i2i
+o0l $1 $4
+o0b i1h
+o0b $0
+i39 i49
+c $5 $4
+^n ^o ^m ^e ^l
+] o8d
+R4 ,5 i53
+K Z1 i75
+E +8
+$q $u $e
+$o $r $e
+$k $s
+$k $m
+o4i o5r
+o4a $1 $2 $3 $4
+o40 i59 o68
+o3e o4f
+o3b ,4
+o3a *40
+o2j i3a
+o2g i3o
+o25 *24
+o1i o2p
+o1e o2g
+o0m $3
+o0L $0 $1
+l $a $n
+i46 i59
+i19
+c $< $3
+c $2 $!
+^u ^k ^a
+^r ^a ^e ^d
+^o ^r ^t ^c ^e ^l ^e
+[ z2 ^1
+[ y2 E
+[ o1y
+Y1 $x
+T0 T4 T3
+$t $p
+$o $f $t
+$n $i $n $j $a
+$S E
+t o3.
+o8i ]
+o5o o6p
+o40 i50 o69
+o3v ]
+o3a $2 $1
+o37 i48 o59
+o2r D4
+o2j r
+o0m z1
+o0k o2u
+o0j i2m
+o0h i2r
+o0d o2h
+i75 i79
+c $5 $9
+^r ^e ^t ^n ^e
+^o ^l ^o ^l
+^n ^i ^r ^e
+^a ^d ^n ^i ^l
+Z1 o0J
+D1 $2 $0 $1 $0
+$x $1 $2
+$b $g
+oB7
+o75 ,8
+o6e $t
+o5y o6a
+o5_ o61
+o5B l
+o4o $1
+o45 i54 o65
+o44 i51 o65
+o41 $0
+o3u $1
+o3j +0
+o3h r
+o3a i4m
+o2z D4
+o2e o3k
+o1v
+o1o $7
+o1i i2m
+o1a i2h
+o0k o5i
+o0a $1
+o0L u
+i79 i71
+i76 ,8 ,9
+i35 i34
+c $1 $9 $9 $1
+c $1 $9 $8 $5
+c $1 $9 $8 $4
+^y ^r ^c
+^s ^d ^o ^g
+^p z1
+^n ^a ^e ^j
+^h ^o
+T0 T6 T4
+D2 $2 $0 $1 $1
+*21 *03
+$c $b
+o5o o6d
+o5a o6i
+o5@ i61 i72 o83
+o53 $3
+o4q o5u
+o3o o4m
+o3n o4i
+o3h ]
+o3a o7a
+o2l i3o
+o2d o3r
+o2a $9
+o1o o2g
+o1m r
+o1m
+o1e $3 $2 $1
+o0z k
+o0w r
+o0k $0 $6
+o0f i1t
+l ^i ^b
+l $b $a $r
+i6d i7a
+i44 i54
+i21 i32
+i0g ^a
+c $6 $0
+^y ^l ^l ^e ^j
+^y ^d ^n ^e ^w
+^t ^a ^l
+^d o1z
+Z1 o44
+E o13
+$u $1 $2
+$l $g
+$9 $8 $4
+$7 $4 $7
+o7l o5s
+o51 i63 i71 o83
+o4u o5x
+o4a o5j
+o3a r
+o2v D4
+o0k o3u
+o0k o3n
+o0j i1g
+o0g o2j
+o0c i3l
+i69 i79 i89
+i59 i53
+i30
+^t ^a ^h ^w
+^o ^d ^r ^a ^u ^d ^e
+^e ^g ^n ^a ^r ^o
+[ ] d
+$m $f
+$2 $!
+$1 $4 $3
+$# Z1
+u +7 ,3
+o6p o7o
+o4x ]
+o4u o5g
+o43 $3
+o40 i50 ,6
+o3s i3d
+o3m o4u
+o35 i46 o57
+o2r o3g
+o1e $0 $1
+o1a o2g
+o0j o2f
+o0j $0 $9
+o0d $4
+o0c o1i
+l $d $a $v $i $d
+i53 i52
+i39 i38
+c $9 $8 $5
+^z ^a ^m
+^t ^s ^i ^r ^h ^c
+^r ^e ^t
+^r ^e ^i ^v ^a ^j
+^r ^a ^g ^u ^s
+^l ^e ^a ^f ^a ^r
+^1 ^7
+$x $5
+$s $e $v $e $n
+$p $a $t
+$n $e $s $s
+$f $i $r $e
+$c $d
+o7i
+o5d i6r
+o4g o5h
+o3z D5
+o3j K *32
+o2x +5
+o2g o3n
+o2b i3o
+o2a o3k
+o1p D3
+o0k o6k
+o0k o2f
+o0j $7
+o0h $9
+o0d i2g
+o0d i1w
+o0a D4
+l $j $a $y
+l $f $r
+i5c i6a i7t
+i02 i10 i20
+d '9 $2
+c ^6 ^1
+^y ^o ^r ^t
+^w ^o ^b ^n ^i ^a ^r
+^t ^n ^e ^l ^i ^s
+^s ^a ^x ^e ^t
+^p ^m ^i ^p
+^o ^r ^t ^s ^a
+^1 o19
+^0 ^0 $0 $0
+$w $u
+o5i i6r
+o5e o6v
+o4u *21
+o4r o5y
+o4a o5u
+o30 ,4
+o2y *02
+o2s *57 +0
+o2P l
+o1t +3
+o1q D2 D3
+o1k D3
+o0k $2 $5
+k ^8
+i52 i60 o71 ,8
+i5. o61
+i24
+c $2 $0 $0 $6
+c $1 $.
+$u $k $i
+$u $1 $2 $3
+o6a $r
+o4a $2
+o3a o4p
+o2o i2j
+o2n o0s
+o2n c *78
+o2g *31
+o1u $1 $5
+o0s $2 $0
+o0k $2 $7
+o0k $1 $6
+o0j ,1
+o0i o1s
+o0c o3c
+o0b o2a
+o0W $1
+l $a $m $o $r
+l $0 $4
+i58 i57
+i57 i74
+i15
+i0e
+f E 'B
+c T6 $1
+c $9 $8 $4
+^z $z
+^y ^a ^l
+^t z1
+^h ^m
+^e ^d ^a ^j
+^_ T1
+[ Z4
+T0 T2 T5
+$z $i $l $l $a
+$z $1 $3
+$y $1 $2 $3 $4
+$p $b
+$d $f
+$9 $8 $5
+$4 $1 $1
+o76
+o6v ]
+o68 K .5
+o5l $o
+o4d ,5
+o3e o4c
+o3n *35
+o2s o3o
+o2r o3c
+o2l r
+o2j o3i
+o2c ,3
+o2C E
+o1u o2p
+o1s D2
+o1i o2b
+o1a o2r
+o0s i1c
+o0m i3i
+o0l D5
+o0k o5o
+o0k i1a
+o0j Z1
+o0a o1i
+l $e $s
+i69 o76
+i68 o79
+^w ^o ^h
+^r ^e ^e ^b
+^o o2u
+^o ^z ^n ^e
+^n ^a ^h ^t ^a ^n
+^e ^c ^a
+$r $h
+$m i7g
+$g $r
+$a $j
+$6 $9 $6
+o6a o7z
+o5u o6p
+o4K l
+o44 *56
+o3w +1
+o3i i3r
+o2y +0
+o2s o4a
+o2s -4
+o2h *53
+o2c *03
+o23 o17
+o0u ^m
+o0k $4
+o0h o3a
+o0g o2f
+o0g $2 $4
+o0S $1 $2 $3
+o0M $6
+o0M $0 $9
+c $6 $9
+^y ^a ^h ^s
+^w ^o ^l ^s
+^t ^o ^o ^f
+^s ^l ^e
+^e ^i ^t ^a ^k
+^8 o17
+$y *16 *13
+$y $m
+$s $n $a $k $e
+$a $p
+$R $1 c
+$/
+p2 T0 '9
+o6a o7g
+o5n $1 $2 $3
+o4o o5w
+o42 *56
+o3v +0
+o3u o4p
+o3s +4
+o1l D3
+o0l $5 $6
+o0j i1s
+o0e i1c
+o0d o5s
+o0d D4
+o0c o2a
+o0c i1s
+o0H l
+l $0 $2
+i57 i56
+^o ^l ^k
+^n ^e ^k ^c ^i ^h ^c
+^f ^f ^e ^j
+$r $1 $2 $3
+$p $e $r $e $z
+$9 $9 $0
+y4 y4
+u $7 $7 $7
+o7t o8a
+o5o o6g
+o5c i6h o7o
+o55 ss5 $5
+o42 i55 o66
+o3x +4
+o3w +2
+o1s o2d
+o1i o2f
+o1E E
+o0l D3
+o0k i1s
+o0g y2
+o0g o3e
+o0f i1g
+o0d o3e
+o0c i2l
+o0c $1 $0
+o0a $0 $5
+i72 i80 ,9 oA8
+i55 i53
+i52 i51
+i0h
+c $4 $0
+c $1 $9 $8 $9
+^y ^n ^n ^o ^j
+^y ^h ^s
+^y ^d ^u ^j
+^o ^t ^n ^a
+^o ^c ^a ^t
+] o14
+[ ^S o2a
+$m $h
+$5 $1 $2
+$1 $0 $0 $%
+t Z1 ^3
+o7d o8a
+o51 o62
+o4p ]
+o4c ,5
+o43 *54
+o41 i59 i66 o78
+o3u $1 $2
+o3a $1 $2 $3 $4
+o3G l
+o2s i3c
+o1u $1 $0
+o1m -3
+o1i o2e
+o1e $7
+o0x r
+o0c $1 $1
+l $j $o $n $e $s
+i58 i53
+i56 i66
+i4t i5h i6e
+^t ^o ^n ^k ^p ^i ^l ^s
+^t ^e ^w
+^s ^e ^l ^i ^m
+^r ^a ^e ^f
+^p ^a ^r
+^o ^c ^o ^h ^c
+Z2 $0
+$r $2
+$r $1 $3
+$p { sdo
+$m $t
+$f $r $e $a $k
+y2 .4
+sa@ $1
+o8j
+o7x ]
+o7o 'A
+o6z [
+o5l +6
+o48 i51 o68
+o45 i54 o63
+o41 i53 o62
+o2m o3c
+o2h o3u
+o0s $1 $4
+o0l $3
+o0j $2 $4
+o05 z1
+k *20 o0f
+i59 i58
+i58 i56
+i58 i55
+i28
+c o77
+c $3 $!
+^t ^u ^n ^a ^e ^p
+^t ^n ^a ^s
+^s ^i ^e ^v ^o ^l
+^n ^i ^m
+^l o1i
+^g ^e ^r ^g
+$p $o $r $t
+o7u +6
+o6y $1
+o5k o6u
+o3s *41
+o3i o5a
+o3d +5
+o2x *01
+o26 .0
+o1z D3
+o1u o2t
+o1q
+o1g r
+o1a D3
+o0l ]
+o0k $1 $1
+o0j $9
+o0i o1r
+o0i i1b
+o0b i2l
+o0b $3 $3
+o0!
+l $s $m $i $t $h
+l $a $r $t
+i69 i71 i81
+i68 o75
+i56 i74
+i54 i64
+i4i i5n
+i49 i59
+^u ^e ^v ^o ^l ^i
+^n ^i ^m ^d ^a
+^d ^i ^k
+] o8l
+[ o1e
+$y Z1
+$m $a $r
+$f $a $c $e
+} } d
+s7w i7u
+o8i i9n oAg
+o4y o5o
+o4r
+o45 i56 sS7 $8
+o2t *34
+o2o o3s
+o2o o3r
+o2i o4e
+o1r o2a
+o1e o2i
+o0l o2o
+o0k o5l
+o0j o2t
+o0j o1s
+o0j D5
+o0g i1e
+o0b o3a
+o0b i2g
+o0b $2 $1
+l $c $o
+^s ^a ^w
+^p ^u
+^o ^r ^e ^h
+^l ^e ^o ^j
+Y2 ,3 [
+$u $r $i
+$5 $1 $0
+} o0k
+u sS5
+t +5
+r ,1
+r $o $l
+oA3 c
+o51 i62 o71
+o4m ,5
+o39 i48 o57
+o2n o3o
+o2c
+o1u o4i
+o1o ,2
+o1k o2a
+o0h *12
+o0g i1w
+o0c o2i
+o0c o1y
+o0c $3
+o0a o1t
+o0S $1 $0
+o0C $1 $2 $3
+i81 i90 iA1
+i6a i7s i8d
+i59 i55
+i58 i68
+i57 i75
+i4i i5n i6g
+i39 i37
+c $1 $9 $8 $8
+^y ^l ^o ^p
+^t ^c ^o
+^s i4s
+^s ^u ^t ^o ^l
+^p ^o ^o ^p
+^o ^v
+^n ^a ^v ^e
+^m ^a ^I
+^l ^c
+T6 T5
+$u $m $a
+$n $y
+$l $t
+$7 $!
+$1 $3 $1 $3
+$1 $0 $1
+o6K c
+o42 i55 i68 o70
+o3o o7o
+o3f +5
+o3e o4b
+o3S l
+o2s $1
+o2r *02
+o1r o2o
+o1o o2p
+o0e o1w
+o0d o2w
+o0d i1s
+o0K o71
+i59 i57
+i57 i73
+i54 i75
+i42 [
+c $9 $9 $9
+c $1 $9 $8 $6
+^w ^o ^h ^s
+^u ^r ^u ^g
+^s ^i ^b
+$t $e $a
+$8 Z2
+$3 $1 $1
+$1 $2 $1 $2
+$* $1
+y2 o4h
+o6a o7i
+o5e o6b
+o5e $l
+o4y +3
+o3s o4o
+o3i $2
+o2h
+o1c r
+o1a o2s
+o0s $0
+o0k o2y
+o0k o2w
+o0d i1m
+o0b o3e
+o0a D3
+o0a D2
+i60 i70 i89
+i18 i19
+^t ^i ^f
+^s ^j ^d
+^s ^e ^n ^i
+^o ^m ^l ^e
+^o ^k ^i ^k
+^k z1
+R4 -5 o3o
+$s $u $p $e $r
+$m $i $x
+$j $e $s $u $s
+$2 $1 $6
+$1 $9 $6 $1
+} Z2
+z4
+o5l ,6
+o5D E
+o3s o5a
+o3r
+o3i $7 $7 $7
+o2x o0j
+o2p ]
+o2k D5
+o2g +3
+o2d o3j
+o2B *02
+o1a i3s
+o0k o1y
+o0k o1r
+o0j $2 $0
+o0d $1 $3
+o0c o3i
+i59 i70
+i41 E
+d $1
+^t ^e ^e ^r ^t ^s
+^s ^s ^a ^l ^g
+^s ^o ^n
+^r ^e ^v ^i ^r
+^n ^a ^i ^l ^u ^j
+^b ^o ^r
+^b ^e ^w
+Y2 ,8
+$h $e $a $d
+$@ $#
+$9 $9 $2
+$4 $1 $0
+$! $1
+u i74 o8U
+ss1 $2 $3 $4 $5 $6 $7
+o8u
+o7c
+o6a +7
+o5l o6u
+o4s ,5
+o4i o5x
+o4e o6o
+o3u o5a
+o3c o4i
+o3a $1
+o2r D5
+o2i o3f
+o2L l *41
+o1e D3
+o0k $8 $0
+o0j o3k
+o0f ]
+o0d $1
+o0b $1 $1
+i65 i76 i87
+i57 i53
+i32 [
+^z ^b ^d
+^y ^r ^r ^e ^t
+^y ^l ^l ^a ^s
+^y ^e ^k ^o ^m ^s
+^r ^e ^m ^o ^h
+^o ^i ^r
+^n ^a ^f
+^2 ^4 o20
+Y2 -A
+K i62
+.2 $2 $2
+$x $i
+$v $e $r $a
+$_ Y1
+$4 $0 $0
+$' $s
+y2 o44 k
+y1 .5
+o8A l
+o75 i90
+o5u T0
+o3w k
+o3m ]
+o3l o4u
+o3P T3 -6
+o2r i3s
+o2d o4r
+o2U c
+o1a i4a
+o0m o3u
+o0l o4e
+o0k $9
+o0j o1o i2h
+o0i o1g
+o0d i2e
+o0a $2 $3
+i56 i78
+i35 i32
+^z ^e ^p ^o ^l
+^y ^z ^z ^u ^f
+^y ^n ^n ^u ^f
+^y ^m ^e ^v ^o ^l
+^t ^u ^o
+^r ^u ^h ^t ^r ^a
+^o ^l ^u ^a ^p
+^n ^i ^l
+^h ^g ^i ^h
+[ o4.
+Y2 $7
+K i37
+D3 $.
+$u $c
+$l $a $d $y
+$k $c
+o4p K *35
+o4o i5t
+o4k $1 $2
+o3i $2 $1
+o3g o4i
+o3g $1
+o2u D4
+o2f *42
+o1p -2
+o1o $7 $7 $7
+o0l o1y
+o0k $s
+o0k $2 $6
+o0i i1c
+o0h ^g *24
+o0e i1n
+o0c $0 $5
+l i6j
+l $a $h
+i4i i5s
+i36 i36
+i31 i40
+i01 i12 i23
+c $1 $9 $8 $1
+^t ^t ^e ^r ^b
+^e ^i ^d ^d ^e
+[ o4z
+T0 T6 T5 T7
+$u Y2
+$p $o $t
+$f $b
+$9 $5 $4
+$9 $5 $0
+$3 $!
+$1 $9 $5 $6
+y2 *12
+o5i $e
+o5e +6
+o55 i65 ,7
+o4u o5c
+o4u ]
+o4o o5v
+o4o $2 $1
+o42 i50 i60 ,7
+o42 E D3
+o41 i59 i69 o76
+o3e o5a
+o2x o3i
+o2s r
+o1u o2x
+o1m *21
+o0n r
+o0m $2 $3
+o0k o1a ]
+o0j o2w
+o0j i1r
+o0j i1e
+o0g i2m
+o0d o2j
+o0b -4
+o0b *43
+o0b $0 $5
+l $h $i $l $l
+i47 i56
+^y ^e ^k ^n ^o ^d
+^t ^n ^a ^r ^g
+Z2 $4
+Y2 o0v
+Y2 $e
+.2 $9 $9
+.2 $1 $3
+$m $i $a
+$l $i $g $h $t
+$2 $. $0
+$1 $9 $5 $7
+} o1h
+y2 i5a
+u $0 $0 $1
+o8f
+o89 Z1
+o5y T0
+o4s +7 ]
+o48 $8
+o41 i52 ss3 $4
+o40 i51 i60 o72
+o2z o3o
+o28 ^1
+o1u o4a
+o1r [
+o1m D6
+o1l -2
+o1k i0m
+o1a $2 $0 $0 $5
+o0m i3l
+o0m i2i
+o0k o4e
+o0k $4 $4
+o0h D6
+l ] $i $n $g
+i87 i98 iA9
+i54 i79
+i30 .2
+c $6 $3
+^y ^t ^r ^a ^m
+^y ^l ^s
+^y ^a ^d ^b
+^o ^g ^i ^r ^d ^o ^r
+^g i1t
+^8 o16
+K *25 *30
+$9 $8 $3
+$9 $4 $5
+{ { { { { {
+o4z ]
+o4y +0 l
+o4y $1
+o4a ,5
+o43 i65
+o3i $3 $2 $1
+o3a K
+o2r -4
+o2i i3k
+o2h D4
+o1u o2z
+o1r r
+o1k r
+o1g D4
+o15 *13
+o0k $2
+o0k $1 $8
+k ^9
+i89 i99 iA9
+i54 i52
+i34 i32
+c $4 $e $v $e $r
+c $1 $9 $8 $2
+^y ^z ^z ^o
+^x -1
+^w ^o ^e ^m
+^s ^i ^d ^o ^g
+^l ^m
+^e ^c ^a ^p ^s
+u $3 $4 $5
+o6o $d
+o5n $e
+o4s o5y
+o41 i59 i69 o78
+o3f +0
+o3e i2r
+o3b i5r
+o2p -5
+o2k $1
+o1u i2b
+o1t r
+o0s $1 $5
+o0k $1 $3
+o0k $1 $2
+o0g o1y
+o0g o1p
+o0e o1a
+o0c $2 $2
+i59 i65
+i56 i55
+i54 i77
+^y ^e ^v ^r ^a ^h
+^x ^i ^n ^e ^o ^h ^p
+^u ^o ^y ^e ^v ^o ^l
+^o ^m ^s ^o ^c
+^o ^i ^d
+^o ^d ^n ^a ^n ^r ^e ^f
+^m ^i ^k
+^l ^e ^d
+^V
+$s ^h
+$m $n
+$1 $9 $5 $9
+$1 $3 $5
+o63
+o5s ]
+o5j o6e
+o5f o6e
+o51 i64 o73
+o3e K
+o3e *40
+o2z o3y
+o2s o3c
+o2o o3k
+o2i $0 $1
+o2g D6
+o2B c
+o0m $9 $9
+o0j $2
+o0f $2
+o0M $2
+o0C $2
+l i5c
+l $i $a $n
+l $1 $2 $3 $4 $5 $6 $7 $8 $9 $0
+i6d i7e
+i54 ss5 $6
+c $3 $1
+^o ^o ^g
+^e ^v ^e ^t ^s
+E ] Y1
+D8 c $6
+.2 $2 $1
+$9 $1 $0
+$1 $2 $5
+o7y
+o7n o8e
+o7i $e
+o6a i7t o8a
+o4s '8
+o4o i5m o6a
+o2o D3
+o2l o4a
+o2e o3w
+o2a $1
+o1u o2c
+o1a i2d
+o0w k
+o0m o4i
+o0m T0 ]
+o0k K *35
+o0c D3
+o0b $1 $0
+o0a o5a
+o0@
+l $g $a $y
+i69 o75
+i58 i67
+i41 i52
+c o79
+c $5 $8
+c $1 $9 $9 $0
+^y ^l ^l ^i ^s
+^y ^k ^c ^i ^v
+^w ^h
+^o ^y T2
+^o ^m ^z ^i ^g
+^l ]
+^e ^f ^i ^l
+^Z D3
+$v $m
+$n $e
+o5e $s
+o5a o6u
+o50 i65 i70 o86
+o4z o5u
+o4i i5t o6o
+o4a o6o
+o3s ,4
+o3i $0 $7
+o2v o3o
+o2e o3g
+o2e o3b
+o1o D3
+o1l *12
+o1a i1i
+o1.
+o0k o3z
+o0k $2 $0
+o0j o2r
+o0g d
+o0f *20
+o0b o4u
+o0b o2e
+l i6.
+i58 i79
+i48 i58
+i27
+c o74
+^s ^i ^h ^t
+^s ^a ^l ^o ^c ^i ^n
+^r ^c ^m
+^n ^a ^g ^r ^o ^m
+^l ^i ^v ^e ^d
+[ o0e $1
+Z1 o0N
+T0 T5 T1
+T0 $D
+$m $e $n
+$l Z1
+o79 ,8
+o6i $i
+o5i $1 $2 $3
+o4z ,5
+o49 i51 ,6
+o3o $0 $1
+o3e o4x
+o3L c
+o2c *31
+o1t o2f
+o1o o2t
+o1b r
+o1a i4e
+o0p *20
+o0l *31
+o0h $4
+o0g $1 $6
+o0d $1 $2
+o0d $1 $1
+o0a o1p
+o0G D1
+o0C $1 $2
+l $f $a
+i59 i76
+i55 i77
+c $9 $8 $9
+^v ^e ^r
+^r ^e ^m ^a ^g
+^o o2k
+^n ^a ^h
+^m ^u ^l ^l ^a ^c
+^l ^r ^a ^c
+] o7w
+Y3 *64 *57
+$w $r
+$r $e $x
+$m $a $n $i $a
+$k $8
+$9 $1 $6
+$3 $1 $0
+$$ Z1
+r ^t
+o7t o8e
+o5z o6a
+o5p o6e
+o5i $o
+o5a o6f
+o51 i62 ,7
+o51 R6
+o4l *51
+o44 $5 $6
+o41 i59 i69 o77
+o3z o4o
+o3a o4j
+o2n $2
+o2j o3o
+o2i o3r
+o1d o2e
+o16 *31
+o0k o5m
+o0k o1w
+o0j $1 $8
+o0c $0 $2
+o0a $1 $0
+l o7i o8n
+l $h $p
+i76 o67
+i68 i78 i88
+i57 ss8 $9
+i0l ^j
+c o75
+^y ^d ^o ^b
+^w ^o ^l ^f
+^u o2u
+^u ^g o2y
+^r ^o ^t ^c ^o ^d
+^p ^r
+^p ^i ^h ^c
+^8 o15
+Y2 oB4
+.2 $1 $2 $3
+$x
+$v $8
+$t $i $a
+$r $u $n
+$p $l $a $y
+$3 $2 $3
+$1 $2 $8
+} o1w
+y4 -0
+o5s o6k o7y
+o5a o6n $a
+o4h $1
+o4c *51
+o3s $1 $2
+o3p o4h
+o2y o3a
+o2i o3g
+o1o o2w
+o1l r
+o1i y2
+o1e ,2
+o1a i2t
+o1a i2k
+o0l o3e
+o0k $5
+o0j $2 $6
+i52 i60 i70 o89
+i46 i54
+c $3 $5
+^z ^a ^d
+^y ^v ^a ^n
+^y ^p ^p ^o ^p
+^y ^o ^s ^o ^y
+^n ^o ^d ^n ^o ^l
+^n ^a ^c
+^b ^u ^l ^c
+^0 ^7
+[ p2
+o7a o8l
+o54 i60 o74
+o4i r
+o3u o4g
+o3k ,4
+o3g ]
+o3d o5l
+o1d o2a
+o1a $8
+o0o o1l
+o0l $0 $1
+o0k o4m
+o0k i1h
+o0j o1w
+o0d D5
+o0c i1k
+o0B $1 $2
+i49
+c $3 $7
+^w ^e ^d
+^t ^a ^h ^p
+^r ^e ^d ^n ^e ^f
+^c ^f
+^8 o13
+[ [ [ [ c
+$u $c $a
+$p $t
+$o k
+$i $a
+y2 o4i
+sfw
+oA1 iB2 oC3
+o5i o6x
+o50 $0
+o4z $1
+o4x *46
+o4p ,5
+o4p *40
+o4o o51
+o4o ,5
+o4n o5u
+o46 sS9 $6 $9
+o43 i53 o64
+o42 $8
+o3k o4y
+o2m ]
+o2f ]
+o23 i32
+o1z D2 D3
+o0x ^e
+o0l o3i
+o0k i3i
+o0j $2 $5
+o0i o1f
+o0e i1t
+o0d $1 $4
+o0c o4d
+o0b o3u
+o0S $4
+o0M $0 $8
+o0K o1o
+i64 i75 i86
+c o10
+^y ^h ^t ^a ^k
+^t ^r ^o ^f
+^s ^n ^e ^j
+^s ^i ^e ^f ^i ^l
+^d z1
+^a ^h ^a ^h
+^1 ^4
+[ [ [ c
+[ T4 o0T
+$r $o $d
+$c $s
+$2 $5 $8
+$1 $9 $5 $8
+o5s
+o5c $o
+o4r ]
+o4l c
+o4a o5y
+o42 i52 o64
+o42 i50 i60 o72
+o42 $3
+o2n $5
+o2k -5
+o2d c
+o2b +6 +3
+o2a o3p
+o1m o2o
+o1j D4
+o1a i3i
+o0e i1k
+o0b y2
+o0a o1z
+o0a $0 $4
+i57 i76
+i55 i52
+^s *15
+^o i1p
+^o *60
+^7 o16
+[ o1m E
+D2 ^a r
+D1 $2 $0 $0 $9
+$s $o $l $o
+$r *21
+$o $m $a
+$m $w
+$4 $1 $2
+$1 $0 $1 $0
+r ^z
+o5y i61 i72 o83
+o4_
+o43 i66
+o42 i52 o68
+o41 $4
+o3w
+o3s *45
+o33 i44 o55
+o32 i44 o56
+o2t ]
+o2s D5
+o2m -3
+o2c +3
+o0z o1e
+o0p r
+o0j o1r
+o0g +7
+o0d o2i
+o0b o3o
+o0S $2
+o0C $8
+o0B $2 $3
+o0A $1 $2
+k D0 $a
+i90 oA1
+i8e *87
+i84 c
+i67 [
+i57 i78
+i0a $9
+c $9 $9 $0
+^y ^p ^s
+^s ^d ^i ^k
+^n ^e ^h ^c
+^m ^i ^t
+^k ^s
+^S D4
+$s $t $u $f $f
+$r L5
+$m $a $y
+$( $:
+o8e
+o7n o8g
+o6t
+o6n $t
+o5w o6i
+o4x Z1
+o4t o6b
+o4o o5c
+o41 i51 o62
+o40 $0 $1
+o4!
+o3w ]
+o2w +3
+o2u i0b
+o2j -1 -1
+o2g ^a
+o2e o3f
+o1r D3
+o1o o2k
+o1o i2m
+o1j o2s
+o0r r
+o0m $0 $1
+o0k o4l
+o0k o3e
+o0f o3u
+o0d o3i
+o0d $1 $0
+o0c o2o
+o0c ,1
+o0M p4 D5
+o0B $8
+i68 o77
+i61 i70 i80
+i55 i79
+c ^0 ^2
+c $1 $9 $8 $3
+^t ^n ^a ^i ^g
+^s ^w
+^s ^e ^n ^o ^j
+^2 ^8
+] K
+Y2 $5
+.1 ,4 ,5
+$x {
+$p $g
+$l $s
+$a Z2
+$8 $1 $2
+$7 $1 $3
+$4 ^4
+$2 $4 $2
+$1 $2 $3 $.
+o6v o7a
+o5z
+o5o $s
+o4y
+o4a r
+o2w ,7
+o2u $1 $0
+o2h o3n
+o2g D5
+o2d +3
+o2.
+o1x
+o1v o2e
+o1u o3i
+o1s o2u
+o1s D3
+o1i o2r
+o1e o2c
+o1d o2h
+o1d i0j
+o0k o5e
+o0g o2k
+o0f o5a
+o0f *31
+l $b $a $l $l
+i54 [
+^y ^r ^r ^a ^b
+^t ^r ^e ^w ^q
+^n ^e ^d ^i ^a
+^b ^c
+^2 o10
+$y $1 $5
+$7 $0 $7
+$4 Z3
+ss$ $1
+o6p
+o5g o6i
+o4b i5o ,6
+o44
+o42 i54 i66 o78
+o3o o4g
+o3a o4x
+o37 i47 ,5
+o2p o3u
+o2n ,3
+o1w o2e
+o1l +2
+o1_
+o0m i3h
+o0m -2
+o0d $3 $3
+o0c o3a
+o0b o2o
+o0b i2e
+o0a o2b
+o0M $1 $3
+l ^a ^r ^t ^l ^u
+i53 i51
+i4a *13 *04
+c $9 $8 $6
+c $6 $2
+^w ^a ^d
+^r ^e ^d ^n ^a ^x ^e ^l ^a
+^r .1
+^a ^n ^a ^i ^d
+[ ^S
+*20 p1
+$w $o $w
+$r $a $p
+$p -4
+$h $c
+$e $v $a
+$9 $7 $8
+$! D4
+t o1U
+o7o $1
+o6w o7a
+o5o o7e
+o5k $e
+o4l ]
+o4e $1 $2 $3
+o3u K
+o3o o4b
+o3a o4v
+o34 o15
+o2v D5
+o2t o3y
+o2l *42
+o1e $2 $1
+o0w o1a
+o0k o1o $1
+o0k i4n
+o0k $2 $8
+o0i i1h
+o0g $2 $0
+o0c i2m
+o0b ,1
+o0b $2 $2
+o0D u
+i58 i77
+i4_ '8
+i13
+c ^y ^M
+c $*
+^t ^i ^n
+^s ^a ^n
+^r ^o ^j ^a ^m
+^n ^e ^b T3
+^l ^i ^r ^p ^a
+^i ^m ^i ^m
+^d ^i ^c ^a
+^a ^c ^u ^l
+^9 ^8 ^7
+^2 ^6
+Z2 oA2 E
+K $c
+$r $u $m
+$-
+{ { [
+o6u o7l
+o4k $3
+o4a o5i
+o47 i50 o67
+o42 i51 o65
+o42 i50 i60 o73
+o3x o4i
+o3o o4x
+o2r $1
+o1s D2 D3
+o1n D3
+o1h D4
+o1a i2s
+o0v r
+o0v o1i
+o0r i0p
+o0k o3a
+o0k $3 $0
+o0j $2 $8
+o0g i2o
+o0f o3a
+o0f i1d
+o0G D2
+l ^l ^a ^m
+i61 i72 i85
+i6# o71
+i58 i72
+i52 i60 i71 ,8
+i44 i58
+i37 i31
+^z ^u ^r ^c
+^r ^e ^p ^p ^o ^c
+^n ^e ^v ^e ^t ^s
+^n ^e ^m ^r ^a ^c
+^l ^e ^u ^m ^a ^s
+^f ^d ^s ^a
+^S o1l
+^1 ^0 ^1
+[ o0o
+$p $a $r $t $y
+$6 $2 $6
+$4 $1 $5
+t D8 ]
+slr
+o61
+o4c +5
+o47 i57 ,6
+o3u o4f
+o3k l *34
+o3k $1 $2
+o3i o4f
+o3i o4b
+o31 i40 ,5
+o2d o3f
+o1u $7
+o1r ^h
+o1m D4
+o0m i3c
+o0k o4a
+o0e D3
+o0c $2 $3
+o0b i3n
+o0a $0 $3
+l i6t
+i58 i50
+i53 i76
+i46 i58
+i3&
+d '7 $1
+c o70
+^y ^s ^s ^u ^p
+^t ^h ^g ^i ^n ^k
+^n ^i ^a ^t ^p ^a ^c
+^h ^p ^e ^s ^o ^j
+^a ^p ^a ^p
+[ o51
+Y2 o5z
+Y2 o2h
+K o0h
+$t $i $t $o
+$s $i $s
+$p $u $p
+$e $u
+$9 $1 $2
+$2 $0 $2 $0
+$" ^"
+s/P ^y }
+r $z
+o47 i50 ,6
+o40 i59 i68 o77
+o3y $1
+o3v
+o3P c
+o2n +3
+o1u o3a
+o1i i3e
+o1a o2u
+o0s $2 $1
+o0f $5
+o0e i1p
+o0.
+l $b $a $b $e
+i58 i75
+i57 i52
+i54 i59
+i39 i31
+c ^3 ^1
+^y ^f ^f ^u ^b
+^y ^d ^n ^a ^r ^b
+^w ^w
+^t ^s ^e ^r ^o ^f
+^t ^n ^e ^g ^a
+^r ^e ^f ^i ^n ^n ^e ^j
+^l ^a ^c
+^d ^l ^o ^c
+^3 ^2 ^1 $4 $5 $6
+[ $8 $5
+[ $2 $0 $1 $0
+T1 T3 T2
+D3 D3
+$f $l $y
+$b $l $a $c $k
+} Y2
+y2 ^b
+u $e
+o6s l
+o4y o5e
+o4k ,5
+o3w o4o
+o3i o4r
+o2z $1
+o2t ^c
+o2i o3p
+o1y -0
+o1i o2a
+o0v *20
+o0l i3a
+o0l i1k
+o0j i2b
+o0i i1k
+o0h i1j
+o0f o3i
+o0e o1h
+o0D $1 $2
+l $l $i $f $e
+k {
+k o34
+k *54
+i65 K c
+i55 i73
+c $1 $9
+c $1 $7
+^x ^e ^t
+^p ^m ^o ^c
+^o ^l ^e ^m
+^n ^m
+^i ^k ^i ^k
+^7 ^9 ^9 ^1
+^6 o14
+.2 $7 $7
+$x u
+$u $z
+$k $9
+$2 Z2
+t o2N
+t '4
+o6u
+o5s o6k o7i
+o5p o6i
+o5o o6v
+o4n o6t
+o4g ,5
+o42 i61 i50
+o3y D5
+o31 i44 o57
+o2y $1
+o2o o3t
+o2j o3e
+o2c o3u
+o2b ]
+o1k o2o
+o1h o2a
+o1A k
+o0k i1b
+o0k ] r
+o0j i1h D3
+o0f i3k
+o0b o1h
+o0F D4
+o0C $0 $9
+i57 i51
+i32 i38
+^y ^o ^b ^w ^o ^c
+^x ^a ^j
+^r ^e ^c
+^o ^l ^e ^c ^r ^a ^m
+^n ^e ^l ^e ^h
+^i ^b ^a ^g
+[ o4z K
+[ o0w
+$s $w $e $e $t
+$n $m
+$n $i
+$c $j
+$c $h $e $n
+$b $d
+$9 $8 $2
+y5 c
+o8G l
+o7q
+o7m
+o7d
+o6h
+o59 Z2
+o4p o5c
+o4e i6e
+o32 $2
+o2l D5
+o2i $0 $3
+o1e o2t
+o1d -2
+o1d
+o0n o1i
+o0m $0 $0
+o0l o5e
+o0k o1t
+o0e r
+i67 o74
+i57 i72
+i27 ,3
+c $5 $2
+c $4 $3
+^s ^u ^e ^h ^t ^a ^m
+^n ^a ^r ^g
+^m ^o ^d
+^l ^e ^x ^a
+^e ^d ^u ^d
+^a ^r ^a ^s
+^S D3
+^3 ^2 ^1 ]
+^3 ^1 ]
+$s $i $m $o
+$p $a $n
+$o $r $a
+$j $i $m
+} ^6
+t o0V
+o7l i8e
+o4i o5b
+o4C E
+o3o $1
+o32 $3
+o31 i40 o51
+o2o o3p
+o1u o3t
+o1e D7
+o1a $1
+o0s i1m
+o0s $1 $1
+o0g o3i
+o0g i2b
+o0e D4
+o0c o2u
+o0K K
+i69 o71
+i48 i59
+i34 i44
+^y ^n ^n ^e ^p
+^t ^u ^n
+^s ^u ^r
+^r z1
+^o ^b ^o ^l
+^g ^n ^a ^w
+^e ^v ^i ^l
+^e ^n ^n ^a
+^e ^l ^b ^u ^o ^d
+^a ^i ^m
+Z4 Z2
+T0 T6 T4 T5
+$j $a $n
+$i $m
+$7 $5 $3
+$2 $2 $5
+} q '8
+t o2K
+t +6
+o8i $e
+o6t ,7
+o5n $t
+o50 i64 i70 o85
+o45 i78
+o42 $2
+o41 i54 o63
+o3k $0
+o3d o5a
+o2j D4
+o2i o3b
+o2h r
+o2h *12
+o2e o3v
+o1q D3
+o1o o2f
+o1e i2b
+o18 *31
+o0m $1 $2
+o0d $2 $3
+o0b i2a
+o0b $0 $1
+i78 i79
+i61
+i58 i51
+i33 i43
+c $9 $8 $3
+^z ^i ^b
+^u ^r ^a ^h
+^u ^k ^o ^g
+^l sx$ +6
+^a ^s ^i
+^L T1
+^6 ^5 ^4
+Z1 ,4 {
+Y2 +9 *58
+T4 T5
+$t $i $c $k
+$k $i
+$9 $5 $5
+$6 $0 $0
+o6o o7k
+o5o +6
+o4y o5n
+o4k +6
+o4k $2
+o4d $k
+o4a ]
+o49 i51 o66
+o42 i50 i60 o75
+o42 i50 i60 o74
+o2r o3f
+o1t D4
+o1k +4
+o1c D4
+o0m i3n
+o0m $2 $2
+o0k o4n
+o0h o4i
+o0g o3a
+o0g i2n
+o0g i2e
+o0f $1 $0
+o0a $2
+k *12 i03
+i64 o56
+i59 i72
+i56 i79
+i56 i75
+i42 i53
+i34 i31
+i12 i23 i34
+i0f i1e
+c o71
+c ^8 ^2
+^z ^a ^b
+^v ^a ^g
+^s ^u ^e ^d
+^r ^e ^w ^q
+^n ^a ^v
+^e ^i ^l ^u ^j
+K ] $8
+$z $o $o
+$1 $2 $1
+$- $-
+o6y i6a
+o5o $l
+o52
+o4y +2
+o4i $k
+o48 i50 ,6
+o47 i58 o67
+o42 i52 o60
+o3o D5
+o2w o3i
+o2r o3s
+o2h o3i
+o2e o4a
+o1l o2u
+o1e i4l
+o0m $5 $5
+o0k i4k
+o0k D2
+o0j $1 $6
+o0i o1a
+o0g o2a
+o0g $2
+o0c $0 $4
+l $b $i
+k *21
+i68 o71
+i59 i77
+i59 D9 [
+i53 i63
+i39 i48
+i37 o46
+i26 i39 .8
+i25
+c $9 $8 $1
+c $5 $3
+c $3 $2 $1
+^y ^a ^n
+^t ^o ^b ^o ^r
+^o ^b ^o ^h
+^n ^o ^r ^e ^m ^a ^c
+^n ^i ^l ^o ^c
+^n ^e ^d
+^g ^o ^d ^y ^m
+^e ^s ^e ^e ^h ^c
+^e ^m ^i ^a ^j
+^d ^r ^a ^h
+^T T1
+^8 ^5
+[ $8 $6
+E ^3
+D5 D5 D5
+.2 $i
+$n $b
+$9 $9 $7
+$9 $7 $4
+$8 $0 $0
+$3 ^1
+u i3A
+u $1 $2 $3 $4
+sTk y2 *57
+r i1u
+o4y *32
+o4i o5v
+o3y o4u
+o3n ]
+o3!
+o2r o3p
+o2p -3
+o2o c
+o2h o3e
+o1p r
+o1o i2b
+o1k o2s
+o1b o2i
+o0m i4e
+o0l i2a
+o0k i2t
+o0j $5
+o0j $3
+o0f o2o
+o0d o4i
+o0b $0 $2
+o0S $0 $8
+l $t $o $w $n
+i76 o89
+i59 i74
+i59 i52
+i58 [
+i45 i57
+c $1 $9 $9 $2
+^y ^t ^r ^e ^z ^a
+^y ^s ^s ^i ^m
+^t ^n ^i ^m
+^r ^o ^h ^t
+^p ^a ^k
+^o ^l ^e
+^o ^c ^a ^j
+^l ^e ^u ^n ^a ^m
+^e ^i ^r ^a ^m
+Z3 c +7
+Y3 +8
+K i31
+*40 *15
+$3 $2 $4
+$2 $1 $0
+$1 $2 $4
+} ^l
+o6< $3
+o4d iA0
+o46 R5
+o45 i55 ,6
+o44 i51 ,6
+o44 i50 ,6
+o3z o4u
+o3o o4d
+o3g $1 $0
+o2i o3c
+o1s o2h
+o1l D4
+o0w o1e
+o0m o3e
+o0k o4i
+o0k D5
+o0k $3
+o0j $2 $9
+o0h o1y
+o0g i2u
+o0g i1s
+o0g i1j
+o0d i1p
+o0b *23
+i69 o74
+i5f
+c ^7 ^0
+^z ^y ^x
+^y ^o ^b ^d ^a ^b
+^v ^a ^j
+^t ^i ^d ^n ^a ^b
+^t ^e ^r
+^t ^e ^k ^c ^o ^r
+^r ^a ^t
+^r ^a ^g ^d ^e
+^o ^s ^i
+^c o1h o2i
+^7 o15
+^3 ^6
+E i70 -6
+$t $h $r $e $e
+$o Y2
+$l $u $n $a
+$e $v
+$c $r $e $w
+$_ $1
+$9 $9 $6
+$9 $7 $9
+$4 $3 $2 $1
+$4 $2 $5
+$1 $3 $8
+{ d
+u $1 $0 $0
+sa@ so0 si1
+o9k
+o4x +2
+o4O E ]
+o42 i51 o64
+o3d $1
+o2n o3z
+o2a o5a
+o1u o3e
+o1j o2u
+o1i o3i
+o1e o2s
+o1e o2h
+o1a o2f
+o0m i3a
+o0k i3e
+o0j o5m
+o0d -3
+o0c D2
+o0c $c
+l o6b o7a $b $y
+i79 i81 i91
+i68 o72
+i64 o72
+i5_ D9
+i59 i75
+i38 i31
+i27 i29
+c $2 $0 $0 $5
+c $1 $9 $8 $0
+c $0 $8
+^s i2a
+^p ^o ^h ^p ^i ^h
+^i ^l ^u ^j
+^f ^o ^g ^n ^i ^k
+^c o1z
+^a ^t ^r ^a ^m
+^a ^l ^e ^g ^n ^a
+K i47
+K $j
+$y $t
+$p $i $z $z $a
+$b $m
+$2 $5 $6
+o6o +7
+o6e $s
+o65 i75 ,8
+o5o Y1
+o57 Y2
+o4u +5
+o4k *35
+o4a o51
+o1e r
+o1d -3 -3
+o12 *04 *90
+o0t $0 $9
+o0k o1i D3
+o0k $2 $9
+o0j $0 $6
+o0e o1k
+o0d $7 $7
+o0d $0 $5
+o00 T2
+k *42
+i73 o61
+i61 i70 i82
+i55 ^8
+i54 ss2 $0
+c $9 $8 $2
+c $0 $3
+^y ^d ^o ^o ^w
+^w ^o ^n
+^t ^e ^s
+^s ^u ^a
+^l ^a ^v
+^e ^k ^u ^d
+^1 i22 i43 o64
+Y2 o3z
+K r *46
+K T1 k
+E i5.
+$m t
+$l $y
+$k $1
+$9 $7 $5
+$9 $5 $3
+$3 $d
+$. $1 $2 $3
+t sEA
+o6a -7
+o5e
+o5C l
+o55 i65 o76
+o54
+o41 $5
+o3i $1 $2 $3 $4
+o3c o4u
+o2x o3o
+o1o i4s
+o1g o2h
+o1g o2a
+o1e D4
+o1d o2k
+o0r o1e
+o0m y2
+o0l $1 $2
+o0k $1 $0
+o0h i2u
+o0d +1
+o0c o2e
+o0c $4
+o0S $8
+o0F $0 $1
+o0B $1 $3
+l $k $i $m
+k c +1
+i78 o89
+i44 i57
+^y ^b ^r ^i ^k
+^s ^e ^b
+^r ^e ^c ^a
+^o ^M
+^m ^r
+^e ^k ^i ^l
+^6 o13
+^2 ^1 ^0 ^2
+^1 o16
+K Y2
+D3 y4
+$x $z
+$k $i $l $l
+o9d
+o7i $t
+o6e $e
+o5o o6t
+o4y $1 $0
+o49 i59 ,6
+o41 R5
+o3o o5i
+o3l ]
+o2y o3u
+o2c $2
+o1k K
+o16 K
+o0m o1w
+o0j o2e
+o0h ]
+o0f o3o
+o0f i3e
+o0c $2 $1
+o0b +6
+o0D $1 $2 $3
+o07 o27
+l $d $o
+l $c $k
+k o33
+i67 o75
+i60 i71 i80
+i58 i52
+i55 i51
+i53 i66 o79
+i47 i58
+i47 i57
+i21 o30
+c o81
+c $1 ^1
+^z ^a ^h ^c
+^y ^e ^r ^d ^u ^a
+^y ^e ^o ^z
+^t ^l ^o ^c
+^t ^g ^s
+^o ^t ^u ^r ^a ^n
+^o ^l ^g
+^n ^e ^w ^o
+^i ^w ^i ^k
+^i ^a
+^d ^n ^u ^o ^s
+] ^a shm
+[ o5w
+[ [ c
+Y5 o5w
+$y i19 '5
+$x $1 $0
+$j [
+$g $o $l $d
+$f $g
+$c $l $u $b
+$1 $2 $3 $*
+u $D
+o4t o5z
+o4t ,5
+o3s ]
+o3o o4c
+o36 i47 o58
+o2q ]
+o2e $0 $1
+o2d +6
+o1s +0
+o1e i3t
+o0y r
+o0t o1e o3t o2s
+o0m i2u
+o0m $0 $2
+o0g o2v
+o0g i2a
+o0d D6
+o0d $4 $4
+o0c $0 $1
+i77 .6
+i68 i52
+i67 o58
+i66 o72
+i5e i5d
+i56 i58
+i55 i74
+i48 i55
+i47 i55
+i46 i56
+i37 i38
+i37 i36
+c sa@ so0 se3
+c $7 $!
+^s ^s ^o ^r
+^r ^e ^d ^n ^u ^h ^t
+^o ^k ^i ^n
+^o ^a ^m
+^m ^a ^c
+^f y1
+^f ^a
+^7 o13
+[ o0u
+Y2 o5x
+D5 $1
+.1 o0L p5
+$~
+$s ^b
+$s Y1 +4
+$p -0
+$j $o $s $h
+$a $n $n $a
+r $e $s
+o9i
+o5t o6u
+o5p o6o
+o4c $k
+o4a $k
+o3j -5
+o3b ]
+o3J l
+o2x
+o2n +4
+o2c ]
+o1p ^c
+o0k o1p
+o0k $1 $5
+o0j $2 $7
+o0g o4a
+o0g $5
+o0d i1h
+o0c +1
+o0c $4 $5
+o0B D3
+l $e $t
+i73 i82 i91
+i71 i81 i91
+i59 i51
+i58 i74
+i55 i76
+i54 i63
+^y ^c ^a ^r ^t
+^t ^r ^a ^h
+^s ^u ^g ^a
+^s ^e ^r ^t
+^s $1 $2
+^p o2w
+^m ^s
+^k ^e ^r ^e ^d
+^f ^l ^o ^w
+^e ^r ^a ^e ^w
+^e ^i ^b ^m ^o ^z
+^T D4
+^9 o10
+] o2e E
+K i64
+K Z1
+K *45
+E Z1 T4
+$x $e
+$s ^i
+$s $p $e $e $d
+$p $o $l
+$m +6
+$Q
+$9 $9 $4
+$8 $9 $0
+$2 $0 $9
+u $3 $6 $0
+o6e ,7
+o4y i5b i6o o7y
+o4o o6o
+o49 E
+o44 *74
+o41 i52 i63 i74 o85
+o40 i50 o62
+o2w -3
+o2w +4
+o2r o3l
+o2l i72
+o2a r
+o1u o2h
+o1i r
+o1i i2g
+o1e $2 $0 $0 $6
+o1d o2o
+o1d D4
+o1a i2j
+o0u o1n
+o0t o2m
+o0k o4u
+o0k $2 $3
+o0i *31
+o0d $s
+o0A $1 $2 $3
+l i5i i6t
+k o2f
+i66 i77 i88
+i62 i72 i82
+i60 o79
+i58 i76
+i56 i65 o74
+i54 i78
+i54 i53
+i4@
+i47 i53
+i44 i59
+i13 i11
+c $3 $6
+c $1 T1
+^y ^e ^o ^j T4
+^t ^n ^u ^h
+^s ^n ^a ^r ^t
+^s ^a ^l ^l ^a ^d
+^r ^e ^s ^a ^l
+^o ^l ^i ^k
+^n ^e ^k ^o ^r ^b
+^l ^e ^b
+^l ^a ^n ^i ^f
+^Z D2
+^3 ^2 ^1 $3 $2 $1
+$w $i $l $d
+$n $c
+$k $e
+$g $m
+$e $k
+$V
+$@
+$9 $9 $3
+$6 $5 $4
+$6 $1 $0
+{ o41
+o7e $s
+o6u o7k
+o5g $a
+o58 i60 ,7
+o50 Y2
+o4p $1
+o4j *37 -1
+o3i $2 $0 $0 $5
+o2i o4a
+o1y D3
+o1v D4
+o1j .3
+o1f p3
+o0s $1 $3
+o0m o2u
+o0k $0 $7
+o0j $3 $0
+o0h u
+o0d $1 $5
+o0D $1 $0
+l $a $v
+k i32
+i68 o73
+i66 o71
+i62 i70 i80 ,9
+i58 i65
+i47 i59
+i0a $0
+c $# $1
+^y ^k ^c ^i ^n
+^y ^e ^n ^r ^a ^b
+^y ^d ^d ^e ^r ^f
+^v ^a ^s
+^t ^s ^i ^m
+^r ^e ^t ^l ^a ^w
+^o ^t ^t ^o
+^n ^o ^s ^a ^m
+^m ^d
+^a ^n ^a ^n ^a ^b
+^a ^c ^i ^n ^o ^m
+Z1 $z
+$r $o $s $s
+$n $i $g $h $t
+$i $n $a
+$8 $1 $8
+y1 u
+o7l o8e
+o6_ Y1
+o5j o6i
+o53 i64 i73 o84
+o4e c -5
+o42 i60
+o3e o5i
+o3e o4v
+o1v o2c
+o1i $9 $9
+o1e o3k
+o1a $2
+o0m i4a
+o0m *76
+o0k o5a
+o0k D4
+o0j i2a
+o0j D2
+o0j $1
+o0c i3e
+o0c i1p
+o0c D5
+o0S $5
+o0P $0 $1
+l ^i ^t ^l ^u ^m
+k -3 +5
+i91 iA0 iB1
+i62 i71 i80
+i55 i63
+i53 i79
+i45 i55
+^t ^s ^a ^c
+^m o1y
+^m ^a T2
+^g ^l
+^e ^r ^o ^m
+^a ^u ^q ^a
+^3 z2
+[ t
+[ $9 $2
++1 D4 d
+$w $i $n $s
+$s $z
+$r $u $b $y
+$r $1 $0
+$p $u
+$p $e $a $c $e
+$g $s
+$e $c
+$9 $5 $2
+$4 $0 $8
+$2 $1 $4
+z1 ^t
+y2 o0R
+u $1 $0 $1
+s90 Y2
+o7t -5
+o5f o6o
+o58 ,6
+o3u o4x
+o3a o5o
+o31 i43 o55
+o2p *54
+o2j *41
+o2j *31
+o2e o4i
+o2b *03
+o1v o2i
+o1o o3d
+o1f ,2
+o1f
+o0k $7 $7
+o0g i3e
+o0g *12
+o0M D4
+l $a $t
+l $2 $1
+k o2d
+i6g
+i69 o77
+i67 o79
+i62 i71 i83
+i56 i64
+i53 i75
+i49 i55
+i46 i53
+i37 i32
+i27 i36
+i21 o33
+^z ^i ^g
+^z ^a ^h
+^y ^l ^l ^a
+^u ^k ^c ^u ^f
+^6 ^3 o20
+[ $f
+K ^g
+D5 ^7
+$o r
+$j $w
+$X
+$9 $9 $5
+$5 $2 $5
+$5 $2 $1
+y1 ^s
+o5m Z1
+o5l $1 $2 $3
+o59 ,4
+o4z o5y
+o4i $3
+o42 i50 o61
+o3z c
+o3p $1
+o3n r
+o1w +3
+o1t o2a
+o1o o3t
+o1o $1
+o1k o2u
+o1a o3t
+o1a D6
+o0z r
+o0m i2k
+o0m i2h
+o0j o3e
+o0j i2r
+o0i o1v
+o0i i1g
+o0M $6 $9
+o0L $1 $0
+i78 o86
+i66 o73
+i58 o63
+i54 i73
+i52 *5A
+i46 i55
+i38 i37
+c $1 $9 $9 $3
+^y ^l ^l ^o ^d
+^y ^l ^e
+^t ^e ^n ^a ^l ^p
+^s ^u ^k ^r ^a ^m
+^r ^i ^m ^a
+^p ^o ^r ^d
+^o ^N
+^m ^j T2
+^l ^l ^u ^f
+^a ^k ^a
+^a D4 r
+^a $1
+^P T1
+^3 ^5
+Y1 i4m
+D1 D1
+$r $7
+$g $o $o $d
+$f $e
+$d $r $e $a $m
+$c $r
+$@ $1
+$$
+o6o $s
+o5s ,6
+o4a o6d
+o4,
+o2i o3x
+o2e o6e
+o1u i3s
+o1o i3s
+o1a i3a
+o0z o1i
+o0v o1e i2r
+o0m $1 $3
+o0i o1w
+o0g o4m
+o0f ,3
+o0d i3a
+l ^i ^x ^a ^m
+i56 ss6 $6
+i56 i70
+i56 [
+i35 i31
+^y ^t ^t ^a ^m
+^u ^M
+^t ^e ^d
+^p ^s ^e
+^o ^m ^i ^s
+^n ^e ^j
+^n ^a ^e ^d
+^k o1a i2t
+^a ^l ^i ^m ^a ^c
+^7 o14
+[ i25
+K c T4
+D3 $8 $7
+$p $o $d
+$l $1
+$j $i
+$j $a $m
+$b $e $s $t
+$W
+o5y +2
+o5i o6o
+o4o o5z
+o4o o5x
+o4e ]
+o43 i52 o63
+o42 ss0 $0 $0
+o3p o4u
+o3f $1
+o33 i42 o51
+o2v $1
+o2u D6
+o2l *13
+o2a K
+o1r o2d
+o17 *14
+o0z o1a
+o0k o5u
+o0k $1 $4
+o0h i2a
+o0g o5k
+o0d $2 $1
+o0M $8 $8
+o0L $1 $2
+o0B $5
+l i6b i7o o8y
+l $i $d
+l $h $o
+i71 i80 i91
+i6d i7o i8g
+i63 i74 i85
+i55 i78
+i48 i57
+i39 i30
+i38 i36
+i37 i30
+i17 i10
+i0f i1r
+c i8?
+c $9 $9 $2
+^y ^h ^p ^r ^u ^m
+^r ^A
+^o ^v ^a ^t ^s ^u ^g
+^o ^g ^n ^a ^t
+^n ^o ^s ^k ^c ^a ^j
+^n ^e ^i ^l ^a
+^l ^l ^a ^b ^e ^s ^a ^b
+^0 z1 }
+[ $8 $2
+D3 o3-
+D1 $!
++6 } }
+$x *31
+$l [
+$2 $2 $0
+$1 Z2
+$1 $2 $6
+$1 $0 $0
+} i52
+t o0M -1
+oA4 c
+o90
+o7n o8a
+o6o
+o5z o6i
+o5w *23
+o5t $o
+o49 i58 i67 o76
+o3d *45
+o2u o3z
+o1u $0 $1
+o1o $5
+o1k -2
+o1e i3s
+o1e i2h
+o0m i4r
+o0k o3d
+o0k D3
+o0j o2j
+o0i r
+o0d o2o
+o0a o2k
+i6e i7k
+i5y sg1
+i57 i70
+i53 i74
+i48 ^8
+i41 i51
+i36 i35
+i16 i15
+i0h i1a
+c ^0 ^1
+c $9 $7 $9
+^y ^e ^l ^y ^a ^h
+^u ^m ^a ^s
+^t ^c ^e ^f ^r ^e ^p
+^o ^n ^h ^c ^e ^t
+^o ^l ^a
+^o ^B
+^k ^b
+^i ^l ^a ^c
+^4 D3
+^2 o13
+[ q
+T0 ^D
+$x $s
+$w $a $r $s
+$t u
+$m $u
+$k $a $t $e
+$d $a $v $e
+$L T0
+$9 $7 $6
+$2 $1 $5
+$1 $9 $5 $5
+{ { $n
+{ ^x
+o7l o8i
+o6a o7u
+o5g $e
+o5a o6p
+o4o $9 $9
+o4n +5
+o4k +5
+o42 i50 ss0 $6
+o42 i50 i60 o77
+o42 *54
+o3i o4x
+o3g -5
+o3d ]
+o2s +0 *04
+o2o o3b
+o2i $2
+o2f
+o23 $1
+o1u i3i
+o0m o3o
+o0m o2y
+o0l o3o
+o0k i1j
+o0k *30
+o0j -6
+o0f $1 $4
+o0c o4c
+o0b i3l
+o0a $0 $1
+i69 o72
+i69 o70
+i66 o75
+i57 i64
+i53 i78
+i51 i61
+i18
+c ^1 ^1
+^y ^e ^s ^l ^e ^k
+^x ^e ^m
+^r ^e ^s ^u
+^p ^o ^h
+^p ^a ^l
+^m ^u ^r ^d
+^m D3
+^k o1u o2r
+^i ^r ^b
+^e ^o ^z
+^b ^o ^d
+^a ^i ^f ^o ^s
+^T D5
+^1 $9
+'4 Y2 y2
+$7 $1 $0
+$5 $4 $3 $2 $1
+$4 $2 $1
+$2 $2 $4
+z2 E ^1
+u sE4 o5U
+s08 Y2
+r $w
+o7g
+o5x $1
+o4t ,7 +5
+o4e o6i
+o3y o4n
+o3u o4z
+o2i *30
+o2i $1
+o2g $2
+o2e o4o
+o2M c
+o1w D4
+o1o o3k
+o1k +2
+o1g
+o1a o2x
+o0m $2 $1
+o0k o3o
+o0k o2g
+o0h .2
+o0g o1s
+o0g i3d
+o0c o2w
+o0b .2
+o0H $1 $2
+l i5k
+i70 o87
+i57 i66
+i53 i50
+i46 i24
+i41 ]
+i0g
+c $4 $m $e
+^y z1
+^y o2y
+^y ^r ^g ^n ^a
+^w ^e ^n T3
+^t ^h ^g ^i ^f
+^p ^m ^u ^j
+^o o2o
+^o ^a
+^o ^K
+^m ^o ^r ^f
+^e ^t ^a ^k ^s
+^a ^v ^a
+^T D2
+^S D6
+$w $l
+$o $1
+$c $g
+$_ $1 $2 $3
+$4 $!
+$2 $1 $9
+$1 $9 $5 $0
+} ^5
+{ { { c
+o6I E
+o5l o6y
+o5l $e
+o5l $a
+o5k $1 $2 $3
+o5e o6y
+o5a o6w
+o42 $4
+o3e o4w
+o32 i43 o54
+o2z *23
+o2h ]
+o2d $3
+o1v r
+o1u i2d
+o1o o2c
+o1i o3k
+o0k o2v
+o0k k *73
+o0j $1 $4
+o0h o2i
+o0d $0 $1
+o0b ,3
+o0a -2
+o0B $0 $9
+k i58
+i73 o86
+i5d i6o i7g
+i58 i65 o72
+i58 i63 o71
+i55 i65
+i21 o32
+i1. i3. i5. o7.
+d 'E
+^y ^r ^i ^a ^h
+^y ^l ^l ^i ^w
+^y ^k ^n ^i ^p
+^o ^a ^i ^c
+^i ^n ^a
+^g ^c
+^a ^e ^s ^l ^e ^h ^c
+^8 ^8 $8 $8
+^1 o17
+[ o5y
+Z2 o4_
+K } ^5
+$u $y
+$m $a $d
+$2 $5 $0
+y3 Z1
+o7c o8a
+o6v
+o5y $4
+o5x Z1
+o5i $m $e
+o4a $t
+o41 i52 ,6
+o3z $1
+o3d o4j
+o3a o4w
+o2x +3
+o2i i3d
+o1r o2b
+o1i i3a
+o0j o3a
+o0h $0 $1
+o0d i3e
+o0c o1s
+o0J T5
+o0F D3
+l $c $v
+k i56
+k *34
+i7h
+i5i i6n
+i59 o65
+i59 i78
+i58 o64
+i56 i77
+i4x
+i4d i5e
+i4/
+i32 ]
+i19 i19
+i17 ^3
+i16 i11
+i0f i1a
+c ^2 ^0
+c '7 $1
+c $1 $0
+^v i3d
+^v ^a ^c
+^t ^i ^m ^a
+^r ^e ^p ^s ^a ^c
+^p ^e ^e ^k
+^l ^b
+^e ^s ^u ^o ^h
+^c ^r ^a ^m
+^a $7
+[ $8 $7
+.2 $0 $3
+$x i6d
+$w D8
+$s z1
+$s $a $u $c $e
+$k $i $t $t $y
+$a $f
+o7- $t $y $l $e
+o5t
+o5o o6c
+o5o $d
+o4a $1 $2 $3
+o3j ]
+o2t *53 *36
+o2W c
+o1y o2s
+o1x ]
+o1u o4o
+o1i i2k o3a
+o1h o2o
+o1a o2p
+o1a o2j
+o0t r
+o0p $2 $4
+o0n D1
+o0m o5i
+o0l y2
+o0g o2e
+o0d o3h
+o0c $0 $3
+l $a $v $e
+i54 i50
+i53 i77
+c T4 si1
+c $4 $9
+^y ^r ^e ^v ^a
+^s ^l ^e ^g ^n ^a
+^o ^t ^i ^t
+^l ^e ^b ^a ^s ^i
+^g ^i ^a ^r ^c
+^e ^m ^a ^g
+^b ^h
+^1 D5
+D3 $8 $5
+'4 d t
+$p $e $n
+$m $x
+$m $a $r $k
+$k $i $d $s
+$d $e $a $d
+$7 $4 $1
+$3 $1 $2
+$3 $0 $9
+$1 $a
+u $2 $0 $0 $0
+r t
+o6m
+o57 z1
+o4a o6i
+o49 i50 ,6
+o3z k
+o3z ]
+o3i i5l
+o3e ]
+o1z D4
+o1s o2f
+o1e i2m
+o0x ] r
+o0l i2g
+o0k $2 $2
+o0j o2y
+o0g Z2
+o0e o1t
+o0d i2s
+o0d i1v
+o0b i3a
+o0G D3
+k o29
+k -3 -2
+i79 $3
+i65 o78
+i59 i71
+i57 i62
+i54 i74
+i48 i54
+i21 ,3
+i10 i10
+i0a ^L
+c o80
+^u ^y ^a
+^s ^u ^g ^n ^a
+^r ^e ^t ^s ^e ^h ^c
+^e ^s ^s ^e ^j
+^c o1h o2a
+^1 o12
+K i6b
+K i32
+*24 ] p1
+$4 $8 $8
+$4 $0 $4
+$2 $.
+o62 i70 i81 o94
+o5u o6x
+o5l .2
+o53 ,3
+o4y $1 $1
+o4o o5h
+o4e o5p
+o4a $a
+o41 ss2 $3 $4
+o3k $6
+o3f o4o
+o34 t
+o1u o4e
+o1i o2v
+o0s o1a
+o0s $8
+o0m i1s
+o0l $2 $1
+o0j o3d
+o0j i3i
+o0i o1t
+o0h $1 $5
+o0g o3z
+o0f o5l
+o0V $1
+i75 i85 i95
+i6a i7r
+i59 i50
+i57 o66
+i52 [
+i45 '8 .3
+i38 o43
+i37 i35
+i36 '8 *02
+i35 .2
+c $9 $6 $3
+c $1 $9 $9 $5
+^y ^s ^p ^y ^g
+^y ^e ^l ^d ^a ^r ^b
+^y ^b ^g ^u ^r
+^v ^a ^l
+^t ^h ^g ^i ^n ^d ^i ^m
+^t ^e ^n ^a ^j
+^t ^a ^h ^t
+^p ^a ^r ^c
+^n ^a ^h ^t ^a ^n ^o ^j
+^m ^o ^m
+^m D4
+^l *21
+^h ^s ^e ^r ^f
+^f ^s
+^e ^l ^g ^o ^o ^g
+^a ^n ^u ^r ^b
+^a ^n ^e ^l ^e
+[ $7 $3
+Y2 ,3
+Y2 *96
+$r $o $y
+$l $o $r $d
+$9 $8 $1
+$9 $4 $7
+} } } } } '4 p1
+{ $j
+o5r $1 $2 $3
+o5a o7d
+o5a $e
+o4b i5o o6i
+o44 i51 o64
+o42 $5
+o3p ]
+o3o $2 $3
+o3i ]
+o3g ,4
+o3f ]
+o3a $2
+o2s +0
+o2r i4n
+o2d p3 *13
+o2a D4
+o1y o2l
+o1s o2m
+o1o o3s
+o1i $2
+o1c .6
+o1a i3e
+o0m o4o
+o0k i3a
+o0k i2n
+o0k $1
+o0j o4d
+o0i D4
+o0g $1 $0
+o0b ]
+o0b $0 $4
+o0T $0 $1
+i6b i7a
+i66 o74
+i56 i66 i76
+i34 i33
+i24 o35
+i12 i11
+c $1 $9 $7 $9
+^y ^p ^o ^o ^n ^s
+^t ^r ^a ^t ^s
+^t ^n ^e ^c ^n ^i ^v
+^s ^i ^n ^e ^p
+^r ^o ^t ^c ^e ^h
+^l ^l ^a ^b ^t ^o ^o ^f
+^l ^i ^m
+^a ^s ^o ^r
+^R T1
+^8 ^0 ^8
+[ k D3
+$v $g
+$t $a $g
+$P
+$A r l
+$5 $0 $4
+$1 $0 $2 $4
+{ [ {
+ss- $o $n $l $y
+oB1
+o5t ,6
+o5g Z1
+o4k $0
+o4i o5p
+o4M c
+o4D c
+o41 $1
+o3y r
+o3i o5o
+o3a o5a
+o2s o5a
+o2r o5k
+o2a D5
+o1k o2h
+o1i o2x
+o1c o2e
+o0x D1
+o0s $9
+o0n o1o
+o0l i1o
+o0l $1 $1
+o0j o4a
+o0h $1 $0
+o0g o4e
+o0g $1 $1
+o0c D4
+o0b i2u
+o0a o2s
+o0C $0 $8
+l ] $e $d
+i77 i87 i97
+i6c o7h
+i57 i63
+i56 i63
+i28 ,3
+i14 i23
+i0t ^j
+c o73
+c $4 $8
+^y ^r ^a ^u ^n ^a ^j
+^s ^u ^a ^l ^k
+^r ^e ^t ^x ^e ^d
+^r ^e ^p ^o ^o ^c
+^p ^m ^a
+^o ^d ^o ^d
+^m $1
+^g ^n ^i ^y ^l ^f
+^C o1h
+^3 o10
+^3 ^4 ^1
+*13 [ p1
+$i $d $e
+$c $p
+$7 $8 $9
+$6 $1 $2
+$2 $3 $!
+o5o ,6
+o5c +6
+o5$
+o4o $1 $2 $3
+o42 i51 o63
+o41 i50 i61 o70
+o3r -5
+o2y D4
+o2u D5
+o1t o2v
+o1a i2p
+o0m $1 $0 $1
+o0l o5o
+o0k i2u
+o0i i1v
+o0g i3a
+o0g i1k
+o0d o4a
+o0d -5
+o0G $8
+l $8 *34
+i74
+i6a i7g
+i67 o70
+i66 o77
+i64 o77
+i35 i30
+i22 o33
+c i6@
+^z ^e ^d
+^z ^a ^c
+^y ^t ^s ^a ^n
+^y ^l ^r ^a ^h ^c
+^s ^A
+^r ^u ^a ^l
+^p ^a ^m
+^o ^a ^n
+^m ^a ^j
+^l ^a ^t ^i ^g ^i ^d
+^h ^a ^e ^l
+^c ^i ^p ^e
+] ] K
+E T6 -8
+D7 c T4
+D4 }
+$o $i $d
+$m $g
+$a $n $g $e $l
+$5 $0 $3
+$5 $!
+$1 $9 $5 $4
+{ { {
+u $2 $0 $0 $6
+o8e $s
+o5l $l $o
+o4o i51 i62 o73
+o4g
+o41 i53 i61 o73
+o3e o5o
+o2o o3w
+o2k ]
+o1u i2e
+o1r o2t
+o1o o0p
+o1o i3i
+o1i i4s
+o1e i3e
+o1c i1s
+o1a o2i
+o0x o1y
+o0l $1 $0
+o0k ,1
+o0j o4j
+o0h i3e
+o0h $1 Z1
+o0g o4k
+o0g $1 $3
+o0d y2
+o0d i3s
+o0b y4
+o0b .3 *21
+o0b *02
+i78 o87
+i6b ,7
+i68 o74
+i62 o75
+i62 o70 ss0 $9
+i62 o70 ss0 $0
+i5s c
+i55 i71
+i4f o5o o6r
+i37 i34
+i1. i3. i5. i7. i9.
+d '8 *20
+c $1 $9 $9 $4
+c $. $1
+^z ^t ^i ^r ^f
+^y ^b ^l ^e ^h ^s
+^y ^a ^f
+^v ^i ^d
+^u ^b ^u ^b
+^s ^y ^h ^r
+^o ^r ^c
+^k ^d
+^4 ]
+^2 o16
+[ i24
+[ i19
+$v $l
+$8 $1 $0
+$8 $0 $9
+$7 $1 $7
+$4 $0 $9
+$2 $1 $3
+{ y2
+o5t Z1
+o5n $o
+o5l Z1
+o4y o5m
+o2z *03
+o2h *31
+o1h o2e
+o0r i1e
+o0p o1c
+o0o *02
+o0k i2s
+o0k $3 $3
+o0i i1p
+o0F D6
+o0B $1 $2 $3
+l *13 k
+l $e $a
+k K *13
+i72 i81 i92
+i6i i7s
+i67 o72
+i64 o76
+i63 i72 i81
+i63 i71 i82
+i57 o65
+i57 i64 o71
+i54 i58
+i4s [
+i43 i54 o67
+i38 i32
+i38 i30
+c $9 $8 $0
+^y ^o ^b ^b
+^y ^e ^n ^d ^y ^s
+^x ^e ^d
+^s ^u ^s
+^s ^a ^i ^t ^a ^m
+^p }
+^o ^m ^e ^d
+^m ^g
+^h y1
+^d ^h
+^a ^n ^i ^n
+^a ^n ^e ^l
+^2 D4
+^1 D4
+[ $8 $9
+[ $2 $0 $1 $1
+D3 $4 $7
+.1 ^M
+$x *20 r
+$n Z1
+$l $i $n $e
+$b [
+$a $s $s
+$9 $!
+$1 $4 $8 $8
+$1 $2 $7
+$1 $2 $0
+t o1B
+o6o -7
+o6l $y
+o5b $r
+o4Y c
+o4T c -6
+o41 i51 i60 o72
+o3u r
+o3k r
+o3e o5e
+o3a $9 $9
+o38
+o2s -3
+o2n -4
+o1p o2h
+o1j o2w
+o1i i4n
+o1i i2d
+o1a $2 $0 $0 $3
+o0l ,5
+o0l $2 $3
+o0k o1a o3a
+o0j $4
+o0h o4a
+o0e o1x
+o0e ^B
+o0d i2i
+o0c o3u
+o0D $2
+l $i $c
+l $0 $3
+i57 i61
+i55 ss5 $5
+i51 i50
+i4m i5a i6n
+i40 i58
+i39 i35
+c o85
+c T3 i3-
+c $9 $8 $8
+^y ^b ^b ^a ^g
+^u ^l ^a ^m
+^p ^t
+^i ^l ^i ^l
+^e ^m ^o ^h
+D1 $8 $6
+$r $v
+$m $o $r $e
+$d $e $a $t $h
+$9 $4 $8
+$3 $2 $5
+y2 o0P
+u $2 $0 $0 $5
+o7r o8a
+o7e +8
+o6z o7a
+o5z i6i
+o59 Y2
+o4k $s
+o3z o4y
+o2n r
+o2k +3
+o2i $2 $1
+o1y o2c
+o1o o3i
+o1o o3a
+o1k o2w
+o1k *42
+o1e o3e
+o1d o2i
+o1a o2w
+o0k o4o
+o0j -4
+o0i D3
+o0c +3
+[ i2b
+o0M $2 $1
+o0C $4
+l $b $u
+i67 o71
+i61 o78
+i61 i71 i82
+i57 i66 o75
+i55 i72
+i55 i62 o70
+i55 i50
+i50 r
+^y ^g ^g ^i ^z
+^y ^d ^d ^e
+^r o2y
+^o ^r ^c ^e ^n
+^o ^l ^c
+^o ^i ^m
+^n ^i ^l ^r ^e ^m
+^l o1u
+^h ^s ^i ^r ^i
+^a ^n ^i ^r ^a ^m
+[ o0E
+Y2 $s
+D3 $9 $6
++4 { {
+'7 $7
+$o $t $o
+$k $j
+$i $e
+$g $c
+$d $w
+$1 $2 $9
+$. $,
+} ^m
+o5l $y
+o4y o5l
+o4u o5z
+o3x o4a
+o1u i2s
+o1o o2z
+o1o o2v
+o1o $2
+o1e o2w
+o1c ,2
+o0p o1a
+o0j $1 $0
+o0g $3 $3
+o0e i1j
+o0d i2w
+o0d *32
+o0c *42
+o0a i2d
+o0L $1 $2 $3
+o0G $0 $1
+l $t $a
+k o0m *12
+i81 i77
+i72 i74
+i66 o78
+i5i o6s
+i58 ^8 C
+i56 i52
+i52 i61
+i24 i37
+i22 o34
+i0b i1r
+c o6@
+^y ^k ^c ^i ^m
+^w ^e ^m
+^u ^s ^a
+^t ^u ^c
+^s ^m ^j
+^r ^e ^t ^t ^u ^b
+^r ^e ^p ^a ^p
+^r ^e ^h ^t ^a ^e ^h
+^o ^b ^o ^r
+^m ^j
+^l ^i ^h ^p
+^j D5
+^e ^r ^i ^a ^l ^c
+^a ^s ^a ^c
+^a ^i ^d ^e ^m
+^7 ^0 ^0 ^2
+^1 ^8
+^0 ^1 $1 $0
+[ i28 +0
+D3 $6 $5
+$s $y
+$k $d
+$9 $7 $1
+$7 $1 $4
+$5 $0 $9
+$3 $0 $5
+} K
+y3 Y3
+o8c ]
+o7a o8t
+o6m c
+o6i +7
+o5b ,6
+o5?
+o41 i52 i63 i74 i85 o96
+o3t $1 $2
+o3o o5e
+o2p i3o
+o2i o3v
+o2e o5e
+o2e D4
+o1u o5a
+o1s o2a
+o0j $8
+o0i o2a
+o0b k
+o0D o61
+l $2 $0 $1 $4
+k +3 [
+i72 i79
+i65 o76
+i61 o77
+i59 i73
+i55 o68
+i54 i62
+i47 i54
+i46 i57
+i40 i56
+i40 i55
+i25 i36
+^y ^t ^a ^n
+^y ^e
+^t ^r ^a ^d
+^t ^n ^e ^r ^b
+^t ^e ^l ^o ^i ^v
+^r ^e ^p ^p ^e ^p
+^r ^e ^m ^m ^a ^h
+^o ^l ^a ^l
+^n ^m ^a ^d
+^m ^o ^o ^d
+^c ^a ^a ^s ^i
+^a ^l ^o ^h
+^Z
+[ $9 $1
+E i4@
+D3 $7 $4
+$r $0 $1
+$m $a $g $i $c
+$l u
+$; o7i
+$$ Z2
+o6z o7e
+o62 .3
+o5e ,6
+o5c $e
+o4o o6i
+o4a o6a
+o4a i5t o6a
+o3x r
+o32 $4
+o2m $2
+o2k $2
+o2g o4a
+o2H c
+o2F c
+o1o o2h
+o1i D3
+o1d ]
+o1a $2 $0 $0 $4
+o0k i1c
+o0h o3o
+o0d i1g
+o0b $9 $9
+o0D -9
+l -2 {
+l $h $a $l $l
+i72 i78
+i6_ +7
+i63 o77
+i58 i62
+i43 i58
+i40 i57
+i28 o39
+^y ^r ^t ^n ^u ^o ^c
+^y ^n ^o ^p
+^y ^n ^a ^m
+^y ^k ^r ^a ^p ^s
+^w z2
+^w ^a ^j
+^t ^s ^o ^m
+^t ^i ^t ^e ^p
+^s ^r ^a
+^s ^e ^l ^a
+^m ^o ^c
+^m ^k
+^k ^n ^u ^p
+^g ^b
+^e ^p ^e ^p
+^S D5
+^9 o14
+[ $7 $5
+[ $7 $4
+Y4 $q
+D7 D3
+D6 $1
+.2 $0 $2
+$p $a $l
+$l $v
+$k [
+$8 $5 $2
+$5 $1 $3
+$4 $4 $4
+$2 $0 $2
+$! [
+$! D9
+o6n ]
+o6L E
+o5v o6o
+o5q i6u o7e
+o4y $1 $2
+o4i $1 $2 $3
+o4a $l
+o45
+o42 i50 ss0 $0
+o33 i40 ,5
+o2a o0t
+o1b ]
+o1a o2h
+o1a $3
+o0w $1
+o0p o1e
+o0l y2 k
+o0k o4b
+o0k $0 $5
+o0i o1k
+o0h o3u
+o0f $1 $2
+o0c o3o
+o0c i3a
+o0c i2p
+o0c -3
+o0a i1w
+o0D $0 $1
+o09 z2
+k *13
+i6d i7r
+i69 o73
+i57 i50
+i56 i66 o77
+i54 i33
+i53 i70
+i53 i62 o77
+i49 i56
+i37 i39
+i37 D1
+^y ^k ^n ^i ^t ^s
+^y ^d ^a ^h ^s
+^t ^r ^a ^c
+^s ^u ^n ^i ^l
+^s ^u ^e ^z
+^s ^i ^n ^n ^e ^t
+^r ^e ^w ^o ^l ^f
+^r ^e ^t ^a ^k ^s
+^o ^d ^l ^a
+^n ^i ^b ^o ^r
+^n ^e ^p ^o
+^l ^A
+^l D3
+^k ^c ^a ^b
+^i ^g
+^i ^d ^a
+^5 z2
+^1 o15
+] l ] $e
+] i33
+D3 $8 $9
+D3 $8 $1
+$y $1 $1
+$p $a $b $l $o
+$8 $0 $5
+$2 $0 $6
+$1 Z3
+t o4B s.U
+o5l -7
+o3o o5a
+o3a o4i
+o2u o4a
+o2n [ Y1
+o1y o2e
+o1t o2o
+o1k D4
+o1i ^A
+o1h o2i
+o0u i1n
+o0s o1e
+o0k i3u
+o0k i1o
+o0j o1e $1
+o0j i1w
+o0g o3u
+o0f i3r
+o0c o4i
+o0c $1 $2
+o0a o2r
+l ^9 ^9 ^9 ^1
+k o2b
+i94 iA5 iB6
+i65 o74
+i65 i71
+i59 i69
+i59 i63
+i58 o66
+i58 i63
+i57 ss7 $7
+i56 i65
+i53 i60
+i40 i51
+i36 i45
+i36 i32
+i33 i39
+i10 i20 i30
+c ^4 ^3 ^2 ^1
+c '8 $1
+c $3 $9
+^w ^o ^l ^b
+^t ^e ^l ^l ^u ^b
+^t ^a ^e ^h
+^s ^m ^a
+^r ^w ^a ^r
+^n ^r ^o ^b
+^n ^e ^v ^e ^s
+^l ^o ^s
+^l D2
+^k ^c ^i ^d
+^i D5
+^e ^s ^a ^h ^c
+^a ^l ^l ^e
+^_ $_
+^T +7
+^5 ^3 ^1
+^3 o14
+T0 T4 T7
+K o0c
+K D2 $9
+D3 $7 $6
+D1 o2-
+$w $o $o
+$h $e $l $l
+$S
+t +8 o0M
+soy c
+o6r o7u
+o6#
+o5s o6u
+o40 i55 i60 o76
+o3y $1 $3
+o30 i40 o51
+o2r o4i
+o2r ,3
+o2n +5
+o1z o2i
+o1k ]
+o1k *30
+o1e o3t
+o1e o2p
+o1a r
+o0k i3n
+o0h .4
+o0g o4u
+o0e $4
+o0d i1d
+o0d $2 $2
+o0b $1 $2
+o0L D4
+l $i $i
+k $3
+i79 o80
+i6g i7h
+i69 i40
+i56 o63
+i56 i72
+i55 o67
+i55 i38
+i54 i51
+i41 i53
+i37 o45
+i36 o44
+c sa@ so0 si1
+^y ^e ^l ^s ^e ^w
+^v ^a ^r
+^u ^n ^i
+^s ^l ^a
+^r ^i ^f
+^p i1k
+^p ^u ^s
+^p ^o ^t ^s
+^p ^o ^c
+^p ^a ^j
+^o ^h ^c ^a ^n
+^e ^f ^a ^c
+Y2 $4
+T0 o5P
+K D1 $7
+D6 D6 D6
+D3 ^6
+D3 $6 $9
+'7 [ *41
+$r $a $g $e
+$p $i $t
+$h [
+$U
+$9 $7 $2
+$7 $1 $8
+$3 $2 $7
+$3 $2 $6
+$3 $2 $0
+$1 $?
+ss4 $y $o $u
+o7s o8e
+o5q ]
+o4t +6
+o4s $1 $2 $3
+o4k D7
+o41 i50 i62 o70
+o3t +6
+o3e $4
+o2i o3o
+o2g +6
+o1y o2r
+o1j ]
+o1i $1 $2
+o1e i3n
+o1e $4 $5
+o0z o1o
+o0s o1k
+o0m ]
+o0m ,3
+o0l i4e
+o0h i2i
+o0g o2y
+o0f o4o
+o0e o1j
+o0d i1l
+o0H $8
+l $i $t $e
+k D4
+i81 i91 iA1
+i61 o76
+i54 i72
+i51 o69 i77 o88
+i4m o5a o6r
+i40 i54
+c $4 $6
+^x ^a ^s
+^w ^o ^l ^l ^i ^w
+^t ^r ^o ^m
+^t ^i ^r
+^t ^h ^g ^i ^l ^i ^w ^t
+^t ^a ^w
+^t $1 $0
+^s ^g ^o ^d
+^r ^u ^s
+^o ^e ^d ^i ^v
+^l ^k
+^f ^c
+^T D6
+^M T1
+^7 ^0 ^0 ]
+^5 o13
+[ k $1
+Y1 o0L
+D3 $9 $1
+$l $u $c $y
+$4 $1 $3
+$3 Y2
+$1 $9 $4 $5
+oAe
+o6s ]
+o5u $r
+o5i o6p
+o5b $o
+o5B T0
+o4u o5i
+o4i ]
+o4a $e
+o43 i53 ,6
+o42 i50 ss0 $9
+o41 i51 o63
+o3d ,4
+o2z
+o2t o3z
+o2j +3 *43
+o1z o2y
+o1i i3i
+o1i i2k o3i
+o1a $0 $0
+o0u o1l
+o0p D1
+o0k D6
+o0j o5a
+o0g o5a
+o0g i2d
+o0f $1 $1
+o0e o1i
+o0d i4e
+o0d $0 $2
+o0c i3i
+o0c *15
+o0L $2
+o09 $8
+k o2m
+k i67
+k [ r
+k D2 c
+i75 i80
+i75 -6
+i72 o80 ,9
+i65 o77
+i57 i71
+i53 i72
+i39 i33
+i31 i32
+i24 i35
+i22 ,3
+i1. o3.
+i0w i1e
+i0s i1o i2u
+c o60
+c $0 $5
+^y ^z ^z ^a ^j
+^y ^r ^i ^a ^f
+^y ^c ^a ^m
+^x Z1
+^w ^a ^s
+^u ^e ^v ^o ^l
+^o ^r ^d
+^o ^m ^o ^h
+^n ^o ^t ^n ^a
+^a ^l ]
+^W
+^0 ^1 ]
+[ o0k D3
+K o0g
+K .0 *12
+D3 $8 $6
+,4 i4Z c
+$n $k
+$m -6
+$h $k
+$8 $3 $1
+$7 $0 $0
+$3 $1 $7
+$3 $1 $5
+o7m o5g
+o6C $s l
+o5v
+o4y o5t
+o42 $0
+o41 i50 i62 o79
+o3z ,9 *43
+o2s ]
+o2r o3y
+o2n ]
+o2l ]
+o2i o6i
+o2i o4o
+o1o i3d
+o1o $4
+o1i o4o
+o1i o4a
+o1i i4l
+o1f ]
+o0m i2p
+o0k o1i ]
+o0k D3 $0
+o0i i1t
+o0h o2y
+o0g o4r
+o0g -4
+o0g +1
+o0d o3z
+o0c i2s
+o03 r
+i74 +6
+i66 ,7
+i65 o73
+i65 o72
+i57 o64
+i57 i63 o71
+i56 i65 o70
+i55 i64 o76
+i53 ss3 $3
+i49 i58
+i35 i45
+i28 i21
+i22 *02
+c $5 $1
+^s ^u ^f ^u ^r
+^o ^m ^o ^t
+^o ^a ^i ^x
+^n ^e ^l ^l ^a
+^m ]
+^k ^c ^i ^r ^t ^a ^p
+^i ^r ^a
+^g ^n ^u ^o ^y
+^g ^n ^a ^h ^z
+^e ^i ^h ^p ^o ^s
+^e ^c ^n ^a ^d
+^a ^d ^n ^a ^p
+^8 ^9 ^0
+[ ^h +2
+K Z2
+K E *56
+D3 r
+$s $e $t
+$o $z p3
+$k $e $n
+$b $o $x
+$9 $2 $5
+$7 $8 $7
+$6 $2 $0
+} y2
+} K *50
+u o3V
+t $S
+sjG c s!K
+oBC *65 c
+o8m *68
+o5o o6i o7d
+o5_ D2
+o55 i64 i73 i82 o91
+o4o r
+o41 i51 i62 ,7
+o3u o4j
+o3s o4w
+o3o $2
+o3a o5i
+o3a o4z
+o3a $2 $0 $0 $5
+o2x o3a
+o2l ^i
+o2e K
+o1u o2f
+o1o $k $a
+o1k t [
+o1e o2v
+o0s $0 $1
+o0k i2o
+o0j $1 $3
+o0T $1 $0
+o0B D2
+o02 r
+k }
+i78 i88 i98
+i66 i76
+i54 i61
+i4e i5r
+i40 o31
+i33 r
+d 'A
+c $9 $7 $3
+^y ^m ^m ^i ^t
+^y ^l ^l ^o ^p
+^y ^h ^t ^a ^c
+^y ^a ^r T3
+^t ^n ^e
+^t ^i ^u ^r ^f
+^s ^t ^a ^c
+^o ^n ^i ^h ^c
+^o ^m ^e ^m
+^n ^a ^i ^t ^s ^i ^r ^h ^c
+^f ^l ^o ^g
+^e ^t ^a ^k
+^e ^i ^f ^l ^a
+^d ^l ^i ^w
+^d ^a ^r ^b
+^a ^n ^i ^l ^o ^r ^a ^c
+^1 ^5
+] i34
+] ^2
+[ $8 $3
+K { -3
+K i44
+K -5 $1
+D5 o4f
+$p $u $p $p $y
+$m -0
+$m $1
+$l l D4
+$h $e $r $o
+$? +6
+$8 $!
+$7 $1 $2
+$3 ^2
+$2 $1 $7
+oB6
+o7r
+o7A
+o6o o7u
+o58
+o4i o0p
+o4b
+o4a o5o
+o47 i58 i69 o70
+o3g -4
+o3d o4y
+o3c E
+o2b *32
+o1w *53
+o1k o2i
+o1g o2u
+o13 r
+o1!
+o0t o1o
+o0r o2d
+o0r o1o
+o0k o1a i2y
+o0j $5 $4
+o0g o3o
+o0g $0 $1
+o0K T5
+o0K $1 $2
+o0F D5
+o0A $2
+i76 D3
+i73 i81
+i65 i74
+i63 o75
+i57 i68 o79
+i45 ss6 $7
+i36 i31
+i29 ,3
+i0s i1c
+i0k i1a
+c $9 $7 $8
+^t ^e ^n ^r ^e ^t ^n ^i
+^s ^o ^t ^n ^a ^s
+^s ^i ^u ^s ^e ^j
+^o ^r ^t ^e ^m
+^o ^o ^p
+^m z2
+^l ^f 'A
+^e ^i ^l ^l ^e
+^b ^e ^l ^a ^c
+^a ^f ^a ^r
+] c T6
+[ $8 $4
+R7 c .7
+D3 $7 $3
+D1 o12
+$s $u $e
+$r -1
+$p $1 $2 $3
+$k $h
+$5 $1 $1
+$2 $1 $8
+$1 $3 $0
+$1 $1 $3
+$+ R6 R6
+sa@ so0 se3
+r ,5 y1
+r $x
+o4u
+o4m $5
+o4a $d
+o42 i50 o62
+o3i o5u
+o3i $8
+o3e ,4
+o2r o4a
+o1v D3 ]
+o1e $9 $9
+o0m o5o
+o0k $k
+o0j o2a
+o0h $1 $2
+o0e o1u
+o0d i1k
+o0c i2c
+o0B $6
+l o6m o7e
+l $9 $9
+i8x '9
+i78 i81
+i73 +6
+i6g i7a
+i65 i76
+i57 -2 [
+i46 i42
+i38 o46
+i34 i45 i56
+i29 i30
+i27 i34
+i21 i31
+i20 o31
+i0g i1e
+c o91
+c $3 $3 $3
+^y ^d ^a ^r ^b
+^t ^r ^e ^s ^e ^d
+^r ^h ^c
+^r ^e ^y ^a ^l ^s
+^r ^e ^t ^f ^a
+^o ^t ^o ^f
+^o ^r ^e ^v
+^n ^i ^s
+^l ^l ^e ^b
+^l ^e ^h ^c ^a ^r
+^j ^t
+^e ^m ^o ^s ^e ^w ^a
+^a ^m D5
+^a ^k ^i ^r ^e
+^9 z2
+] y5
+D4 $6 $9
+D3 $8 $3
+$w $1 $2 $3
+$m $a $t
+$l $a $d
+$c $e
+$a k
+$5 $1 $5
+$1 $5 $0
+$1 $1 $!
+} ^k
+} ^a
+si1 se3
+o70
+o5a o6z
+o4d i6r
+o44 i55 i66 o77
+o43 i50 ss0 $0
+o3y o4o
+o3s Z1
+o3o $7 $7 $7
+o3Y c
+o2j ,3
+o2i r
+o1z o2a
+o1n o2a
+o1i o5a
+o1h o2u
+o1c o3a
+o1a C [
+o0p o1i
+o0m o5u
+o0g o5o
+o0d ]
+o0d $0 $0
+o0L D3
+o0K $0 $1
+i72 o84
+i64 o78
+i60 i79 o88
+i59 i34
+i56 i73
+i56 i66 ,7
+i56 i51
+i54 o66
+i44 i56
+i43 i53
+i42 i52
+i40 i59
+c $9 $!
+c $6 $1
+c $3 $8
+^t ^s ^o ^r ^f
+^r ^p ^a
+^r ^e ^t ^r ^a ^c
+^o ^d ^r ^a ^c ^i ^r
+^k K
+^a ^r ^a ^l
+^1 o11
+T0 ^K
+D8 D8
+D3 $7 $9
+$r $3
+$f $e $r
+$3 $5 $0
+t o2Y
+o7z
+o7o .6
+o7a -8
+o6p $1
+o5s o6o
+o5r $o
+o5a o6y
+o56 i69 sS6 $9
+o4x $1
+o4v ]
+o4k $1 $2 $3
+o41 i52 i61 o72
+o2o D4
+o2j *34
+o2e o3z
+o2a o3z
+o1l o2y
+o1i o3t
+o1e o3i
+o1e i3r
+o0s r
+o0s $5
+o0o i1k
+o0m $0 $3
+o0k -5
+o0k $2 $1
+o0h $1 $3
+o0b o1y
+o0b $0 $3
+o0a i2r i3o
+o0M $7
+o0G D4
+o0D D2
+o0C $1 $3
+l $e $e
+i7a c
+i58 i60
+i52 i50
+i4m [
+i49 i57
+i4,
+i39 i32
+^y ^n ^i ^t ^s ^e ^d
+^y ^a ^p
+^u ^B
+^t ^p ^a ^c
+^n ^e ^l ^g
+^l ^a ^n ^e ^s ^r ^a
+^e ^m ^i ^n ^a
+^c ^k
+^a ^t ^l ^e ^d
+^a ^r ^d ^n ^a ^s
+^7 ^4 ^1
+^4 o10
+^4 ^1 ]
+] ^f
+] $o t
+[ i4f
+[ $7 $9
+D1 $6 $8
+$r $z
+$r $u $s $h
+$p +0
+$n $1
+$h $m
+$b $h
+$9 $1 $4
+$7 $6 $5
+$6 $6 $9
+o7i T0
+o5a $o
+o4i $a
+o3s o4y
+o3r ]
+o3o D6 *45
+o3e o4z
+o33 i43 ,5
+o30 i49 o58
+o2l o3y
+o2k $1 $3
+o2b o3y
+o2a $2
+o1y o2k
+o1y o2d
+o1u $5
+o1r +5
+o0k o6i
+o0k o3j
+o0k i1e
+o0k $0 $1
+o0j o3i
+o0j $s
+o0g $3
+o0d i4a
+o0d i3i
+o0b i3e
+l o6m o7a
+i7s
+i79 +6
+i66 i71
+i60 o77
+i59 i62
+i58 o62
+i58 o61
+i54 i61 o77
+i51 i69 o78 o87
+i45 i54
+i44 ^1
+i43 o34
+i34 i38
+i31 ss0 $1
+c $2 $0 $0 $1
+^z ^a ^p
+^z ^a ^l
+^y ^d ^d ^a ^p
+^y ^c ^i
+^t ^t ^i ^r ^b
+^t ,3
+^s ^a ^l ^g ^u ^o ^d
+^r ^e ^h ^c
+^p ^i ^l
+^p $s
+^o ^t ^a ^p
+^o ^e ^m ^o ^r
+^o ^c ^n ^a ^r ^f
+^n ^o ^r
+^n ^i ^w
+^d ^n ^a ^r ^g
+^U D3
+^7 ^7 $7 $7
+^3 D4
+] ] ] $o
+T7
+D4 o31
+D4 $b
+$y i7o
+$r $o $l $l
+$q $a
+$m $i $n
+$8 $8 $9
+$4 $1 $9
+$2 $2 $8
+u $9 $9 $9
+q c
+o5p o6u
+o5e o6x
+o4y o51
+o4u o5a
+o4t
+o3g $1 $2
+o2x -3
+o2c i3o
+o1g *21
+o1c ]
+o0z o1u
+o0m $0 $4
+o0i $1 $0
+o0g i2i
+o0e o2d
+o0d i4r
+o0c -4
+o0R $0 $1
+o0H $0 $1
+o01 r
+l +4 *30
+i73 [ [
+i6a +5
+i65 i70
+i58 i70
+i57 Y1
+i56 s2.
+i56 i64 o75
+i56 i50
+i55 o63
+i55 i64
+i4t D0
+i43 i54
+i37 i44
+i36 i38
+i1. i3.
+i0b i1u
+c ] Z2
+^z ^i ^m
+^z ^a ^n
+^y ^l ^g ^u
+^t ^o ^o ^r
+^s ^e ^l ^g ^a ^e
+^s ^c ^m
+^o ^r ^d ^n ^a ^j ^e ^l ^a
+^n ^i ^m ^a ^j ^n ^e ^b
+^i ^m ^a
+^h ^t ^r ^a ^d
+^h ^a
+^d ^e ^r ^a ^j
+^b ^p
+[ $9 $5
+K $f
+D6 D7
+$r $a $c $e
+$o $l $o
+$o $a
+$l $d
+$i $c $e
+$c $f
+u Z2
+sdn
+oAA l
+o9c
+o8u $s
+o7v o8e
+o5z ,6
+o5h c
+o41 i59 i60 o77
+o3i r
+o3c $0
+o30 i40 ,5
+o1u o5i
+o1u $2
+o1i o2z
+o1a y2
+o0r i1h
+o0k i4a
+o0j o4e
+o0g Y2
+o0e o2s
+o0d o4o
+o0d o3u
+o0T $8
+o0P $2
+o0K $1 $2 $3
+o0G $1 $2
+l ^a ^e ^s
+i59 i66
+i57 i67 o70
+i51 i78
+i48 i53
+i11 i32 i53
+c o72
+^z ^n ^a ^r ^f
+^s ^s ^a ^m
+^r ^e ^e ^d
+^p ^l ^e ^h
+^o ^e ^h ^t
+^o ^a ^c
+^n ^a ^c ^i ^r ^e ^m ^a
+^l ^a ^t ^s ^y ^r ^c
+^h ^c ^n ^e ^r ^f
+^e ^p ^o ^h
+^e ^b ^e ^b
+^d ^g
+^a ^y ^a ^m
+^a ^m ^l ^a
+^a ^i ^d ^u ^a ^l ^c
+^a D5
+^9 ^1 r
+^1 $a
+^0 z2
+[ o0q
+[ $6 $9
+[ $6 $6 $6
+E T1 ]
+D3 $8 $2
+D3 $7 $5
+D1 $8 $2
+$t $e $e $n
+$r $5
+$o $t $a
+$m $u $s
+$i $o
+$g $p
+$d $i $e
+$d $e
+$b $e $a $s $t
+$9 $2 $9
+$9 $2 $0
+$2 $3 $5
+$2 $0 $8
+u o1Z
+o4h
+o4f
+o41 i59 i60 o75
+o41 i53 ,6
+o40 i50 o64
+o3z $1 $1
+o3o r
+o3#
+o2y +3
+o2r } [
+o2j -5
+o1w o2c
+o1v ^d
+o1r o2y
+o1i o5i
+o1i i3s
+o1a -5
+o0y ^d
+o0s i1w
+o0s $7
+o0m i4i
+o0l $1 $3
+o0k i4r
+o0k i4e
+o0c i4r
+o0H D3
+o0H $1 $2 $3
+l $2 $0 $0 $4
+k +4
+i99 iA9 iB9
+i72 o83
+i6i i7n
+i66 o70
+i62 i73 i81
+i57 i68 o76
+i55 i70
+i54 o69
+i44 i55
+i3x
+i24 i26
+i0m ^a
+c $4 $!
+c $2 ^1
+^y ^r ^k
+^s ^i ^r ^o ^d
+^s ^e ^r
+^r ^a ^l ^c
+^r ^a ^e
+^o ^l ^e ^g ^n ^a
+^o ^g ^a ^r ^d
+^n ^w ^a ^d
+^n ^e ^l ^l ^a ^f
+^n ^a ^p
+^m ^o ^d ^e ^e ^r ^f
+^l ^e ^e ^t ^s
+^i ^o ^m
+^i ^d ^e ^j
+^h ^t ^i ^a ^f
+^f ^e ^h ^c
+^e ^r ^u ^t ^u ^f
+^e ^a
+^9 ^5 ^1
+^3 o15
+^1 o18
+D3 $1
+$m +4
+$m $a $r $i $e
+$9 $7 $0
+$9 $2 $7
+$6 $9 $0
+$1 $5 $7
+} c ^3
+sio Z1
+oB1 c
+o5b $e
+o4t ]
+o4k ]
+o4a $3
+o41 i51 ,6
+o41 i50 i60 o74
+o40 i53 i60 o74
+o3z ,4
+o3e o5u
+o2v -3
+o2i o3z
+o2e $1
+o2b $1 $2
+o1t i2r
+o1s r
+o1e $1
+o1a o3a
+o1a *54
+o14 r
+o0s o1m
+o0r ^C
+o0k i2l
+o0k *31
+o0j $1 $5
+o0h i3i
+o0g -1
+o0f i1o
+o0c o5o
+o0M $7 $7
+o0M $4
+o0M $2 $3
+o0C $5
+o0B $0 $8
+l ^i ^r ^t
+i79 i70
+i66 i77
+i65 o79
+i65 $9
+i62 o74
+i62 i71 i82
+i61 i70 i81
+i60 i70 o87
+i57
+i55 o69
+i51 $2
+i0g z1
+i0c i1e
+c T8 i8_
+c $2 $3
+^y i1h
+^y ^r ^f
+^y ^n ^n ^a ^m
+^s ^r ^e ^p ^u ^s
+^s ^e ^h
+^r ^e ^b ^m ^e ^c ^e ^d
+^p ^l ^a
+^o ^r ^k
+^l ^l ^i
+^l ^a ^n ^a
+^h ^j
+^e ^l ^o ^c ^i ^n
+^S $1
+^8 ^0 ^1
+^3 ^<
+] [ k
+] K Y2
+[ $9 $7
+[ $7 $6
+D3 $9 $0
+D3 $4 $2
+D3 $0 $9
+$y $u $m
+$k D3
+$k $u
+$6 $7 $8
+$6 $0 $6
+$4 $2 $3
+$3 $0 $7
+{ K
+t o4T
+t o3E
+o7t o8h
+o51 $1
+o4u $a
+o4t o5v
+o4o ]
+o4b c
+o3y o2c
+o3u o0p
+o3o o4j
+o3i *53
+o3g o6e
+o1w D5
+o1s o2g
+o1g o2o
+o1g D3 ]
+o0l i4a
+o0j i2h
+o0j *32
+o0j $2 $3
+o0j $2 $1
+o0e D2
+o0c D6
+o0S $7
+o06 *54
+o01
+i75 i80 i90
+i68 i78
+i63 o78
+i56 i60 ,7
+i52 o60 ss0 $9
+i45 i59
+i45 i58
+i45 i54 o66
+i39 i34
+i36 i37
+i15 i14
+c $5 $2 $0
+c $1 $9 $9 $6
+^z ^a ^r
+^y ^n ^n ^a ^f
+^x ^i ^n ^e ^f
+^s ^i ^l ^a
+^s ^e ^n
+^r ^o ^t ^o ^m
+^r ^e ^k ^c ^a ^h
+^o ^c ^i ^r
+^n ^i ^a ^r ^b
+^n ^d
+^m ^b
+^l ^s
+^k ^c ^u ^h ^c
+^e ^n ^i ^l ^a
+^e ^k ^a ^l ^b
+^e ^i ^n ^n ^a
+^c o1h o2o
+[ i35
+[ c $1
+[ $7 $7
+[ $7 $2
+D2 $6 $6 $6
++0 d
+$z $s
+$h $o $t
+$9 Z2
+$9 $0 $8
+$6 $0 $9
+$#
+t o1J
+o6a $o
+o4m
+o48 i58 ,6
+o2u y3
+o2l $1 $2
+o2g ]
+o1u D4
+o1i o3e
+o1e o6e
+o1e o3s
+o1d o3a
+o1a o2z
+o1a o2v
+o0q r
+o0p $6
+o0k i1w
+o0k $5 $4
+o0j $0 $7
+o0b i4a
+o0b $0 $0
+o0a o1w
+o0a ]
+o0a ,1
+l ^e ^c ^a ^f
+l $t $e $s $t
+l $b $o $y
+l $a $n $n
+k y2 ,3
+i79 o88
+i6h
+i6g [
+i64 i74 i84
+i61 i72 i81
+i60 o72
+i55 i64 o73
+i49 .3
+i46 i50
+i40 i53
+i40 i52
+i24 i38
+i0g i1a
+c $1 $0 $1
+^z ^i ^r ^t ^a ^e ^b
+^y ^r ^r ^e ^k
+^y ^e ^c ^a ^l
+^u ^l ^a
+^t ^r ^o ^h ^s
+^t ^n ^e ^r ^t
+^s ^r ^e ^k ^a ^l
+^r ^e ^h ^t ^s ^e
+^o ^o
+^o ^e ^t ^a ^m
+^n ^o ^b
+^h ^a ^o ^n
+^g ^u ^o ^d
+^f ^j
+^a ^d ^n ^o ^h
+^0 o16
+] ] $o
+Y3 *96 ,7
+D7 D7 D7
+D3 ] r
+D3 $9 $7
+D3 $5 $8
+$y $h
+$p $e $t
+$9 $6 $9
+$9 $0 $4
+$6 $2 $5
+$1 $@
+$1 $3 $3
+$1 $1 $8
+$. [
+o7u o8m
+o6z ,7
+o5l ]
+o5h $o
+o5d *67
+o55 Z1
+o4o $s
+o4m $1 $2 $3
+o4a $2 $0 $0 $4
+o3t
+o3o o4h
+o3i $3
+o3a o4y
+o2y o3z
+o2u K *43
+o2s $1 $2
+o2i i4s
+o1z o2e
+o1o i3a
+o1l o2u o3e
+o1e o4e
+o1e o2x
+o1e i2s
+o1a i4n
+o0y o1u
+o0s $9 $9
+o0m $a
+o0j *51
+o0j $0 $1
+o0g o5g
+o0e o1p
+o0d o4u
+o0c o4a
+l $j $j
+k +6 r
+i75 D3
+i73 i80
+i71 o86
+i66 D1
+i5l i6a
+i5D l
+i59 o66
+i55 i61 o70
+i54 i60
+i52 i79
+i4t o5o
+i46
+i38 o49
+i33 i30
+c $&
+^y ^t ^a ^p
+^y ^l ^d ^a ^e ^d
+^t ^c ^a
+^s ^a ^d ^i ^d ^a
+^r ^o ^n ^o ^c
+^q ^a
+^p ^e ^e ^j
+^o ^t ^r ^e ^b ^l ^a
+^o ^r ^t ^e ^r
+^o ^o ^f
+^o ^o ^d
+^o ^g ^n ^i ^b
+^o ^g ^a ^i ^h ^t
+^n ^a ^i ^m ^a ^d
+^m ^o ^t T3
+^l ^l ^i ^t ^s
+^k ^l ^i ^m
+^i ^a ^m
+^h ^s ^a ^l ^f
+^g ^j
+^f ^b
+^e ^l ^o ^c
+^e ^i ^k ^o ^o ^c
+^c ^o ^d
+^1 o14
+^1 ^1 ]
+[ i04 ^4
+[ d c
+[ $7 $8
+[ $6 $8
+K i12
+D3 $8 $0
+-5 [ d
+*42 *21
+*14 *30
+$y $z
+$x $D
+$t +7
+$p L6
+$o $s $e
+$k $i $s $s
+$j $v
+$i $s $t
+$h $b
+$d $e $n
+$c $a $n
+$6 $1 $8
+$6 $1 $1
+$5 $0 $0 $0
+$4 $2 $6
+} z2
+} ^1
+o7a +8
+o5o -6
+o5i o6z
+o4e o6e
+o3a ]
+o2z ]
+o2y o3o
+o2v ]
+o2u o4i
+o2j ]
+o2a +4
+o1u i2m
+o1o i4a
+o1i i2t
+o1h ]
+o1e i3i
+o1e i3h
+o0z ^i
+o0t o1i
+o0p $7
+o0l i1j
+o0k $t
+o0j i1i
+o0j +5
+o0g $2 $2
+o0d o1y
+o0c o5a
+o0L $0 $8
+k +3
+i92 iA0 iB0
+i67 i78
+i66 i74
+i63 o74
+i5N l
+i54 i60 o75
+i52 i62 o78
+i38 i35
+i36 o45
+i18 T2
+i0h ]
+c ^2 ^2
+c T5 i5-
+c T4 i4.
+c $5 $0 $0
+^z ^e ^m ^o ^g
+^y ^r ^r ^e ^b
+^y ^r ^o ^r
+^w ^e ^l
+^s ^s ^a ^c
+^s ^i ^l ^e
+^s ^e ^l ^u ^j
+^n ^r ^o ^k
+^m o1i o2s
+^l ^e $o
+^k ^w ^a ^h
+^f D2
+^c ^b
+^a ^i ^c ^u ^l
+[ $9 $0
+[ $7 $1
+Z1 ^A
+D1 $2 $0 $1 $1
+'7 $0
+$n $j
+$d D1
+$8 Y1 D0
+$6 $!
+$5 Z2
+$3 $0 $8
+r $v
+o7T E *21
+o5t o6y
+o5b $d
+o5a o7i
+o4w Z1
+o4o o6a
+o4o +6
+o4n $0
+o4e o5z
+o3u ]
+o3l $1 $2
+o2n o3y
+o2m y3
+o2i D5
+o2a E
+o1u o3z
+o1r D4
+o1p *23
+o1l ]
+o1e i4a
+o1a i3a o5a
+o0v o1a
+o0s o2m
+o0m $3 $2 $1
+o0j *03
+o0g o4o
+o0a i2t
+o0T $1 $2
+o0L D2
+o0B $8 $8
+k t *21
+k $1
+i91 iA0 iB0
+i68 i77
+i67 i77 i87
+i62 i75
+i56 i62
+i4g
+i44 i55 o68
+i41 i50
+i0h i1e
+c $9 $9 $1
+c $7 $8 $9
+c $1 $6
+^y ^n ^o ^b ^e
+^y ^e ^b ^b ^a
+^u ^S
+^t ^l ^a ^s
+^s ^u ^n ^e ^v
+^r ^o ^l ^o ^c
+^r ^e ^i ^p
+^o ^n ^a ^n
+^o ^d ^a
+^o ^E -0
+^l z1
+^e ^s ^o ^r
+^e ^a ^m
+^d ^r ^a ^w ^d ^e
+^c ^g
+^a ^i ^v ^i ^l ^o
+[ i1-
+T0 T7 T6
+D5 $0 $9
+$s $o $n $i $c
+$r $o $1
+$n $i $n $a
+$l $a $u $r $a
+$i $l
+$c $o $d $e
+$O u
+$9 Z3
+} ^4
+y5 o1o
+u i1E
+sa4 u sI1
+o7x .6
+o3o i4k D9
+o35 i40 ,5
+o2y i3n
+o2u -3
+o2a o4a
+o1i o2o
+o1i D4
+o1c o3c
+o0z o2k
+o0z K
+o0l $0 $0
+o0k i1a i2i
+o0f *41
+o0e i1f
+o0d o3o
+o0S $6 $9
+o0B $2 $1
+l $b $e $e
+i89 i99
+i68 i79
+i67 o73
+i66 i75
+i63 o71
+i62 o79
+i61 c
+i5b
+i59 o61 ,7
+i57 o61
+i3f [
+i26 p4
+i0b ^l
+^y ^z ^a ^r ^k
+^y ^l ^r ^a ^c
+^t ^f ^e ^l
+^r ^u ^n
+^r ^e ^t ^u ^p ^m ^o ^c
+^r ^e ^g ^g ^i ^n
+^n ^a ^m ^r ^e ^g
+^i -0 ^l
+^e ^i ^g ^g ^a ^m
+^d ^n ^a ^e ^m
+^a $6
+^U D2
+^9 o19
+^2 ^0 ^1
+[ $9 $6
+T2 T3 T4
+K D4 $3
+K $g
+D4 $9 $0
+D3 $9 $3
+D3 $9 $2
+D2 }
+$n $u
+$k $1 $0
+$e $m $o
+$d $u
+$c $h $r $i $s
+$9 $2 $8
+$9 $0 $1
+$5 $7 $9
+$1 $5 $9 $7 $5 $3
+y2 c $1
+oA5
+o7B c
+o5s Z2
+o5n o6u
+o5c i5u
+o4t o0v
+o4i o5z
+o4h $n
+o40 i52 i60 o73
+o40 i51 i60 o71
+o3o o5o
+o3a *64
+o2y T0
+o2u +3
+o2e r
+o1u o5o
+o1i o5o
+o1e o2z
+o0t o1a
+o0t i1j
+o0l i1e i2o
+o0h *20
+o0d $k
+o0S $6
+o0L $0 $9
+k ^h
+i76 i75
+i58 i61
+i56 i60
+i53 o68
+i53 i71
+i5/
+i46 {
+i46 $7
+i35 i38
+i1_
+c ^1 ^2
+c T7 i7-
+c '7 $8
+^y ^e ^l ^i ^a ^h
+^w ^a ^p
+^t ^s ^u ^d
+^s ^a ^v
+^o ^n ^a ^i ^p
+^i D4
+^d ^r ^a ^h ^c ^i ^r
+K $m
+D4 $9
+D3 $8 $8
+D3 $4 $6
+D3 $1 $0
+'8 $7
+$h $u
+$7 $2 $7
+$5 $0 $1
+z2 -0 y1
+o7S c
+o4y o5g
+o4u $i
+o3e i5l
+o2o D5
+o2i o4u
+o1u $3 $2 $1
+o1s D4
+o1i o3u
+o1a o2y
+o0o i1l
+o0n o2t
+o0k $0 $0
+o0b o1s
+o0b i2k
+o0b *23 *43
+o0a o2a
+o0a ,2
+o0F $1 $2
+o05 r
+k -1
+i71 o83
+i68 -4
+i67 i72
+i54 i71
+i4l i5a
+i45 o56
+i17 i38
+c ^1
+c T2 $1
+^y ^n ^n ^e ^l
+^y ^k ^c ^a ^j
+^y ^d ^o ^l ^e ^m
+^y ^a ^y
+^t ^n ^e ^b
+^t ^i ^t
+^s ^i ^v ^a ^r ^t
+^s ^i ^c ^n ^a ^r ^f
+^s ^b ^a
+^l ^l ^a ^m ^s
+^i ^v ^a ^d
+^i ^m T2
+^e ^t ^a ^h
+^d ^r ^o ^f
+^S D2
+^2 o17
+^0 ^2 ]
+[ $5 $1
+K t ]
+D3 $7 $8
+$7 $0 $2
+$4 $5 $0
+$3 $3 $0
+$2 $2 $7
+u d '8
+t o2X
+sVL E o5v
+o7i -8
+o5A l
+o4o o5j
+o4a *76
+o3k o0v
+o3i o4j
+o2y o3l
+o2w ]
+o2r Z1
+o2e o3x
+o1u o3o
+o1u i3e
+o1o i3k
+o1o i2h
+o1e i3a
+o0u o1k
+o0u ^G
+o0k o4p
+o0k o4j
+o0k i2e
+o0k $0 $2
+o0j i2s
+o0c k
+o06 r
+l $e $s $t
+k ] ^b
+k *52 -1
+i75 i76
+i69 i72
+i64 i74
+i64 i72
+i62 i70 i80 o96
+i56 o68
+i53 i62 o70
+i52 i62 o76
+i47 i54 o61
+i46 o53
+i45 ss0 $0
+i38 i33
+i27 ^3
+i23 i35
+i14 i16
+c $4 $5 $6
+c $1 $9 $7 $8
+^y ^p ^p ^u ^p
+^y ^l ^l ^o ^j
+^x ^u ^l
+^t ^a ^o ^b
+^s ^n ^a
+^s ^i ^s ^i
+^s ^e ^t
+^s ^a ^e ^r ^d ^n ^a
+^r ^u ^t ^r ^a
+^r ^i ^g
+^k ^s ^a
+^e ^c ^u ^r ^b
+^d ^s
+^d ]
+^9 ^8 ^7 ^6 ^5 ^4 ^3 ^2 ^1 ]
+^1 $0
+[ i33
+T5 i5G
+R4 T0 D2
+K D1 $4
+*10 r D3
+*02 *23 *12
+$w $q
+$v $1 $2 $3
+$m $i $l
+$i $p
+$b $t
+$a *21
+$8 $1 $5
+$2 $0 $5
+$1 $5 $6
+o8k o9a
+o6b $o
+o5t o6z
+o5b +7
+o4o o6d
+o45 i50 i60 ,7
+o42 i50 ss0 $7
+o42 i50 sS0 $5
+o42 i50 sS0 $3
+o3t i4y
+o3a o4u
+o35 i45 ,5
+o2d o3y
+o25 i61
+o1y o2u
+o1u i2g
+o1i o6i
+o1i D6
+o1e i4r
+o1c .3
+o1a sbk
+o1a o3k
+o1a o3d
+o1a i3u
+o0w o1i
+o0g o3s
+o0g $s
+o0b i1p
+o0S $0 $7
+o0D D1
+o0B $6 $9
+k K *54
+i73 i80 i90
+i6e oAC sml
+i6e i7l
+i67 i71
+i66 *20
+i63 i70
+i61 i72 i80
+i60 o74
+i47 i55 o64
+i46 o33
+c $9 $9 $6
+^r ^e ^p ^i ^v
+^o ^t ^o ^t
+^o ^l ^b ^a ^i ^d
+^n ^n ^y ^l
+^n ^i ^v ^a ^g
+^n ^h ^o ^j T4
+^h ^c ^s
+^d ^l ^r ^o ^w
+^d ^a ^e ^h
+^b ^g
+^U D4
+[ $n
+[ $6 $2
+T0 o4D
+K *54 *02
+*63 *14
+'7 $2
+$y $2 $2
+$w $o $n
+$m $i $o
+$l $i $n $k
+$j $a $n $e
+$f $u
+$a $l $e
+$8 $2 $8
+$5 $1 $7
+$0 $0 $9
+$. $2
+{ $l
+o7n o8i
+o6$
+o5f +7
+o5a $d
+o4t $1 $2 $3
+o4k i4u
+o4i $s
+o42 i50 sS0 $4
+o40 i51 i62 o73
+o4# o51
+o3u -8
+o3p o5o
+o3a o2y -4
+o2i o4i
+o2i D4
+o2e i3h
+o2a o6a
+o25 z1
+o1o o4a
+o1o o2x
+o1o i3g
+o1e o2j
+o1e *24
+o1e $1 $2
+o1I u
+o0s D7 $1
+o0s $0 $4
+o0k i2a
+o0j o5b
+o0g ,1
+o0f i2a
+o0d *64
+o0d $9 $9
+o0a o2i
+o0K i1a
+o0H $2
+o0F $1 $2 $3
+l ^e ^y ^e
+l $d
+l $b $a $y
+i7f
+i71 o84
+i64 i77
+i63 i70 i80
+i60 o78
+i60 o76
+i5u o6s
+i5d i5e
+i58 ss8 $8
+i57 o63
+i44 o58
+i26 ,3
+i23 i37
+i22 o31
+c ^3 ^2
+c T3 i3_
+c '9 $5
+c $5 $!
+c $2 $0 $0 $4
+^y ^e ^n ^s ^i ^d
+^y ^c ^i ^u ^j
+^x ^a ^j ^a
+^v ^e ^s
+^t ^n ^i ^a ^p
+^s ^e ^c
+^r ^e ^v ^o ^l
+^r ^e ^l ^l ^i ^m
+^r ^a ^n
+^p ^i ^d
+^o ^k ^e ^n
+^o ^i ^r ^a ^d
+^n ^e ^e ^u ^q
+^f ^d
+^e ^l ^l ^e ^h ^c ^i ^m
+^a ^l ^o
+^0 o17
+[ [ [ [ [ c
+[ $a $a
+[ $9 $4
+D4 r
+D3 $9 $5
+D3 $3 $7
+D3 $2
+D2 $8 $8
+D1 $8 $0
+$p $a $d
+$m $o $n $e $y
+$k $a $i
+$5 $1 $6
+$4 $9 $2
+$3 $3 $1
+$1 $8 $0
+} +4 }
+o7t o8o
+o6y c
+o6T c
+o5z o6o
+o5e o7e
+o5a $z
+o4y ]
+o4o $k
+o4e $s
+o40 R5
+o3x o4o
+o2r i3f
+o1o i3o
+o1i $0 $0
+o1e $2 $0 $0 $5
+o0s o1o
+o0q ] r
+o0p D2
+o0l $9 $9
+o0k $5 $5
+o0k $3 $5
+o0j o3o
+o0j o2i
+o0j i3s
+o0j $1 $1
+o0a i2e
+o0a $1 $2
+o0S $2 $1
+o0G $1 $2 $3
+o0D $6
+k o1f
+i70 i80 o97
+i69 i70 ,8
+i63 i71
+i62 i72 i83
+i52 i65 o76
+i48 o54
+i47 o54
+i4-
+i36 i34
+i2t i3h
+i0m i1e i2g
+i0M i1a
+c o69
+c $0 ^0
+^z ^z ^u ^f
+^z ^i ^w
+^y ^e ^n ^t ^r ^u ^o ^c
+^s ^i ^t ^o
+^s ^i ^g
+^s ^a ^s
+^r ^e ^d ^n ^o ^w
+^o ^y ^o ^y
+^o ^n ^i ^g
+^o ^d ^r ^a ^n ^o ^e ^l
+^n ^u ^g
+^n ^a ^m ^o ^r
+^l ^a ^y ^o ^r
+^j ^n
+^g ^o ^r ^f
+^f ^r ^u ^s
+^e D4
+^d ^u ^b
+^c ^p
+^c ^i ^n ^o ^s
+^a ^z ^z ^i ^p
+^a ^f ^l ^a
+^S o1w
+^0 ^0 ^1 o30
+[ $9 $8
+[ $9 $3
+T0 i5x
+K $@ ,7
+D3 $5 $7
+D3 $4 $0
+D2 $3 $9
+D2 $.
+D1 $7 $9
+'8 -2 -0
+$s ^o
+$r $1 $1
+$p $a $s
+$p $1 $2
+$n $t
+$m $v
+$d [
+$9 $9 r
+$5 $.
+$4 $4 $0
+$1 $1 $0 $9
+$/ $/
+t o3G
+skH E
+o8v o9e
+o8i
+o7i o8c
+o71 Y2 *78
+o6i i6v
+o42 i53 i64 o75
+o3o ,4
+o3e o4j
+o2r o4o
+o2r $1 $2
+o2l Z1
+o1e o4a
+o1e i2v
+o1e $3
+o1a $2 $0 $0 $2
+o0v i2l
+o0p o2r
+o0n i1m
+o0m .2
+o0k i4i
+o0k i2i
+o0k $0 $3
+o0h $9 $9
+o0f i4k
+o0e o1z
+o0b o2y
+o0P $1 $0
+o0O $1
+o0K o4a
+o0J D3
+o0B D4
+l $j $o $y
+i8z '9
+i78 i80
+i72 +6
+i68 i72
+i65 i75 i85
+i62 o77
+i58 o65
+i53 i61 o70
+i4o i5n
+i45 o57
+i42 i57
+i38 i34
+i37 i33
+i36 i30
+i26 i36
+i23 *76
+i0m i1a i2g
+c o63
+c $: $)
+c $6 $!
+c $- $1
+^t ^p ^e ^s
+^s ^u ^e ^t ^a ^m
+^s ^k ^c ^a ^j
+^s ^a ^l ^o ^h ^c ^i ^n
+^r ^o ^o ^d
+^r ^e ^i ^v ^a ^x
+^p ^a ^z
+^o ^p ^o ^p
+^o ^k ^o ^l
+^f D4
+^e ^t ^a ^l ^o ^c ^o ^h ^c
+^a ^m ^i ^d
+^a ^g ^l ^o
+^L ^e E
+^2 o18
+^1 ^1 $1 $1
+[ i59
+[ $0 $9
+K D2
+D5 $2
+D3 $7 $0
+D3 $6 $3
+'7 $8
+$z $1 $0
+$r $2 $2
+$i $g
+$h $e $r $e
+$h $e $a $r $t
+$h $d
+$e $h
+$9 r
+$9 $2 $6
+$8 $1 $1
+$7 $1 $5
+$4 $1 $6
+$3 $0 $0
+q Y5 '9
+o8q *67 Z1
+o6x
+o5o $e
+o5J T0
+o4r ,5
+o4a i51 i62 o73
+o4a $f
+o2l o5o
+o2l o4o
+o2e D5
+o2d Z1
+o1y $1
+o1n o2i
+o0z o2m
+o0m i4o
+o0k $9 $9
+o0g *42
+o0g $0 $7
+o0c i3s
+o0c i2a
+o0b o4y
+o0a o2g
+o0P $5
+o0M $2 $4
+o0K $1 $0
+o0J $1 $0
+o0B $7
+o04 r
+l $a $i $r
+i80 [
+i72 o87
+i62 [
+i59 i60
+i4r *54 o4e
+i44 sS4 $4
+i43 i57
+i34 i30
+i20 o37
+i16 i13
+c $9 $9 $3
+c $4 $1
+^u ^y ^r
+^t ^x ^e ^n
+^t ^h ^g ^i ^e
+^n ^o ^i ^l
+^m ^t
+^m ^a ^l
+^j ]
+^h ^t ^i ^e ^k
+^f ^t ^w
+^d ^n ^i ^m
+^J T1
+^F o1l
+^3 ^0 ^3
+[ i3b
+[ $8 $1
+[ $8 $0
+[ $3 $0
+Y2 o1y
+K D7 {
+D4 D4 $1
+D4 $5
+D3 $6 $7
+D3 $6 $4
+D3 $5 $3
+D2 $7 $6
+D1 $7 $5
+$p $a $c $k
+$o $7
+$k $2
+$i $n $o
+$e $b
+$a *30 s/O
+$8 $7 $6
+$8 $1 $6
+$2 $4 $0
+u sS4 $U
+o72 Y2
+o6s +7
+o5_ i61 i72 o83
+o43 i54 i65 o76
+o3o $3 $2 $1
+o1y o2f
+o1y o2a
+o1o D5
+o1i D5
+o1e i3d
+o1a D5
+o0x D3
+o0t o1m
+o0t $9
+o0o i1h
+o0m y3
+o0k $0
+o0e $1
+o0d y3
+o0d i4d
+o0c $3 $2 $1
+o0b *30
+o0M $0 $6
+o0G D5
+o0C D7
+l -5 *24
+i82 o91
+i76 i76
+i72 o86
+i6m o7e
+i66 i70
+i64 i75
+i61 i73 i82
+i54
+i43 i55 o64
+i35 o47
+i33 o41
+i32 i30
+i30 i39
+i19 i36
+i0s $s
+c $9 $7 $4
+c $9 $5 $0
+^y ^z ^z ^i ^d
+^t ^u ^p
+^t ^e ^k ^s ^a ^b
+^t ^a ^r ^b
+^o ^l ^r ^a ^c
+^m ^a ^r
+^l ^r ^a ^k
+^l ^l ^e ^d
+^k ^n ^u ^f
+^i ^n ^u
+^g o1u o2i
+^d ^i ^p ^u ^t ^s
+^a ^h ^s ^a ^s
+^a $5
+^2 ^1 ^1
+K o56
+K *31
+D3 $9 $4
+D3 $7
+D3 $2 $5
+D1 $b
+*13 *04
+$s Z2
+$p $3
+$h $o $p $e
+$e $1
+$9 $4 $9
+$7 $5 $0
+$7 $2 $4
+$4 $5 $4
+$3 $1 $9
+$1 $0 $6 $6
+$! $?
+} } +2
+y4 i4y
+u i2S
+u .3
+o9m
+o7t
+o71
+o5g $s
+o4a i5b o6i
+o40 i53 i60 o75
+o3y o4c
+o3q ]
+o3i o4p
+o3i $5 $5
+o3a o5u
+o2s *05
+o2k $1 $0
+o1y o4i
+o1w ]
+o1w .3
+o1u o3h
+o1k o2y
+o1j D3 ]
+o1i i3k
+o1e i2t
+o13 t
+o0y o1a
+o0u r
+o0t i1w
+o0t i1b
+o0s i1b
+o0p o1u
+o0n i1e
+o0j $1 $2
+o0g $1 $2
+o0c y3
+o0c i3o
+o0b i2o
+o0S $2 $3
+o0M $9 $9
+o0F D1
+o0D $8
+o0C ] Y1
+o0C $6 $9
+o07 r
+l +7 K
+k *13 -5
+i85 i95 iA5
+i79 i80
+i75 i86 i97
+i66 i72
+i61 o75
+i5i i6n i7g
+i58 i73
+i58 i60 o75
+i56 o62
+i56 i62 o76
+i52 i62
+i47 i55 o67
+i42 i55
+i41 i59
+i35 o43
+i24 o39
+i14 i12
+i0q i1w i2e
+c o83
+c $9 $1 $1
+^z ^t ^i ^f
+^y ^w ^e ^h ^c
+^y ^r ^o ^l ^g
+^y ^e ^l ^i ^m
+^u ^p ^m ^o ^c
+^u ^K
+^t ^n ^e ^m ^e ^l ^e
+^t ^i ^h ^w
+^t ^i ^b ^b ^a ^r
+^s ^o ^a ^k
+^s ^j ^a
+^s ^i ^a ^h ^t
+^s ^a ^f
+^r ^e ^k ^o ^p
+^r ^e ^g ^n ^a ^d
+^r ^a ^l ^o ^s
+^n ^i ^v ^e ^d
+^n ^e ^r ^r ^a ^d
+^n ^a ^y ^r ^b
+^l ^u ^a ^r
+^l ^r
+^k o1i o2r
+^i ^a ^k
+^e ^n ^a ^j
+^d ^u ^o ^l ^c
+^a ^s ^s ^i ^l ^e ^m
+^a ^i ^l ^i ^m ^a ^f
+^a ^i ^c ^i ^l ^a
+^a ] r
+^W o1i
+^3 ]
+^1 ^1 ^9
+[ i53
+[ i3d
+[ $6 $5
+Y2 ,6
+T8
+E ^8
+D7 $1
+D4 $9 $8
+D3 $6 $0
+D1 $4 $8
+$x $9
+$p $a $c
+$l $e $o $n
+$i $t $o
+$d $a $r $k
+$b $r $o $w $n
+$_ $0 $1
+$5 $5 $0
+$4 $7 $1 $1
+$2 $@
+$1 $2 $3 $!
+o7u sL?
+o5p $a
+o4y o5b
+o4i $i
+o41 i52 i63 o70
+o40 i53 i60 o76
+o3y o5o
+o3y o4t
+o3d Z1
+o2y
+o1u i4l
+o1p D4
+o1o $2 $0 $0 $5
+o1e $2
+o1a $1 $2
+o0p $0 $9
+o0l i3i
+o0l i2o
+o0j o4i
+o0i o1p
+o0h ,5
+o0f *30
+o0R $1 $2
+i73 D1
+i68 i71
+i68 i70
+i63 i75
+i62 o78
+i59 o67
+i59 o64
+i59 o62
+i53 o67
+i53 i61 o72
+i4m i5e
+i47 o53
+i46 i36
+i43 o59
+i19 i10
+i11 i22 o33
+i01
+c i67
+c $8 $!
+c $1 $1 $!
+^z ^a ^i ^d
+^y o1z
+^y ^e ^n ^t ^i ^r ^b
+^x ^e ^l ^f
+^v ^e ^r ^t
+^u ^h ^t
+^t ^u ^o ^c ^s
+^t ^h ^g ^i ^r ^b
+^s ^e ^p
+^s ^e ^n ^o ^b
+^s ^e ^m ^a ^g
+^s ^d ^a
+^p ^m ^a ^l
+^p ^e ^d
+^o ^n ^r ^o ^p
+^o ^m ^e ^n
+^o ^k ^r ^a ^m
+^n ^o ^s
+^n ^e ^v ^a ^r
+^l ^l ^u ^b
+^k ^a ^e ^r ^f
+^e ^d ^o ^c
+^a z2
+^a ^e ^l
+^a *31
+^9 ^1 ^6
+^5 o10
+^2 ^1 o63 o74
+^1 ^2 ]
+[ i21
+[ $7 $0
+Z2 $2
+$x D5 t
+$w $a $g
+$n $e $r
+$k D5
+$d $a
+$_
+$9 $6 $7
+$9 $1 $8
+$7 Z3
+$4 $.
+$2 r
+$2 $4 $5
+$1 $3 $4
+u o4Z
+o5i +6
+o5a o7a
+o4y $3
+o4t Z1
+o4r $i
+o3t o4v
+o3i $k
+o3a $k
+o3a $5 $5
+o2i o5i
+o1o i3e
+o1e D5
+o1a D4
+o0s o1u
+o0n o1e
+o0j Y2
+o0i D2
+o0g $9 $9
+o0f i4a
+o0f i3i
+o0a o2t
+o0M o2d
+o0D D3
+o09 r
+i82 o90
+i79 i89
+i64 i71
+i5i o6n
+i5e o6k
+i59 i67
+i56 o61 o76
+i56 i61 o79
+i4i o5n
+i4G Z1 ,4
+i43 i56 o64
+i39 o46
+c i79
+c i5#
+^y ^g ^g ^o ^d
+^w ^a ^h ^s
+^u ^R
+^t ^n ^u ^a
+^s ^e ^n ^g ^a
+^r ^t ^s
+^p ^i ^z
+^o ^g ^a ^i ^t
+^n ^a ^h ^c
+^k o1i
+^k o1a o2r
+^e ^l ^a ^d
+^e ^h ^t ^m ^a ^i
+^d ^n ^i ^l ^b
+^a ^l ^l ^i ^v
+^a ^b ^b ^u ^b
+^a $3
+[ i39
+[ c $!
+[ $a
+[ $6 $0
+Y1 iA4 c
+T0 o2M
+K D5 $2
+D8 c
+D2 $8 $9
+*56 *12 p3
+*50 *23 *14
+$s $a $d
+$n $o $t
+$f $d
+$d $u $c $k
+$a $u
+$9 $4 $0
+$7 $2 $0
+$5 $0 $2
+$2 $2 $6
+$1 $3 $7
+$1 $3 $2
+y2 E
+u $2 $0 $0 $1
+s1w Y1
+o3i $9 $9
+o2m u
+o1y D4
+o1i o3a
+o0w D2
+o0t $1 $3
+o0r o1a
+o0o ^n
+o0n o2s
+o0l $0 $2
+o0k o6r
+o0j o4o
+o0j o2z
+o0j $3 $3
+o0h o5i
+o0h i1s
+o0g *43
+o0f y2
+o0S $1 $3
+o0D $5
+i57 i60
+i56 i61 o72
+i54 o67
+i54 i65 o76
+i54 D1
+i43 i55 o68
+i18 i04
+d [
+c $2 $0 $0 $2
+c $1 $9 $9 $7
+c $1 $9 $7 $7
+^y ^e ^l
+^y ^a ^d ^n ^e ^e ^r ^g
+^x ^x ^a ^m
+^v ^i ^v
+^t ^r ^m
+^s ^e ^i ^r ^a
+^r ^d ^a
+^p ^i ^v
+^n ^e ^m
+^l ^o ^c
+^l ^a ^s
+^k ^o
+^j o1o i2n
+^i ^m ]
+^i ^k ^a
+^i ]
+^d ^o ^p ^i
+^d ^a ^h ^c
+^d K
+^3 ^2 ^1 D7
+[ *43 r
+[ $6 $4
+[ $6 $1
+T0 T3 T7
+D4 $8 $8
+D3 $5 $9
+D2 $8 $4
+D2 $8 $3
+D2 $5 $8
+-0 o17
+$z $1 $1
+$r $4
+$p *04
+$e $m $m $a
+$e $g
+$b $o $s $s
+$N '6 ^m
+$9 $4 $4
+$6 $6 $5
+$5 $5 $6
+$5 $3 $0
+$4 r
+$3 $1 $8
+$3 $0 $6
+{ $a
+o5y o6o
+o5o $a
+o4i o5u
+o40 i56 i60 o72
+o2v o4s
+o25 r
+o1u D5
+o1o o3e
+o1e o5a
+o1e o3g
+o1e Z1
+o0w o1o
+o0t o1u
+o0l ,1
+o0l $2 $2
+o0k i2m
+o0g i3s
+o0d i1u
+o0a o1y
+o0R $1 $0
+l o6g o7o
+l $j $1
+l $2 $0 $0 $3
+i64 o79
+i64 i70
+i5m o6e
+i54 i62 o70
+i52 i74
+i4u s5y
+i35 o42
+i30 i33
+i23
+c o14
+^z ^i ^n ^e ^d
+^y ^m ^a ^s
+^y ^l ^l ^e ^m ^s
+^y ^k ^s c
+^x ^o ^r
+^t ^s ^u ^r ^t
+^t ^o ^i ^r
+^r ^i ^a ^h
+^o ^g ^s ^t ^e ^l
+^m ^o ^o ^b
+^i ^g ^i ^d
+^f ^l ^a
+^e o1v
+^e ^v ^i ^f
+^e ^r ^o ^c ^d ^r ^a ^h
+^e ^l ^c ^n ^u
+^a ^c ^i ^l ^l ^a ^t ^e ^m
+^8 ]
+^1 ^6
+^0 ^2 ^1
+[ $5 $3
+K o25
+D4 $0 $9
+D3 o33 [
+D1 i03 *21
+D1 $?
+D1 $8 $4
+-0 $a
+$p *42
+$b $p
+$b $i $l $l
+$b $a $d
+$a $l $i
+$9 $4 $6
+$7 $0 $1
+$6 $1 $3
+$6 $0 $5
+$3 $7 $9
+$1 $0 $2
+} ^f
+o7i ]
+o5z Z1
+o46 $6 $6
+o41 i52 i61 o73
+o3c $1 $2
+o31 i41 ,5
+o2z o4a
+o2z i3z i4a
+o2r +3
+o2i o3j
+o2d t
+o1y r
+o1u o3u
+o1u o2i
+o1s o2w
+o1a o4a
+o0t o1e
+o0m ,2
+o0l i3e
+o0j i3e
+o0i o3a
+o0c +7
+o0a o3a
+o0D $1 $3
+l $i $v
+l $0 $4 $0 $5
+k i0b
+k ^e
+k *34 -1
+i79 i78
+i78 i72
+i74 i72
+i6a i7k
+i69 i71
+i5s [
+i5e i6n
+i59 i68
+i55 y1 *73
+i54 *31
+i52 i76
+i52 i65 o70
+i44 i53
+i35 i37
+i30 i38
+c ^5
+c $2 $0 $0 $3
+c $1 $8
+^z ^e ^p
+^y ^t ^u ^a ^e ^b
+^s ^u ^i ^n ^e ^g
+^s ^u ^a ^m
+^r ^e ^p ^i ^n ^s
+^n o1i i2k
+^m ^o ^d ^n ^a ^r
+^m ^a ^s T3
+^l $1
+^e ^u ^r ^t
+^c o1h ]
+^a ^g ^e ^m ^o
+^a ^c ^n ^a ^i ^b
+^T $1
+^P D3
+^7 ^4 ^2
+^0 ^6 ^3
+^0 ^0 ^0 ^1
+L6 L7
+K $3
+D4 o4@ s9R
+D4 $1
+D3 $9 $9
+D2 $7 $8
+D0 $3
+$m $i $n $e
+$k $y
+$N u
+$9 $3 $7
+$5 $a
+$4 $1 $7
+$3 $0 $4
+snX c
+r +1 y2
+o8a $s
+o78 o0L
+o4o K
+o41 i59 i60 o73
+o3y ]
+o3i $2 $0 $0 $4
+o2z i3a
+o2l o3z
+o2k $1 $2
+o1r
+o1p o2w [
+o1o o4i
+o1o ^A
+o1o $1 $2
+o1i $3
+o1g i0e
+o1e o5e
+o1a o3c
+o1K k
+o0x o1i
+o0v D2
+o0r ^o
+o0p o1r i2e
+o0n i1a
+o0k *46
+o0j o3h
+o0j i2e
+o0f i3a
+o0f $2 $1
+o0e $1 $0
+o0c o5i
+o0c o4o
+o0a i2m
+o0a i2c
+l $s $e $x $y
+l $h $1
+i7c l
+i76 o87
+i71 o88
+i70 R6 L6
+i60 o73
+i5d o6e
+i58 i61 o76
+i55 o62
+i54 o68
+i4d i5a
+i48 o56
+i47 ss8 $9
+i41 i58
+i4. o51
+i38 o45
+i32 i40
+i13 i10
+c $9 $9 $4
+c $0 $6
+^y ^k ^a ^e ^r ^f
+^y ^b ^b ^u ^h ^c
+^x i1d
+^t ^s ^u ^m
+^t ^s ^a ^p
+^t ^o ^p ^s
+^s ^o ^s
+^p ^e ^s
+^o ^d ^n ^u ^m
+^o ^b ^m ^i ^j
+^o D4
+^n ^e ^z
+^l ^o ^o ^p ^r ^e ^v ^i ^l
+^i ^s
+^d D4
+^P *21
+^2 ^2 ]
+^0 ^1 ^2
+[ o0M
+[ $4 $7
+D3 o3x
+D3 $6 $8
+D3 $4 $8
+D1 o1-
+'6 ^2
+$m $a $s
+$l $o $u
+$a $s $h
+$a $e
+$9 $0 $5
+$4 $2 $8
+$4 $$
+$2 $5 $7
+$1 $9 $4 $7
+$0 $2 $1 $0
+$. $7
+} ^i
+u i6_
+t o0Y
+ssx c
+o7r o8o
+o60 Y2
+o5a $y
+o4z o51
+o4o $i
+o4m $i
+o3z $1 $0
+o3p Z1
+o3p *35
+o3i $2 $0 $0 $3
+o2y o4a
+o2s
+o2m Y1
+o1o o4e
+o1o D4
+o1i i4r
+o1e i2w
+o1a i3h
+o0p $8
+o0o r
+o0h $h
+o0f +7
+o0d o3y
+o0d o2y
+o0P $1 $2
+o0K $4
+o08 r
+l $w $1
+i87 i97 iA7
+i78 ,8
+i70 i80 i91
+i65 +8 .5
+i62 o70 ,8
+i61 o74
+i59 i61
+i53 i63 o74
+i46 i52 o67
+i45 o59
+i37 o43
+i11 D5
+i0s i1a
+c $9 $9 $8
+^z ^e ^r ^e ^p
+^y ^t ^r ^e ^b ^i ^l
+^t ^r ^e ^w
+^t ^o ^o ^b
+^t ^n ^u ^o ^m
+^r ^o ^v ^e ^r ^t
+^o ^l ^o ^c
+^n ^i ^l ^r ^e ^b
+^n ^a ^d ^i ^a
+^m ^a ^h
+^m $2
+^l ^e ^c ^r ^a ^m
+^l ^a ^b
+^a ^v ^o ^n
+^3 ^2 ^1 D6
+[ k y1
+Y1 o0S
+E D6 ]
+D4 D5
+D4 $6 $6
+D3 $9
+$w $a $s
+$v $n
+$t $o $y
+$m r
+$a -6
+$8 Z3
+$5 $0 $8
+$2 $8 $9
+$0 $!
+s10 Z3
+o9i iAn oBg
+o8n
+o5i *57
+o5g $y p4
+o5Z c
+o3k $k
+o2y *24
+o2s o3g
+o2r o4z
+o1r o2p
+o1i o3d
+o1a i4d
+o0z i1h
+o0s o2b
+o0p D3
+o0m $7 $7 $7
+o0k -4
+o0j ,3
+o0e $2
+o0L $4
+o0D o51
+o0C D3
+o0B $4
+i89 o90
+i72 i82 i92
+i71 o80
+i71 i82 i92
+i6w
+i6b
+i6a o5r
+i67 *02
+i62 -5
+i61 i71 i80
+i57 i60 o72
+i55 D2
+i51 ss0 $1
+i51 i74
+i4k [
+i4h D0
+i48 o55
+i46 o54
+i45 i54 o67
+i44 Z1
+i43 i54 o66
+i3i i4s
+i37 o40
+i36 i33
+c T4 $4
+c $9 $7 $5
+^y ^t ^i ^n ^i ^r ^t
+^y ^l ^r ^u ^c
+^y ^e ^k ^r ^u ^t
+^t $1 $2 $3
+^s ^r ^a ^w ^r ^a ^t ^s
+^s ^i ^o ^l
+^s ^e ^k
+^p ^i ^l ^i ^f
+^p ^i ^k
+^o ^l ^i ^m ^a ^c
+^o ^l ^i ^f
+^o ^e ^r ^o
+^n ^a ^m ^u ^h
+^n ^a ^m ^t ^a ^b
+^j ^e ^h
+^d D3
+^a ^t ^i ^n ^a
+^a ^r ^a ^l ^c
+^a ^l ^a ^l
+^0 ^1 ^1
+[ o01 r
+[ $4 $4
+K o39
+D7 +A T0
+D5 ^c
+D2 $9 $8
+D2 $4 $2
+D1 $6 $6 $6
+'8 $2
+$s $a $s $h $a
+$k s"a c
+$k $i $n
+$j $a $d $e
+$f $x
+$b $i $r $d
+$9 ^8
+$9 $2 $2
+$9 $0 $3
+$8 $9 $1
+$6 $1 $7
+$4 $y $o $u
+$3 $2 $9
+$2 $3 $0
+$0 $.
+$. $5
+$. $1 $2
+$# $3
+sKL '5 Z3
+o8P l
+o4r $1 $2 $3
+o4m $a
+o3t ]
+o3o o4z
+o3d
+o2u o4u
+o1z ]
+o1y o4a
+o1i i5r
+o1i i1S D0
+o1e o5l
+o1e o5k
+o0w i2l
+o0w ]
+o0o *01
+o0n o1u
+o0m i3u
+o0l i2h
+o0j $9 $9
+o0i ]
+o0d o4z
+o0d $4 $5
+o0c i2i
+o0a i2s
+o0M D6
+o0M $3
+o0J D5
+o0H D4
+o0H $0
+o0A D2
+o0A $4
+i7i o8s
+i77 ,8 ,9
+i72 o80 i90 ,A
+i6k o7a
+i6a
+i66 o51
+i62 i74
+i61 i71
+i5d i6a
+i59 o68 o77
+i53 o69
+i53 i65 o70
+i4s i5t
+i45 o33
+i44 i55 o67
+i3t o4h
+i39 o47
+i33 i37
+i33 i34
+i0s i1h
+i0f i1r i2a
+c '9 $3
+c $e $r
+c $9 $7 $7
+c $1 $8 $7
+^y ^r ^e ^v ^e
+^y ^e ^l ^i ^m ^s
+^s ^s ^e ^n ^k ^r ^a ^d
+^s ^m ^c
+^s ^l ^i ^v ^e ^d
+^p ^o ^k
+^o ^v ^a ^r ^b
+^n ^e ^l
+^l ^r ^i ^g
+^l ,4
+^j o1o o2e
+^j ^p
+^d ^a ^d
+^a ^l ^l ^e ^t ^s
+^a ^i ^b
+^9 ^9 $9 $9
+^8 o18
+[ o0w +2
+[ D1
+Z1 i4e E
+T0 o5T
+D3 $9 $8
+D3 $7 $2
+D2 $8 $5
+$x $t
+$u $o
+$n
+$Y u [
+$1 $9 $5 $2
+$1 $1 $9
+$1 $1 $6
+$1 $0 $0 $1
+$- $2
+p4 o7T E
+o7c *76
+o65 Y2
+o65
+o5#
+o4y *64
+o4u -5
+o4l $1 $2 $3
+o4k $a
+o4d $1 $2 $3
+o45 i54 i63 i72 o81
+o3u o5u
+o3i o4z
+o3a $4 $5
+o3a $2 $0 $0 $4
+o2o o5o
+o2i $1 $2
+o1r ]
+o1i o5u
+o1i i3g
+o1h o2y
+o1a i4b
+o0z o2l
+o0w D4
+o0t $0 $6
+o0r $7
+o0q D2
+o0m *57
+o0k i1e i2r
+o0g i3i
+o0g i2t
+o0g i2s
+o0g +6
+o0f -7
+o0e o4e
+o0P $2 $3
+o0K o1u
+l ^e ^l ^e ^t
+l $9
+i7u o8s
+i72 o80 i90 oA6
+i6h Z1
+i69 i77
+i63 i73
+i62 i70 i80 i91
+i5u i6s
+i5t o6h
+i58 i67 o76
+i57 p5 -6
+i57 i61 ,7
+i4i o5e
+i46 $3
+i44 i56 o69
+i44 i52 o66
+i41 i56
+i38 o40
+i36 k
+i34 o47
+i3/
+i0v i1i
+i0j i1e
+c i65
+^y ^l ^e ^n ^o ^l
+^t ^r ^e ^m
+^s ^u ^o ^m ^a ^f
+^p ^m ^e ^t
+^o ^r ^g ^e ^n
+^n ^w ^o ^d
+^n ^a ^l
+^m ^e ^n ^i ^m ^e
+^l ^o ^p
+^b ^u ^d
+^a ^r ^a ^b ^r ^a ^b
+^T -1
+^6 o19
+^4 D2
+^2 ^2 $2 $2
+[ $a r
+[ $2 $7
+[ $1 $0
+D3 $5 $5
+D3 $5 $0
+D3 $3 $0
+D1 o1f D3
+D1 $.
+*74 *65
+$x $1 $1
+$r $8
+$k $e $y
+$e $x
+$b $a $c $k
+$9 $3 $9
+$8 $9 $8
+$5 $2 $7
+$4 $2 $7
+$2 $5 $8 $0
+$1 i7_
+$1 $9 $0
+$1 $1 $5
+$1 $1 $2 $2
+$1 $0 $3
+{ Z3
+u $2 $0 $0 $2
+u $1 $2 $3 $4 $5
+o8t
+o7j
+o5r $y
+o5a +6
+o4k $i
+o4h ,5
+o48 i58 ss8 $8
+o3o $k
+o2z +3
+o1u o4u
+o1u i3t
+o1o o3u
+o1f *31
+o0z D4
+o0o o1k
+o0n o2d
+o0k i3j
+o0j i2p
+o0h o4o
+o0e o1y
+o0c o2z
+o0c ]
+o0a o2e
+o0T $2
+o0T $1 $2 $3
+o0B $3
+l $c $u
+i73 o80
+i71 *04
+i65 $5
+i5J l
+i58 .4
+i52 i64 o77
+i4e i5n
+i46 ss6 $6
+i46 o58
+i44 ss5 $6
+i43 i56 o65
+i38 o41
+i37 o44
+i33 ss3 $3
+c ^6 $6
+c $@ $1
+^z ^o ^l
+^y ^l ^l ^i ^m
+^y ^e ^r ^d ^n ^a
+^t ^i ^r ^i ^p ^s
+^t ^e ^h ^c
+^s ^o ^i ^d
+^s ^i ^n ^a ^j
+^s ^e ^r ^a
+^s ^a ^y
+^o ^r ^i ^m
+^o ^n ^i ^n
+^o ^g ^i ^d ^n ^i
+^o ^d ^r ^o ^g
+^o ^c ^s ^i ^c ^n ^a ^r ^f
+^n ^a ^r ^e ^i ^k
+^n ^a ^i ^b ^a ^f
+^l ^a ^r ^e ^n ^e ^g
+^j ^r
+^e ^s ^i ^u ^o ^l
+^d i0l
+^a ^s ^s ^e ^n ^a ^v
+^a ^r ^a ^c
+^a ^l ^u ^a ^p
+^a ^l ^e ^i ^n ^a ^d
+^5 ^4 ^3
+^4 $2
+^1 ^1 ^1
+] o7v
+[ [ $7
+T0 o1K D2
+K D2 D3
+D4 $4
+D4 $0 $8
+D2 $5 $4
+D2 $0 $9
+D1 $6 $9
+$y $1 $2 $3 $4 $5
+$s $i $r
+$r $u $i $z
+$r $i $m
+$o $m $i
+$l $o $l $a
+$k +3
+$a $d $a $m
+$7 $2 $9
+$7 $1 $6
+$5 $1 $9
+$2 $3 $7
+$2 $1 $2
+$1 $1 $0 $8
+$1 $1 $0 $7
+} ] ^d
+y1 ^E
+o40 i55 i60 o72
+o3y o4m
+o3y o4b
+o3r $1 $2
+o3m $4
+o2v $0
+o1u i2p
+o1u i2k
+o1o i2s
+o1n
+o1i o4i
+o1i i2c
+o1e i3u
+o1a *03
+o0z i1i
+o0s $1 $0
+o0q o1u
+o0j $r
+o0j $0 $2
+o0f $0 $2
+o0c +2
+o0b i3i
+o0P $4
+o0M $2 $2
+o0M $0 $5
+o0L $8 $8
+o0J D4
+o0H $1 $0
+i7m i8a i9n
+i76 i80
+i75 $8
+i72 i76
+i71 [
+i6l o7a
+i65 i72
+i57 o68 o79
+i55 i66 o75
+i54 i60 ,7
+i51 i76
+i47 ss7 $7
+i47 i53 o67
+i44 o50
+i43 i58 o65
+i41 o53
+i39 o42
+i26 o35
+i18 i39
+i0r i1a
+c sa@ +9
+c $8 $8 $8
+^y ^s ^s ^a ^s
+^v ^c ^x ^z
+^v ^a ^n
+^u ^D
+^s ^s ^a ^d ^a ^b
+^s ^r ^a ^e ^b
+^o ^y ^k
+^o ^p ^a ^c
+^o ^m ^i ^t
+^o ^c ^a ^r ^d
+^o ^b ^m ^a ^r
+^o $o
+^n ^o ^s ^m ^i ^r ^c
+^n ^e ^v ^s
+^n ^e ^l ^l ^e
+^m ^i ^r ^g
+^l ^e ^i ^r ^a
+^j ^l
+^i ^v ^a ^j
+^i ^r ^e
+^i ^b ^i ^b
+^c o1h
+^P D2
+^1 ^2 ^3 r
+[ [ $1
+[ D4
+R4
+K +1
+D5 D6
+D4 ^c
+D3 t
+D3 $6 $2
+D3 $5 $4
+D3 $5 $2
+D3 $3 $6
+D1 $8 $3
+D1 $7 $8
+'8 i02
+$o $r $i
+$o $c $a
+$i $r $a
+$7 r
+$2 $0 $7
+$1 $5 $3
+$0 $8 $0 $9
+$0 $1 $3
+u $3 $3 $3
+t o2_
+o7I ] c
+o6r $s
+o52 i60 sS0 $3
+o4u i51 i62 o73
+o45 i50 i65 o70
+o30
+o3$
+o2l t
+o2i i4a
+o2i ]
+o2e ]
+o2a $1 $2
+o1z o2h
+o1y o4k
+o1e o4s
+o0z o1y
+o0z D2
+o0s o1h
+o0r i1g
+o0p o1h
+o0p *40
+o0n o1f
+o0j y3
+o0g o4z
+o0g $0 $2
+o0_ s_p +3
+o0T D3
+o0M $0 $7
+o0J $2
+l $2 $0 $0 $2
+k i48
+i83 i92 iA1
+i7s T0
+i7g
+i79 -3
+i73 i84 i95
+i67 i70
+i65 $4
+i64 o73
+i62 i70 ,8 ,9
+i61 ,7
+i5l o6a
+i53
+i52 ss2 $2
+i51 i65 o79
+i51 i62 i73
+i51 i61 o77
+i47 i57 o68
+i47 i54 o67
+i44 i54 o65
+i42 i54
+i36 i39
+i35 ^8
+i15 i12
+i14 i17
+c T4 -4
+^y ^b ^b ^i ^l
+^w ^o ^d
+^v ^i ^h ^s
+^v ^a ^r ^t
+^u ^a ^n
+^t ^p ^c
+^s ^r ^a ^e ^g
+^s ^i ^t ^r ^u ^c
+^s ^i ^c
+^r ^e ^s ^o ^l
+^r ^e ^g ^d ^a ^b
+^o ^h ^s
+^m ^r ^o ^t ^s
+^l +1
+^k ^h
+^i ^l ^a ^k
+^g D3 +2
+^e ^t ^n ^a ^d
+^a ^t ^s ^a ^r
+^P D4
+^5 ^5 ^0
+^5 ^2 ^1
+^4 o15
+^0 ^0 ^3
+[ i63
+[ i3p
+[ $5 $0
+Y2 +6
+K o5d
+D7 o71
+D5 $7
+D3 $3 $8
+D3 $1 $7
+D1 i33
+D1 D4
++1 +3 -0
+$s $h $e $e $p
+$f $r $o $g
+$4 ^1
+$4 $0 $6
+$1 $0 $9
+u i4Y
+o7x
+o5r Z1
+o4x o5o
+o42 i50 i61 o73
+o40 i50 i60 ,7
+o3a $2 $0 $0 $1
+o2y D5
+o2x *14
+o2x $1
+o2m $1 $2
+o2d $1 $2
+o1y o2z
+o1u o6u
+o1u i3a
+o1i o4k
+o1e o4i
+o1c
+o0v o2k
+o0n i1i
+o0k o5y
+o0f $2 $2
+o0d $0 $3
+o0L $0 $7
+o0G $2
+o0F D2
+o0D $0 $9
+o0+
+l $i $n $e
+i80 ,9
+i70 o81
+i6e o7r
+i6_ -7
+i62 i77
+i62 i73 i82
+i62 i71 i81
+i5r
+i5d [
+i59 i68 o77
+i52 c
+i51 i60 o75
+i50 i60 o77
+i4u o5s
+i4r [
+i4m i5a
+i47 o56
+i47 o55
+i47 i55 o63
+i45 o58
+i45 i56
+i43 i58 o67
+i36 o42
+i19 i37
+i19 i15
+i0b D5
+c $?
+c $7 T3
+c $4 $l $i $f $e
+^y ^l ^f ^r ^e ^t ^t ^u ^b
+^t ^s ^e ^b ^e ^h ^t
+^s ^u ^i ^r ^a ^m
+^s ^n ^a ^d
+^s ^d ^e ^r
+^s ^b ^o ^b
+^s $1 $2 $3
+^p ^m ^i
+^o ^r ^u ^a ^m
+^o ^r ^a ^v ^l ^a
+^o ^g ^n ^i ^r
+^o ^g ^e
+^n ^o ^s ^i ^d ^a ^m
+^n ^i ^f
+^n ^e ^h ^p ^e ^t ^s
+^m ^l ^i ^f
+^l ^i ^w
+^l ^a ^t ^o ^t
+^i ^d ^u ^a
+^g o1i
+^g ^h
+^e ^s ^u ^m
+^a ^t ^a ^d
+^a ^l ^l ^i ^k
+^3 o16
+[ $9 [
+Z2 o0P
+D6 $2
+D5 *41
+D4 $5 $6
+D4 $4 $4
+D4 $2
+D3 $1 $6
+D2 ^6
+D2 $1 $0
+D1 $8 $9
+D1 $5 $8
+@i D1 Z1
++1 o0f
+$o $u $r
+$i $l $y
+$d $i
+$9 $4 $2
+$9 $3 $0
+$9 $1 $3
+$6 $2 $3
+$4 $8 $6
+$4 $2 $2
+$2 $3 $2
+$1 $2 $2 $1
+$1 $0 $5
+$1 $0 $3 $1
+$1 $0 $2 $3
+y4 *32
+o5y $a
+o5i $i
+o5e Z1
+o5a -6
+o4b $a
+o3u -4
+o2h o4i
+o2e Z1
+o2a ]
+o1o $l
+o1i ]
+o1e o3z
+o0z D5
+o0v D3
+o0r o2p
+o0r i1a
+o0p $3
+o0n o1a
+o0k i3o
+o0k *35
+o0i o2i
+o0c -7
+o0c -2
+o0S $0 $6
+o0S $0 $5
+l $g $a $r $c $i $a
+i82 i91 iA2
+i74 o85
+i62 o73
+i5d o6a
+i58 i61 o78
+i55 i60 o71
+i53 i63 o75
+i52
+i4l o5a
+i45 i58 o66
+i44 ss2 $0
+i42 i59
+i34 i39
+i33 o49
+i32 i39
+i21 i32 i43
+i11 i32 o53
+i0B
+c '9 $1
+c $9 $9 $5
+c $9 $5 $1
+c $3 $6 $9
+c $0 $1 $!
+^y ^r ^r ^e ^b ^w ^a ^r ^t ^s
+^y ^o ^r ^e ^l
+^y ^o ^b ^t ^a ^f
+^y ^o ^b ^g ^i ^b
+^v z1
+^t ^n ^a ^h ^p ^e ^l ^e
+^t ^e ^k
+^r ^i ^a ^f
+^n ^o ^t ^s ^o ^b
+^l ^a ^m ^i ^n ^a
+^k ^c ^i ^r
+^i ^v ^e ^l
+^i ^l ^o
+^h ^c ^t ^i ^b
+^b ^s
+^a -6
+^3 o17
+^0 o13
+[ i45
+[ $4 $2
+[ $1 $7
+T0 o3L
+E +7 $2
+D4 $2 $7
+D3 $6 $6
+D3 $6 $1
+D2 $4 $9
+D1 D5
+$p $i $a
+$o $m $e
+$o $9
+$l -5
+$9 $2 $4
+$8 $1 $3
+$7 $5 $7
+$5 $8 $9
+$4 $0 $7
+$2 $2 $3
+$1 $3 $1 $4
+u $5 $5 $5
+r $e $e
+o81 i92 iA3 iB4 iC5 oD6
+o6G c
+o62
+o5f *67
+o4o $a
+o42 i52 ,6
+o41 i50 i61 o73
+o3y $1 $0
+o3s i4w
+o3k $1 $2 $3
+o2p o4a
+o2p $1 $2
+o1y E
+o1u $1 $2
+o1o u
+o1o o4k
+o1k D3 ]
+o1i o3h
+o1i o3g
+o1i i4o
+o1i $2 $0 $0 $1
+o1a i2v
+o0z D1
+o0v o2c
+o0t o2k
+o0n o2c
+o0m i4z
+o0m i4y
+o0l $1 $2 $3
+o0b .3
+o0H D1
+o0A D3
+l $p $o $o
+i72 i75
+i65 i75
+i5n [
+i57 i62 o77
+i55 r
+i55 i61 o72
+i51 i75
+i51 i60 o79
+i44 i57 o68
+i43 i54 ,6
+i42 i51
+i3v [
+i38 o44
+i35 i76
+i35 i44
+i2f ,3
+i24 i34
+i24 ,3
+i17 i39
+c i6#
+^y ^h ^c
+^y ^g ^r ^e ^n ^e
+^y ^e ^c ^a ^t ^s
+^s ^r ^a ^t ^s
+^r i0D
+^r ^u ^o ^s
+^r ^a ^v
+^r ^a ^m ^a
+^p ^a ^s
+^o ^t ^r ^e ^b ^o ^r
+^o ^r ^y ^p
+^o ^o ^t
+^o ^i ^l
+^o ^R
+^n ^u ^r
+^i ^r ^d ^a
+^g ^n ^i ^v ^o ^l
+^e ^v ^o ^l ^y ^m
+^e ^r ^u ^p
+^d ^r
+^c ^e
+^a ^r ^i ^k
+^a D4
+^8 ^6 ^4 ^2
+^2 o19
+D3 $0 $8
+D2 $7 $9
+D2 $7 $4
+'A $1
+$p *34 i9d
+$m $a $t $e
+$i $s $h
+$c $l $a $n
+$b $l $o $o $d
+$b $l
+$_ $6 $9
+$9 $1 $9
+$9 $0 $6
+$7 $2 $5
+$4 $1 $4
+$4 $0 $5
+$4 $0 $2
+$3 $4 $3
+$2 $3 $2 $3
+u Y1 $4
+sdn E
+o7t ,8
+o7s o8a
+o7e $e
+o7a $r
+o6a
+o5y o6k
+o4a $i
+o3p $1 $2
+o39 i49 ,5
+o2z $0
+o2e o5o
+o1u i3d
+o1e o4n
+o0r o1c
+o0o o1d
+o0k o3y
+o0g i4a
+o0g i3c
+o0d i3o
+o0c i5a
+o0K $5
+o0C $2 $3
+o0B $1 $5
+i81 o93
+i7i o8n o9g
+i78 o80
+i78 i89 i90
+i63 ,7
+i62 i72 i81
+i60 i79
+i52 o64 i76 o88
+i4o o5n
+i49 i57 o64
+i47 o59
+i43 *02
+i36 o43
+i34 o40
+i33 o42
+i17 i35
+i16 i38
+i0a i1l i2a
+c ^1 ^0
+^z ^z ^z
+^y ^n ^n ^i ^k ^s
+^y ^k ^n ^u ^h ^c
+^y ^g ^g ^i
+^y ^d ^e ^e ^p ^s
+^x ^o ^c
+^u ^m ^e
+^t ^i ^s
+^s ^m ^a ^d ^a
+^s ^i ^v ^a ^d
+^o ^m ^o ^c
+^n ^w ^a ^h ^s
+^l ^o
+^l ^i ^g
+^i ^k ^k ^i ^n
+^h ^t ^e ^b
+^e ^n ^i ^m ^s ^a ^j
+^e ^k ^a ^f
+^e ^e ^d
+^d o1i
+[ $9 $9
+[ $6 $3
+[ $2 $3
+K o6b
+K *02
+D5 t
+D5 p1 '9
+D4 $7
+D4 $1 $6
+D3 $b
+D1 $7 $2
+.1 $1 $2 $3
+$m $a $e
+$l $o $n $g
+$h $s
+$e $w
+$e $f
+$A $a
+$9 $6 $8
+$7 $0 $9
+$6 $0 $4
+$3 $8 $6
+$3 $0 $2
+$1 $1 $4
+ss- $l $i $k $e
+sS- $I $I
+o7v
+o51 i62 i73 i84 i95 iA6 oB7
+o4z -5
+o4d $a
+o41 i59 i69 ,7
+o3r o4y
+o3b *43
+o2r i4o
+o1z { 'A
+o1v ]
+o1i o4r
+o1a o3s
+o1a $1 $2 $3 $4 $5
+o0z }
+o0u ^J
+o0s o1g
+o0s i1v
+o0n o1g
+o0k i2k o3a
+o0d ,3
+o0L $5
+o0G $1 $0
+o0F $2
+o0D i1i
+o0D $4
+l $e $l $l $a
+i74 i80
+i72 i67
+i6i o7n
+i64 +5
+i62 i78
+i59 ss9 $9
+i57 i61 o72
+i56 i67 o78
+i54 i60 o71
+i4w
+i46 o59
+i46 i54 o65
+i44 i56 o65
+i42 $3
+i36 i27
+i35 i39
+i34 o48
+i33 i38
+i30 i36
+i2s i3t
+i1x o0a
+i14 i13
+c i74
+^z ^u ^s
+^z ^t ^i ^l ^b
+^w ^o ^p
+^t ^r ^a ^u ^t ^s
+^t ^o ^i ^d ^i
+^s ^a ^h ^c
+^r ^e ^t ^s ^m ^a ^h
+^o ^v ^i
+^o ^r ^e ^n
+^n ^r ^u ^b
+^l ^u ^f ^i ^t ^u ^a ^e ^b
+^k ^c ^u ^d
+^i ^n ^o ^m
+^e ^n ^e ^r ^i
+^c o1h $1
+^a ^t ^s ^u ^g ^e ^m
+^a D6
+^V i1a
+^7 }
+^4 ^4 $4 $4
+^3 D3
+[ $6 $6
+[ $5 $7
+[ $1 $6
+K $r
+K $e
+D4 $2 $9
+D2 $8 $0
+D2 $4 $7
+D1 $9 $8
+D1 $9 $6
+D1 $0 $9
+-5 } }
+$o $k $a
+$h $a $p $p $y
+$@ i61
+$9 $1 $7
+$3 $8 $9
+$3 $5 $8
+$3 $2 $8
+$3 $0 $1
+$2 $0 $3
+$. $0
+sa4 u sE3
+r c K
+oB# o4J E
+o9n
+o9b
+o5y $1 $2 $3
+o55 i66 ,7
+o4g $a
+o4$
+o3u -7
+o3a $s
+o3a $d
+o2y o3k
+o2y *32
+o2u $1 $2
+o2n o5i
+o2H u
+o1o o5k
+o1o i3z
+o1i o3o
+o1e o3p
+o1a -4
+o0x o1l
+o0w D3
+o0v ^j
+o0p o2n
+o0p $2
+o0o o1n
+o0n o1c
+o0l $0 $3
+o0i i2n
+o0g o3y
+o0K $8
+o0J $0 $1
+o0G D6
+o0B +3
+o0B $0 $7
+i77 i81
+i6G +7 l
+i69 .5 K
+i61 i72 i84
+i60 i75
+i56 o65
+i56 o60
+i53 i62 o74
+i53 i61
+i52 i73
+i51 i72
+i50 i78
+i4o o5f
+i4f ]
+i46 i52 o65
+i45 i50 o62
+i44 o59
+i41 o56
+d 'A +5
+c i64
+^z ^o ^r
+^z ^e ^b
+^y ^d ^o ^k
+^y ^a ^c
+^v ^e ^b
+^t ^o ^c ^s
+^s ^i ^l ^e ^m
+^r ^e ^k ^a ^b
+^o ^r ^r ^e ^p
+^n ^i ^h ^c
+^k ^c ^a ^j T4
+^i $1
+^f D5 -3
+^a -7
+^2 o12
+^0 o15
+^0 o14
+T0 T2 T3 T5
+K o34
+K *04
+D5 $8 $8
+D2 $8 $7
+D2 $7 $5
+D2 $5 $9
+D1 *20
+D1 $c
++1 o25
+$r i8j
+$p s]# E
+$i $c $h
+$g $a $l
+$c $i
+$9 $4 $1
+$9 $3 $6
+$9 $0 $2
+$8 $9 r
+$8 $0 $4
+$6 $8 $9
+$5 $4 $3
+$5 $4 $0
+$5 $1 $8
+$2 $7 $9
+$1 $9 $5
+$1 $4 $5
+$1 $3 $1
+$1 $1 $0 $6
+$1 $$
+} ^b
+u i79 ,7
+s1G
+o91 iA2 oB3
+o65 -7
+o5o
+o52 $0 $8
+o4a i5v o6i
+o43 i50 i60 ,7
+o3u o2i
+o3e *45
+o3e $s
+o3a $2 $0 $0 $3
+o2y o3c
+o2m o0R
+o1i i2s
+o1e o5o
+o0v o1e
+o0t $7
+o0t $1
+o0s o1i
+o0s $0 $3
+o0m i3e
+o0l i3o
+o0j -5
+o0h i3a
+o0g $2 $3
+o0e o2i
+o0d o5o
+o0c i2e
+o0J o61
+o0A $1 $3
+k o2u
+i82 o93
+i5e
+i59 i67 o78
+i54 o65 o76
+i54 '9
+i52 i75
+i52 i64 o78
+i47 i52 o69
+i45 i57 o65
+i45 i56 o62
+i44 i56 o68
+i43 i57 o65
+i41 *31
+i23 i34
+i20 i30
+i19 i34
+i10 z1
+d '9
+c i66
+c ^8 ^1
+c $1 $8 $2
+^y ^l ^l ^i ^t
+^x ^o ^s ^d ^e ^r
+^t ^a ^t
+^s ^e ^s ^o ^m
+^r ^d ^n ^a
+^o ^g ^n ^o ^b
+^n ^i ^w ^d ^e
+^n ^a ^f ^e ^t ^s
+^n ^a ^b
+^m ^i ^h
+^h ^c ^e ^t
+^e ^v ^o ^l T4
+^a ^i ^r ^o ^t ^c ^i ^v
+^a ^i ^l ^a ^t ^a ^n
+^a $2
+^0 ]
+] ] ] $e
+[ i58
+[ $3 $8
+[ $3 $5
+[ $2 $9
+[ $1 $8
+o3i u
+K o40
+D5 } D2
+D5 $5
+D5 $1 $3
+D4 $2 $8
+D3 $1 $5
+D2 $6 $4
++1 u [
+'7 $6
+'7 $5
+$q $u $i
+$n $u $t
+$f $a $t
+$e $i
+$7 $1 $9
+$6 $3 $0
+$2 $4 $8
+$2 $4 $3
+$2 $2 $1 $1
+$2 $2 $1 $0
+u '7 $4
+t o0N
+o6u +7
+o6p $s
+o4z o5i $a
+o41 i52 i62 o77
+o3y $1 $2
+o38 i48 ,5
+o3,
+o2y o4e
+o2o o1a
+o2n $1 $2
+o1o o3b
+o1i o4u
+o1i i2b
+o1e o3u
+o0z o2e
+o0n o2r
+o0j o3u
+o0j i4s
+o0c $s
+o0M $!
+o0D D4
+o0C $6
+o0B +2
+o0A .1
+l ] ]
+k Z1
+k *64
+i74 i83 i92
+i73 i75
+i72 o81
+i72 i82 i91
+i69 i70
+i65 *35
+i62 o76
+i48 i51
+i35 i33
+i34 i71
+i13 i37
+i0f i1l i2a
+d *04 '8
+c ^7 ^0 ^0 ^2
+c '9 $4
+c $1 $9 $7 $6
+c $1 $0 $!
+^y ^x ^a ^l ^a ^g
+^y ^t ^o ^o ^b
+^y ^d ^d ^a ^m
+^w ^o ^r
+^s ^u ^t ^c ^a ^c
+^s ^i ^l ^l ^e
+^r ^a ^z
+^p ^a ^g
+^o ^v ^e
+^o ^k ^a ^m
+^n ^e ^b ^u ^r
+^l ^e ^h ^c ^i ^m
+^j D4
+^i ^o
+^h ^c ^i
+^d ^e ^m ^h ^a
+^b ^f
+^a ^n ^a ^v ^r ^i ^n
+^a ^l ^y ^a ^k
+^V D3
+^K { T0
+^< $>
+^8 i14 *34
+^4 o17
+[ i30
+[ Y2
+[ $4 $2 $0
+K -5 *43
+D5 $7 $7
+D4 $1 $8
+D3 $7 $1
+D3 $5 $1
+D3 $3
+D2 o2q
+D2 $6 $5
+@n [
++4 o0m
++1 -0 +1
++1 +5 +3
+$p $2
+$m *32
+$m $a $y $a
+$k $1 $1
+$g $u
+$d $i $c $k
+$@ Z2
+$9 $0 $7
+$8 D0
+$8 $2 $1
+$6 $8 $6
+$6 $1 $4
+$5 $6 $2
+$5 $3 $1
+$3 $4 $7
+$2 $5 $4
+$1 $1 $0 $5
+$0 $1 $!
+o5r i6o ,7
+o4x o3z
+o4c $1 $2 $3
+o44 i55 i64 o75
+o41 i53 i62 o74
+o4#
+o3i i3t c
+o2z $5
+o2u o5i
+o2a +3
+o1v $1
+o1u *41
+o1i -4
+o1e o2o
+o1e i4h
+o1e i2p
+o1a i3o
+o0s o2r
+o0n D2
+o0j o3j
+o0j i4e
+o0h $0 $2
+o0g i3z
+o0g i3o
+o0d i4i
+o0c $l
+o0S $2 $2
+o0S $1 $8
+o0L $0 $6
+o0I $2
+l $i $x
+l $7
+k o55 ,6
+k E $9
+k .1 *03
+k +5
+i7i i8t
+i7b
+i77 i72
+i75 i81
+i72 o88
+i71 D1
+i70 o88
+i6i o7s
+i6E E DB
+i61 i74
+i55 Z1 c
+i54 i65 o74
+i52 o67
+i52 i63 o76
+i50 o66
+i46 i56 o67
+i46 i54 o66
+i45 i56 o64
+i44 o55
+i3i i4n
+i35 o44
+i32 o41
+i2d i3e
+i0p i1h
+i0g i1r i2a
+c ^8 $8
+^z ^i ^l ^e
+^y ^r ^r ^e ^m
+^y ^c ^n ^a ^f
+^x ^a ^d
+^v ^e ^h ^c
+^u ^r ^e ^p
+^t ^n ^t
+^s o1s
+^s ^u ^i ^c ^i ^n ^i ^v
+^o ^t ^s
+^o ^n ^i ^k
+^o ^i ^f
+^m ^i ^s
+^l ^e ^t ^o ^h
+^j o1u
+^i ^b ^a
+^h D4
+^g D4
+^c ^d ^c ^a
+^1 ^0 ^0
+[ $5 $8
+[ $5 $5
+E o40
+D4 $4 $5
+D3 $5 $6
+D2 $9 $1
+D2 $3 $4
+D2 $2 $0 $0 $8
++0 +2 +1 +3
+*62 *73
+$m *43
+$l $y $n $n
+$f $1
+$9 $1 $5
+$8 $7 $8
+$8 $2 $5
+$7 $a
+$4 $5 $6
+$1 $7 $1
+$1 $4 $4
+$1 $1 $0 $3
+$0 $1 $2 $3
+{ $k
+seO u
+o7s o6'
+o7o -8
+o5k $k
+o4l $a
+o4i ,5
+o42 i51 i62 o71
+o3u $a
+o3s $1 $2 $3
+o2x ]
+o2l $2
+o1o y2
+o1o *32
+o1&
+o0z o2c
+o0w o2s
+o0t $8
+o0k $4 $5
+o0j $0 $4
+o0g $5 $5
+o0e o2t
+o0M $2 $5
+o0M $0 $2
+o0G $5
+o0E $0 $1
+o0D $2 $1
+o0C D2
+k o49
+i79 i72
+i73 i83
+i70 *23
+i6n o7d
+i6g i7e
+i61 i73
+i5h [
+i55 i62
+i55 i60 o74
+i54 o61
+i52 o64 o76
+i52 i62 o74
+i52 D1
+i51 i79
+i48 o53
+i44 o53
+i43 ss3 $3
+i3t i4h i5e
+i39 o48
+i36 o47
+i0t i1h
+i0c i1h i2a
+i0a ^v
+c ^7 ^1
+c $3 $3 $7
+c $1 $9 $7 $4
+^y ^d ^o ^j
+^v ^l ^a
+^s ^n ^u ^g
+^p ^s ^p
+^p ^i ^l ^i ^h ^p
+^p ^e ^l
+^o ^k ^i ^m
+^o ^d ^u ^j
+^n ^a ^y
+^m ^i ^l ^s
+^l ^l ^a ^b
+^l ^i ^m ^a ^k
+^j D2 D3
+^i ^c ^u ^l
+^e ^t ^u ^c
+^e ^s ^o ^o ^m
+^e ^k ^a ^m
+^d ^a ^l ^v
+^a ^r ^a ^p
+^a ^n ^a ^i ^r ^a ^m
+^8 o19
+^8 $2
+^4 ^1 ^3
+[ $5 $9
+[ $3 $7
+[ $1 $3
+Y2 Z1
+R9 ^S o1e
+L8 K *24
+E D4 $7
+D4 D2 {
+D4 $f
+D4 $1 $7
+D3 D4
+D2 k u
+D2 $9 $2
+D2 $5 $7
+D1 o1f
+D1 D3 $b
+D1 D3 $1
+D1 $6 $7
+D1 $5 $7
+*50 *41
+$u Z1
+$i $o $n
+$g $u $i
+$d $o $m
+$_ $6 $6 $6
+$9 $6 $6
+$6 $9 $1
+$4 $2 $9
+$3 $2 $2
+$1 $9 $7
+$1 $2 $0 $8
+$1 $0 $!
+o3y o5u
+o3i $1 $2 $3
+o2u o4o
+o2m l
+o2G u
+o1e i3c
+o0w i1a
+o0w +2
+o0p i1j
+o0l $a
+o0k $7 $7 $7
+o0k $0 $4
+o0j -7
+o0g y3
+o0g $t
+o0g $0 $0
+o0d $a
+o0C $0 $6
+o0B D5
+k o2s
+k +2
+i79
+i71 i82 i91
+i71 i80
+i71 i79
+i5p s+1
+i51 i63 o78
+i51 i60 o76
+i50 i72
+i5#
+i4i i5e
+i4e i5s
+i48 i57 o66
+i47 i50 o63
+i46 i56 o65
+i43 i57 o68
+i43 i51 o64
+i43 i51 o60
+i43 i50 o61
+i37 o41
+i35 o49
+i2E E
+i1f D4
+c o82
+c $9 $7 $6
+c $2 $4 $7
+c $0 $!
+^y ^f ^o ^o ^g
+^t ^h ^g ^i ^r
+^s ^k ^e ^l ^a
+^s ^i ^r ^r ^a ^h
+^s ^a ^b ^e ^s
+^p ^i ^k ^s
+^p ^e ^r
+^o ^n ^o ^b
+^o ^n ^a
+^o ^i ^t
+^o ^g ^a ^i ^t ^n ^a ^s
+^n ^i ^f ^f ^u ^m
+^n ^a ^s ^u ^s
+^m ^u ^b
+^m ^a ^d
+^k i1j
+^k ^c ^u ^b
+^k ^a ^m
+^k *13
+^i ^d ^i ^e ^h
+^e ^t ^i ^l ^e
+^e ^m ^o ^c
+^e ^k ^o ^o ^r ^b
+^d ^o ^c
+^a ^l ^a ^m
+^9 }
+[ i1x
+[ $6 $7
+[ $4 $9
+[ $4 $0
+[ $3 $3
+[ $2 $5
+T0 .6 .7
+K s27
+D5 $6
+D4 $7 $7
+D3 $1 $8
+D2 *20
+D1 $8 $1
+D1 $7 $6
+$q Z2
+$n $l
+$l D3
+$l -0
+$b $v
+$9 $2 $3
+$7 ^3
+$7 $2 $8
+$6 $0 $2
+$4 $8 $3
+$3 $3 $2
+$3 $#
+$1 $2 $0 $9
+t o3F
+o8y
+o6y ]
+o6x .7
+o4o $e
+o46
+o3t ^s
+o3a $1 $2 $3 $4 $5
+o2x Z1
+o1e $0 $0
+o1a $s
+o0z $1
+o0t o1y
+o0r o1i
+o0r $2 $5
+o0n $7
+o0n $2 $5
+o0n $1
+o0l i2i
+o0h $0 $3
+o0g i4r
+o0g i4i
+o0g $g
+o0d o5u
+o0c y4
+o0c o3y
+o0H $4
+o0G $4
+o0F $5
+o0#
+i80 o91
+i7r o6j
+i7a R6 L6
+i76 $4
+i6u
+i6e o7k
+i69 i79
+i61 i72 i83
+i60 i78
+i60 *34
+i5t o6o
+i5r o6e
+i5o i6n
+i5i o6e
+i56 i61
+i52 o69
+i4w o5a
+i44 i55 o63
+i28 i23
+i17 i17
+i16 i35
+i0y i1a
+i0n i1a
+^y ^p ^o ^c
+^y ^n ^i ^h ^s
+^y ^l ^r ^e ^b ^m ^i ^k
+^y ^l ^l ^a ^w
+^y ^d ^o ^r ^b
+^y ^a ^d ^i ^r ^f
+^t ^s ^i ^r ^k
+^t ^o ^t
+^s ^l ^l ^a ^b
+^s ^d ^j
+^s ^c ^j
+^r ^e ^s ^i ^a ^k
+^p ^i ^p
+^o ^y ^a ^m
+^o ^o ^w
+^o ^c ^s ^o ^b
+^n ^a ^i ^s ^a
+^n ^I
+^m ^d ^j
+^l ^o ^o ^k
+^l ^e ^t
+^k ^c ^a ^h
+^j i0h
+^j $7
+^e ^v ^e
+^d ^v ^d
+^a ^n ^n ^o ^d
+^a ^i ^s ^a
+^a Z1
+^P
+^3 D6
+[ $4 $6
+[ $3 $9
+D5 $9 $9
+D3 $7 $7
+D3 $1 $3
+-0 +1 r
+*20 o0h
+'7 $9
+$y $u $r $i
+$w Z2
+$k $h $a $n
+$e $l $f
+$b $e $l $l $a
+$_ d ]
+$5 $8 $6
+$5 $5 $9
+$3 $7 $8
+$1 $1 $0 $2
+} i46
+sa@ $3
+o81
+o71 o82
+o5o o6z
+o5b r
+o51 ss2 $3 $4 $5
+o4y $0 $1
+o4u $1 $2 $3
+o4o $o
+o42 i50 i62 o70
+o3o y2
+o2w
+o2k o4u
+o2k $k
+o1t o2z
+o1i o2j
+o1e o4o
+o1e $2 $0 $0 $1
+o0x D2
+o0s i1d
+o0p i1s
+o0p $1 $5
+o0p $0
+o0j o1v
+o0j i3g
+o0j $2 $2
+o0f o3v
+o0e o2e
+o0e i2s
+o0d $2 $0 $0 $0
+o0C D6
+o0C $0 $7
+l $l $a $b
+i77 i76
+i73 i72
+i6s c
+i6n i7s
+i69 i78 o87
+i67 i77
+i65 $6
+i62 i72
+i61 i72 i82
+i52 i60 i70 o88
+i51 i60
+i4t i5o
+i4e i5d
+i49 o57
+i48 i51 o66
+i45 i51 o66
+i43 i52 o67
+i41 i54
+i40 o58
+i34 i78
+i34 i36
+i34 D7 *64
+i08 i39
+c ^e ^v ^o ^l ^I
+c ^9
+c '9 $9
+c $1 $9 $7 $3
+^y ^n ^n ^o ^s
+^y ^m ^m ^o ^m
+^y ^b ^l ^o ^c
+^w ^e ^r ^c
+^t ^o ^i ^l ^l ^e
+^s ^i ^r ^a
+^s ^e ^r ^p
+^s ^e ^r ^o ^l ^f
+^s ^d ^a ^m
+^o ^p ^a
+^o ^o ^l ^b
+^o ^d ^o ^r ^f
+^o ^d ^i
+^o ^L
+^n ^o ^v
+^n ^m ^u ^t ^u ^a
+^n ^e ^d ^y ^a ^h
+^m -2
+^e ^t ^n ^o ^m
+^a ^n ^o ^i ^f
+^a +6
+^Y D2
+^S i1i
+^P -1
+^8 ^8 ^8
+^8 ^7 ^6
+^7 ^1 ^1
+^3 o13
+^3 ^0 ^1
+[ i3j
+[ $2 $4
+Y2 y3
+K o82
+D2 o2b
+D2 $7
+D2 $6 $2
+D2 $3
+D1 D3 D5
+D1 $9 $0
+*20 ^1
+$l swJ *51
+$h $a $r $r $y
+$g $u $n
+$_ $8 $8
+$9 $6 $4
+$9 $4 $3
+$8 $1 $4
+$6 $2 $4
+$5 $4 $5
+$4 ^2
+$4 $7 $8
+$4 $3 $0
+$4 $0 $1
+$3 $8 $0
+$2 $5 $2
+$2 $1 $1
+$2 $1 $!
+$1 $5 $2
+$0 $7 $0 $8
+} ^j
+o7s
+o5w c
+o5i o7i
+o56 $6
+o44 ss4 $4 $4
+o2y i3o
+o1u o5k
+o1q o2w
+o1o o3f
+o1i +6
+o1i $2 $0 $0 $5
+o1e o3n
+o1e i2o
+o0v i1a
+o0t $1 $5
+o0r $1
+o0n +2
+o0n $9
+o0l o2y
+o0k +3
+o0g $0 $3
+o0e o3c
+o0P $0 $9
+o0N $0 $1
+o0L $7
+o0E D3
+o0D T3
+o0D $6 $9
+o0B $2 $4
+i88
+i74 i81
+i72 i82 i93
+i68 +4
+i60 i72
+i58 'A
+i54 o63
+i50 i73
+i4t o5h
+i4f [
+i49 $2
+i48 o57
+i45 i53 o64
+i43 i52 o69
+i41 ss0 $1
+i36 o49
+i33 i42 o51 r
+i31 i33
+i20 i15
+i0c i1h i2e
+i0a i1m i2a
+c $1 $0 $1 $0
+^y ^t ^r ^o ^h ^s
+^y ^r ^a ^h ^c ^a ^z
+^y ^a ^r ^b
+^t ^o ^l ^i ^p
+^s ^i ^s ^e ^n ^e ^g
+^s ^a ^t
+^o ^o ^l
+^o ^h ^w
+^o ^c ^e ^d
+^n ^z ^a
+^n ^o ^m ^e ^k ^o ^p
+^n ^o ^m ^a ^r
+^n ^e ^t
+^n ^a ^t ^a ^s
+^n ^a ^i ^d ^n ^i
+^l ^u ^z ^a
+^l ^i ^m ^e
+^k ^n ^i ^l
+^k ^a ^j
+^i ^n
+^h o1i
+^e ^l ^t ^t ^a ^b
+^e ^k ^i ^p ^s
+^e '8
+^a z1 E
+^T i1h
+^9 ^6 ^3
+^7 D2
+^4 ^5 ^1
+^0 o18
+^0 ^1 ^0
+[ o0m y2
+[ $5 $6
+[ $1 $9
+K *28 *65
+D4 ^f
+D3 o23
+D3 $j
+D3 $1 $1
+D2 $9 $5
+D2 $5 $3
+D2 $4 $6
+D2 $1 $9
+D1 $7 $0
+$m $o $u $s $e
+$l $o $w
+$k *54
+$i $c $a
+$h $a $c $k $e $r
+$c $h $a $n
+$b +6
+$_ $1 $0
+$M
+$? $!
+$9 $2 $1
+$8 r
+$8 $1 $7
+$7 $7 $5
+$7 $6 $7
+$7 $2 $3
+$6 $5 $0
+$2 $3 $6
+$2 $2 $9
+$0 $9 $8 $7
+} ^g
+o9l oAy
+o7a i8t o9a
+o6u -7
+o5z $e
+o4h $1 $2 $3
+o43 i50 i63 o70
+o3u $i
+o2o o6o
+o2k r
+o2k o4a
+o2e $1 $2
+o2d *54
+o2d $1 $2 $3
+o2a o4o
+o1y o2h
+o1u ,3
+o1a i4y
+o0z o4a
+o0z o1h
+o0w '7 Z1
+o0s i2l
+o0r o2k
+o0r $8
+o0q ,1
+o0m $r
+o0k ] ]
+o0j ]
+o0j $0 $0
+o0g +2
+o0d $0 $4
+o0b i2i
+o0P $6
+k *7A y1
+i73 i70
+i71 i76
+i55 +2
+i54 i65 o70
+i52 i70
+i4r i5o
+i47 i52 o66
+i47 i51 o67
+i46 i57 o66
+i44 i50 o63
+i37 i79
+i37 i71
+i33 i36
+i12 ^7
+i0z i1a
+i0p i1l
+c ^4 ^1
+c T7 $1
+c $_ $1
+^z ^t ^i ^r ^o ^m
+^y ^z ^z ^i ^l
+^y ^r ^a
+^y ^e ^l ^n ^a ^t ^s
+^u ^l ^a ^b
+^s ^r ^j
+^r ^e ^n
+^o ^r ^t ^i ^n
+^o ^l ^o ^a ^p
+^o ^i ^c ^c ^i ^c
+^o ^g ^a ^m
+^o ^b ^m ^u ^j
+^o ^b ^a
+^o *30
+^k ^c ^i ^r ^e
+^h ^t ^r ^o ^n
+^h ^a ^j
+^e ^d ^e ^f
+^d ^n ^o ^m ^a ^i ^d
+^a ^n ^a ^d
+^a ^b ^a ^b
+^Y D3
+^Y
+^X
+^8 $6
+^1 ^2 ^1
+[ $5 $4
+[ $4 $8
+D4 $0
+D2 D6 $1
+D2 $b
+D2 $6 $9
+D2 $0 $6
++2 -0 -1
+*43 *52
+$v $u
+$h $g
+$e $z
+$b $l $u
+$b $a
+$_ $7
+$_ $1 $3
+$7 $6 $0
+$6 $5 $6
+$5 $4 $6
+$5 $1 $4
+$5 $0 $6
+$2 $5 $5
+o8d o9a
+o7o o8r
+o5p o6h
+o4a $s
+o4a $1 $2 $3 $4 $5
+o4@ i51 i62 o73
+o3o ]
+o2o o4o
+o2o +3
+o1p ]
+o1o *43 *35
+o1i i3o
+o1i i3h
+o1e o5n
+o1e i3k
+o1a ]
+o1E u
+o0w o2r
+o0v o2r
+o0v $1
+o0p $9
+o0n o2g
+o0k o7x
+o0k i3y
+o0j ^D
+o0h o1s
+o0d $1 $2 $3
+o0S $1 $6
+o0L $2 $4
+o0D $7
+o0B $9 $9
+o0B $2 $2
+o0A D4
+o0A $1 $4
+i73 $5
+i7.
+i6t o7r +8
+i62 i76
+i5o o6n
+i5m i6e
+i5j o6a
+i53 ,6
+i52 o63 i72 o83
+i51 o65 o70
+i51 R7 L7
+i47 i57 o66
+i44 i52 o61
+i44 i51 o66
+i43 i52 o68
+i41 t i55
+i16 i39
+i14 i15
+c $u $s
+c $9 $7 $2
+c $9 $5 $7
+^y ^m ^e ^r
+^y ^d ^a
+^y ^c ^r ^e ^p
+^x ^s ^w ^z ^a ^q
+^t ^r ^a ^k
+^s ^s ^e ^t
+^s ^l ^j
+^s ^a ^i ^b ^o ^t
+^r ^o ^t ^i ^v
+^o ^t ^a ^n ^e ^r
+^o ^r ^d ^n ^a ^e ^l
+^o ^i ^c ^o ^r
+^n ^a ^i ^g
+^m ^a ^b
+^l ^f ^o ^r
+^i ^l ]
+^i ^g ^i ^g
+^i ^f
+^i ^d ^n ^a
+^i D3
+^e ^n ^o ^t ^s
+^e ^l ^l ^e ^b
+^a ^n ^i ^t
+^a ^n ^i ^h ^c
+^a ^d ^n ^e ^r ^b
+^a ^b ^l ^a
+^a D3
+^9 ^0 ^1
+^4 o16
+^3 ^1 ^3
+[ i4b
+[ $2 $2
+[ $0 $7
+T0 T6 T2
+K -7 *65
+D4 ^m
+D4 $2 $0
+D3 o3k
+D3 $a
+D3 $4 $3
+D3 $3 $3
+D2 ] r
+D2 $9 $0
+D2 $7 $2
+D2 $6 $6
+D2 $3 $7
+D1 $7
+D1 $4 $7
+D1 $4 $0
+D1 $0 $8
++1 -3 -0
+$p $u $f $f
+$n D2
+$l k
+$k $i $l $l $a
+$k $a $y
+$h $a $l $o
+$9 $0 $0 $0
+$8 $0 $1
+$7 $0 $4
+$2 $a
+$1 $9 $2
+$1 $8 $9
+$1 $4 $6
+$1 $2 $3 $3 $2 $1
+$1 $2 $1 $0
+$1 $0 $6
+$0 $1 $0 $2
+} } $3
+o7p [
+o7$
+o6s o7o
+o6q i7u o8e
+o5p
+o4y $5
+o4o $d
+o4b $x
+o3u o4a
+o2e ,4
+o1u o2a
+o1o i3p
+o1e $2 $0 $0 $4
+o0z o2z
+o0x D5
+o0r o1j
+o0p $1 $0
+o0o o1g
+o0j $t
+o0i o2s
+o0h i3o
+o0a i2i
+o0a -1
+o0M $1 $4
+o0H D2
+o0G $1 $3
+o0D +2
+o0D $0 $8
+o0C $7
+o0C $1 $8
+l $e $n $t
+k o4k
+k D2 +6
+i81 o90
+i7e o8r
+i72 i80 i90 oA6
+i6s ,7
+i62 i73
+i5e c
+i52 o60 ss0 $6
+i52 i61 ,7
+i52 i60 ,7 o88
+i51 k
+i51 i60 o73
+i4l o5e
+i4j o5a
+i4g o5u
+i46 ,5
+i45 ss5 $5
+i45 i53
+i45 i52 o68
+i45 *12
+i44 i53 o65
+i44 i50 o66
+i39 o45
+i39 o41
+i33 +2
+i0n i1e
+c $9 $5 $3
+c $1 $0 $0 $0
+c $1 $*
+^y ^z ^u ^s
+^y ^b ^o ^o ^c ^s
+^w ^e ^h ^c
+^t ^u ^o ^l ^l ^a ^f
+^s ^p ^j
+^s ^b ^u ^c
+^r ^e ^p ^i ^p
+^p ^i ^r ^t
+^o ^r ^o ^b
+^o ^o ^h ^a ^y
+^n ^o ^c ^a ^b
+^n ^e ^g
+^n ^e ^d ^y ^a ^j
+^n ^a ^o ^j
+^m D2
+^k i1i
+^i ^d ^n ^i
+^g ^n ^u ^s ^m ^a ^s
+^f ^l ^e
+^f ^e ^d
+^e ^c ^l ^u ^d
+^a ^t ^i ^r
+^a ^g ^a
+^O i85 ]
+^7 o17
+^7 ^8 ^9
+^7 ]
+^6 ^8 ^7
+^5 ^0 ^1
+^3 i20
+^1 i28
+^0 ^5 ^1
+[ o0t
+[ i2m
+[ [ [ $1
+[ $4 $5
+[ $4 $1
+Y2 o6_
+Y1 i5v
+K o5h
+D7 D8
+D6 $7
+D4 $1 $0
+D3 ^c
+D2 D5
+D2 $9 $7
++1 -2 -0
+*13 p1
+$t $e $d $d $y
+$t $1 $1
+$r $2 $1
+$n $i $c $e
+$m Z2
+$i $n $i
+$a +3
+$_ $0 $9
+$R u
+$9 $6 $5
+$8 $2 $3
+$3 $$
+$2 $5 $3
+$2 $0 $4
+$1 $5 $8
+$0 $2 $0 $8
+y2 y2 E
+o4x c
+o4d $y
+o4b $1 $2 $3
+o42 i53 i62 o73
+o2q
+o2i *31
+o1o o5a
+o1o o4b
+o1a o5m
+o1a $d
+o0x o1t
+o0w i2r
+o0u o1g
+o0r i1o
+o0r D2
+o0d o6r
+o0d i2o
+o0a +1
+o0D $8 $8
+o0C $2 $1
+l $r $o $o $m
+k o50
+k ^m
+i76 i74
+i75 L6 L7
+i6h o7a
+i63 i74
+i62 i79
+i62
+i61 i77
+i5w
+i5g o6o
+i5e i6r
+i59 o63
+i57 +4
+i55 i60 i70 ,8
+i52 i63 o75
+i52 i62 o75
+i51 i64 o75
+i51 i60 o74
+i49 i56 o63
+i49 i52 o66
+i45 i52 o67
+i42 i54 o66
+i39 o40
+i35 o46
+i1f
+i14 i14
+i0g ^k
+c o21
+c $6 $5 $4
+c $1 $1 $1
+^s ^u ^c ^o ^f
+^s ^o ^m ^a
+^s ^n ^a ^v
+^s ^i ^r ^r ^o ^m
+^s ^e ^d ^e ^c ^r ^e ^m
+^r ^o ^t ^a ^g
+^r ^e ^l
+^r ^e ^k ^r ^a ^p
+^r ^e ^b ^m ^u ^n
+^o ^i ^d ^u ^a ^l ^c
+^n ^u ^j
+^n ^a ^t ^s
+^l o2s
+^k ^o ^o ^b ^e ^c ^a ^f
+^j o1i o2m
+^i ^m ^e ^d
+^e ^n ^i ^l ^o ^r ^a ^c
+^c o1h i2i
+^c ^i ^v
+^a -5
+^Q
+^P D6
+^4 o13
+^4 ^3 ^2
+^1 i22 i43 i64
+] ] ] $d $o $g
+[ i3n
+[ [ $1 [ [
+[ $2 [
+[ $1 $1
+Y1 ,3
+D8 -8
+D7 +6 [
+D3 $4 $5
+D3 $2 $9
+D1 $6 $4
+D1 $5 $6
++2 +3 -0
+$l $z
+$k $y $l $e
+$i t
+$c [
+$c $o $w
+$8 $2 $7
+$7 $7 $8
+$7 $7 $6
+$6 Z3
+$3 $8 $2
+$1 $0 $2 $9
+$. $0 $1
+sai t
+oAo
+o7C E
+o5z $a
+o4o $t
+o4k $k
+o40 i58 i60 o78
+o3z $0 $1
+o2i i3f
+o2i Y1
+o2!
+o1u $k
+o1t c
+o1o $0 $0
+o0u o1r
+o0s D2
+o0r o1u
+o0n o3d
+o0j i3a
+o0c $7 $7 $7
+o0Z $1
+o0J $1 $2 $3
+k E $5
+i78 i70
+i74 i84
+i6e i7d
+i62 ,7 o88
+i5r D2
+i57 i60 ,7
+i56 o69
+i55 i60
+i53 o60
+i51 o69
+i4v
+i4o o5u
+i48 i53 o61
+i46 o55
+i46 o50
+i46 i51 o66
+i44 i52 o65
+i44 i52 o64
+i43 ss4 $5
+i43 i58 o66
+i43 i55 o62
+i43 i53 o65
+i41 i50 o68
+i3o i4f
+i3e [
+i3E E
+i36 ss6 $6
+i1r o2u
+c ^( $)
+c '9 $2
+c $8 $9 $0
+c $5 ^5
+c $3 $1 $6
+c $2 $3 $!
+c $1 $9 $7 $5
+^z ^A
+^y ^p ^o ^o ^p
+^y ^o ^m
+^y ^n ^a ^t ^t ^i ^r ^b
+^y ^n ^a ^f ^f ^i ^t
+^y ^a ^j ^a
+^t ^a ^c ^y ^m
+^r ^e ^t ^s ^i ^s
+^o ^t ^i ^v
+^o ^l ^i ^n ^a ^d
+^o ^l ^a ^m
+^o ^f ^u
+^o ^d ^n ^i
+^n ^e ^z ^o ^r ^f
+^l ^i ^a ^m
+^l ^e ^z ^a ^h
+^k ^t
+^i ^r ^p
+^h ^t ^e ^s
+^e ^l ^g ^a ^e
+^d ^k
+^d +2
+^b ^u ^s
+^a ^t ^e ^b
+^a ^m ^m ^e ^g
+^a ^d ^a
+^V D2
+^8 ^9 o27
+^7 ^0 ^0 T3
+^6 }
+[ D3
+[ $5 $2
+[ $3 $1
+D5 o5f
+D5 $9 $4
+D4 $9 $9
+D2 $0 $7
+D1 o2f D3
+D1 $4 $9
+D1 $1 $3
+C s04
++3 -1 -0
+*52 +4 +1
+*41 } }
+$o $w $l
+$m $a $r $t
+$i $f
+$e $y $e $s
+$e $j
+$9 $9 $8
+$9 $6 $0
+$7 Z2
+$5 *52 [
+$4 $2 $4
+$3 $8 $5
+$3 $3 $6
+$2 $3 $8
+$1 $9 $4 $6
+} ^h
+{ Y2
+o99
+o6t o7u
+o5p $e
+o5k ,6
+o5h $t
+o4q ]
+o4b $b
+o3o $1 $2 $3 $4
+o3n .1
+o3N c +5
+o2o o0p
+o2k $1 $5
+o2e ,3
+o2,
+o1u $0 $0
+o1o $1 $2 $3 $4 $5
+o1e o2u
+o1a i3y
+o0z D3
+o0s o2u
+o0r -4
+o0r $1 $5
+o0p $4
+o0n $2 $4
+o0k o1y i3e
+o0k i2k
+o0f $9 $9
+o0e ^L
+o0e ]
+o0e +2
+o0c c
+o0c ^A
+o0P $6 $9
+o0P $1 $3
+o0M $0 $4
+o0G $7
+o0A $2 $1
+l o6m o7o
+k K
+i89 o91
+i81 i92 iA2
+i78 i77
+i75 $4
+i73 o85
+i72 i70
+i6@ $2
+i5i T0
+i50 ss0 $7
+i4u D0
+i4g o5o
+i4d o5e
+i4b i5a
+i49 ss9 $9
+i49 o55
+i48 ss8 $8
+i47 i52 o65
+i47 *30
+i46 i57 o60
+i46 i52 o63
+i46 i51
+i43 o54
+i43 i56
+i42 i58
+i40 ss0 $0
+i3e i3d
+i34 o42
+i34 i77
+i30 o41
+i2j i3a i4n
+i0b i1} o1j
+c o23
+c ^7 $7
+c D6 $8
+^z ^e ^h ^c ^n ^a ^s
+^y ^h ^t
+^x ^X ^x $x $X $x l
+^w ^o ^l ^l ^o ^h
+^t ^n ^o ^r ^f
+^s ^o ^r ^e
+^s ^m ^e
+^s ^i ^r ^g
+^o ^t T0
+^o ^j ^n ^a
+^o ^e ^t
+^n ^o ^s ^i ^l ^a
+^n ^o ^k
+^n ^o ^e ^n
+^l ^i ^r ^v ^a
+^l ^a ^h ^c ^i ^m
+^j o1i i2m
+^i ^m ^e
+^h ^b
+^b o1o
+^a o1z
+^a ^n ^o ^m
+^V D4
+^8 }
+[ i2g
+[ $2 $0
+T0 T3 T1
+K o43
+K Y1 k
+E y4
+D8 $1
+D5 o4x
+D5 $4
+D4 $6
+D4 $3 $5
+D3 o4f
+D3 $3 $5
+D3 $3 $1
+D2 r
+D2 $0 $8
+*53 *20
+$t $r $a $p
+$o $u $t
+$j u
+$8 $3 $0
+$7 $2 $2
+$6 $2 $9
+$5 $8 $0
+$5 $6 $9
+$5 $0 $7
+$4 $9 $0
+$4 $4 $5
+$2 $6 $7
+$2 $2 $0 $9
+$1 $5 $1
+$1 $1 $0 $4
+$1 $0 $2 $0
+} ^n
+{ D1
+oAl 'B
+o7#
+o4t $a
+o4n $1 $2 $3
+o4d $e
+o42 i50 ,6
+o4! ,5
+o3o o5u
+o3i o4h
+o3f
+o3a $2 $0 $0 $2
+o2r -3
+o1u o5u
+o1m u
+o1i $s
+o1g u
+o1e $k
+o1e $h
+o1e $2 $0 $0 $3
+o1a o5a
+o0z +2
+o0w i1o
+o0t i1c
+o0r +2
+o0p o1s
+o0p $1 $1
+o0n $6
+o0k $r
+o0g i3u
+o0e o3l
+o0R $2
+o0M $0 $3
+o0K $0 $9
+l o6j -7
+l $l $i $m
+k o4b
+k ^b *13
+i75 i73
+i70 o84
+i6o i7n
+i6e i7r
+i6d -5
+i61 i72
+i5m o6y
+i57 o68 o76
+i4e i5l
+i46 i51 o67
+i44 i52 o67
+i43 o58
+i43 i57 o63
+i43 i57 ,6
+i43 i55 ,6
+i43 $4
+i38 i79
+i30 i35
+i3,
+i23 i33
+i10 i39
+i0b i1e i2a
+c i7@
+c $8 $5 $2
+c $1 $9 $7 $1
+^y ^w ^o ^n ^s
+^u ^k ^a ^s
+^t ^s ^a ^l ^b
+^s ^u ^l ^p
+^n ^o ^s ^l ^i ^w
+^n ^i ^v
+^n ^e ^p
+^n ^a ^l ^i ^m
+^n ^a ^e ^c ^o
+^l ^o ^r ^a ^k
+^l ^e ^b ^e ^r
+^l ^d
+^j +7
+^i ^n ^a ^m
+^i ^a ^d
+^h o1u
+^h ^t ^u ^o ^s
+^e ^d ^a ^l ^b
+^d ^r ^i ^b
+^a ^k y2
+^9 ^9 ]
+^. ^m
+] i51
+[ i3c
+[ i2d
+[ +1 *02
+[ *40 *51
+[ $2 $8
+[ $0 $4
+TA
+T0 o2B
+K *03
+E i51
+D6 $1 $0
+D5 $3
+D4 $1 $3
+D3 $2 $0
+D1 o1b
+D1 $5 $0
++3 *34 r
++1 +2 -0
+'8 $5
+'7 $4
+$m *24
+$m $o $r
+$i $t $a
+$h i6d
+$e $p
+$8 $7 $5
+$7 $9 $3
+$6 $0 $1
+$5 Z4
+$5 $2 $6
+$4 $9 $5
+$3 $9 $0
+$3 $3 r
+$2 $9 $0
+$2 $5 $1
+$1 $6 $0
+$1 $1 $0
+$1 $0 $1 $2
+$. $8
+$( $)
+z5
+u $2 $0 $0 $4
+o6_ $0
+o5r $z
+o4y o5p
+o4t $o
+o4d $i
+o4c $a
+o4b $e
+o40 i52 i60 o72
+o3u $u
+o3d .5
+o3a $0 $0
+o2u o4z
+o1u $s
+o1o r
+o1e o3a
+o1a o4u
+o0w o2w
+o0t i1e
+o0s o2d
+o0r D3
+o0n o3a
+o0k o4y
+o0k i2h
+o0k $n
+o0i -1
+o0d .2
+o0c o5u
+o0a i3a
+o0a i2r
+o0P D3
+o0L D5
+o0L $8
+o0D $2 $3
+o01 *50
+l $p $a $g $e
+i73 i71
+i6e o7n
+i61 i70
+i5k i6a
+i5_ [
+i57 i68 i79
+i57 ,6
+i55 i61
+i53 o61
+i53 i60 o73
+i4n i5o
+i48 $4
+i46 o52
+i44 o57
+i44 i55 ,6
+i43 i52 o65
+i43 i50 o65
+i40 o54
+i3k o4a
+i3i i4t
+i33 i74
+i2s o3h
+i2s ,3
+i0p i1a
+i0b i1r i2a
+i0a
+c '8 $9
+^z ^a ^p ^s
+^y ^n ^h ^o ^j
+^y ^a ^s ^d ^n ^i ^l
+^s ^s ^a ^r ^g
+^s ^m ^a ^s
+^s ^e ^h ^t
+^s ^c ^a
+^r ^m ^a
+^p ^s ^a
+^p ^m ^j
+^o ^i ^c ^i ^r ^u ^a ^m
+^o ^d ^n ^a ^n
+^n ^a ^t
+^m ^e ^t ^s ^y ^s
+^j o1a o2y
+^i ^k ^s
+^h ^t ^u ^r
+^h ^t ^e ^b ^a ^z ^i ^l ^e
+^h ^c ^a ^z
+^e ^r ^p ^m ^e ^s
+^e ^n ^a ^h ^s
+^c ^i ^m ^s ^o ^c
+^3 y1 }
+[ k -2
+[ $0 $8
+K o3f
+E o51
+E $e
+D7 o7b
+D4 $m
+D4 $3 $2
+D4 $2 $6
+D4 $1 $2
+D2 o2x
+D2 $4 $4
++3 +5 +5
++1 +4 -3
++1 +3 -2
++1 +2 +3 +4
++0 o24
+*32 k
+$o o0v
+$o $f
+$o $a $k
+$m $u $m
+$f $r $a $n $k
+$f $p
+$d $a $y $s
+$_ $1 $2
+$A
+$8 $9 $2
+$8 $0 $2
+$7 $0 $5
+$6 $2 $7
+$5 $7 $5
+$5 $2 $4
+$5 $2 $2
+$4 $8 $0
+$3 $6 $7
+$2 $4 $4
+$1 $0 $2 $8
+$0 $3 $1 $1
+} '7 y1
+o6j
+o4m $o
+o4l $o
+o4a t
+o3o D6
+o3l o0H
+o3i $i
+o1y +2
+o1q ]
+o1o o3z
+o1n ]
+o1e $s
+o1e $2 $0 $0 $2
+o1X c .0
+o0t o2c
+o0r o1k
+o0r $9
+o0p o2c
+o0o i1d
+o0n o2k
+o0n D5
+o0k -3
+o0j $4 $5
+o0g $0 $4
+o0H $7
+o0H $5
+o0D D5
+k -3
+i7M l
+i70 i80 i90
+i68 D3
+i5e o4h
+i5b i6o i7y
+i5a [
+i56 o67 o78
+i51 o68
+i51 o67
+i50 E
+i4s o5a o6n
+i4f o5e
+i48 i51 o65
+i46 i51 o65
+i45 i56 o61
+i43 i54 o63
+i41 o57
+i40 ss0 $7
+i3c [
+i27 .0
+i21 ^3
+i0h ^d
+i0g i1h
+c i54
+c '8 $8
+c $1 $9 $9 $8
+c $1 $5 $9
+^z ^i ^z ^a
+^y ^s ^a ^t ^n ^a ^f
+^y ^h ^s ^i ^f
+^y ^e ^h ^c
+^y ^d ^e
+^y ^b ^o ^b
+^u ^r ^a ^n
+^u ^o ^l ^u ^o ^l
+^u ^k ^u ^k
+^s ^s ^o ^m
+^s ^m ^u ^r ^d
+^s ^i ^a
+^r ^e ^g ^n ^i ^f
+^p ^o ^m
+^o ^y ^k ^o ^t
+^o ^r ^d ^y ^h
+^o ^i ^l ^i ^m ^e
+^o ^a ^h
+^n ^n ^i ^f
+^k ^l
+^k $k
+^i ^d ^e
+^e ^i ^k ^c ^a ^j
+^e D5
+^c ^M
+^b ^e ^d
+^a ^k ^s
+^a ^k ^i ^n ^o ^m
+^a ^d ]
+^_ o7_
+^W D4
+^5 D2
+^1 D2
+[ o3_
+[ D6
+K i4s
+E $_ *75
+D5 $1 $0
+D5 $0 $7
+D4 o4w
+D4 o4j
+D4 $2 $4
+D3 $2 $2
+D2 y3
+D2 $4 $3
+D2 $2 $5
+D1 o3v
+D1 $m
+D1 $6 $6
+$s $o $s
+$r $o $o
+$r $o $m $a $n
+$l $i $o $n
+$j $e $a $n
+$b $o $y $s
+$9 $0 $9 $0
+$8 $7 $9
+$8 $5 $0
+$7 $2 $6
+$7 $2 $1
+$2 $3 $9
+$0 $9 $0 $9
+} '7
+t i3E
+r $4 Z2
+o5_ $5
+o4o +5
+o4i $0 $0
+o2y o5n
+o2n Z1
+o2g +7
+o1z o2k
+o1y i2l
+o1u i2i
+o1s u
+o1i i2p
+o1i $2 $0 $0 $3
+o1h o4h
+o1e o4u
+o0t o1h
+o0s i1e
+o0q ]
+o0o ^H
+o0m $u
+o0k D3 ]
+o0b i3u
+o0b $a
+o0W K
+o0S D3
+o0R $8
+o0R $1 $2 $3
+o0L $1 $3
+o0C D4
+k o2o *A0
+i82 i90 iA0 oB5
+i77 i80
+i77 +8
+i76 o84
+i75 i72
+i6r o5o
+i6g D3
+i6d
+i6a o7n
+i5u
+i58 i64 o73
+i58 i60 ,7
+i50 i60 o71
+i4z
+i4a [
+i49 i52 o65
+i47 i52 o67
+i46 i52
+i45 i50 o63
+i44 i51 o67
+i41 i58 o67
+i3s o4h
+i3o o4u
+i33 $6
+i32 i37
+i31 i38
+i19 ^9
+i08 y1 -5
+c ^4 ^2
+c ^4 $4
+c $3 ^3
+c $0 $8 $1 $5
+c $! Z2
+^z ^e ^r
+^y ^t ^s ^r ^i ^k
+^y ^r ^r ^u ^f
+^y ^m ^m ^u ^m
+^y ^e ^g ^r ^e ^s
+^s ^i ^r ^t
+^r ^e ^h ^t ^o ^r ^b
+^r ^e ^d ^n ^i ^k
+^r ^e ^c ^n ^e ^p ^s
+^r ^b ^a
+^o ^r ^a
+^o ^n ^i ^m
+^o ^a ^h ^c
+^n ^i ^k ^n ^i ^l
+^n ^i ^e ^l ^k
+^m ^u ^m
+^m ^e ^g
+^i o2i
+^i o2a
+^i ] ]
+^h D3
+^e ^n ^o ^h ^p ^i
+^e ^d ^a
+^c ^f ^l
+^c D3
+^b ^m ^u ^d
+^a ^t ^o ^k ^a ^d
+^a ^n ^i ^r ^b ^a ^s
+^a ^j ^a ^m
+^a ^i ^r ^o ^l ^g
+^a +4
+^S +1
+^9 ]
+^3 ^1 ^2
+^1 ^9 o26
+^1 $8
+[ D2
+[ $4 $3
+[ $3 $2
+R4 *89 Y1
+D5 o52
+D4 o4v
+D4 o3p
+D4 $1 $1
+D3 D3 $1
+D3 $d
+D3 $0 $1
+D2 $6
+D1 $4 $6
+D1 $3 $7
+D1 $2 $6
+D1 $2 $5
+D1 $2
+-0 -1
+'8 $8
+$t $r $o $l $l
+$r $1 $2 $3 $4
+$p $i $n $t $o
+$i $v $a $n
+$i $n $k
+$g $1
+$d $z
+$c $z
+$? Z2
+$8 $a
+$7 ^2
+$5 $2 $8
+$4 $5 $8
+$3 $3 $4
+$1 $3 $9
+$. $1 $0
+} }
+} ^c
+t i1A
+o61 i72 i83 i94 iA5 iB6 oC7
+o4i $e
+o4g $1 $2 $3
+o4c
+o40 i53 i60 o73
+o3p
+o2w Z1
+o2r o0V
+o2h o5h
+o1y t
+o1y o3e
+o1u o3y
+o1u o3p
+o1s D3 ]
+o1o o5l
+o1o o4o
+o1o i3y
+o1i o5r
+o1i $2 $0 $0 $4
+o1a o4s
+o1B *10
+o0t i1h o2a
+o0s o2t
+o0s D3
+o0r i1j
+o0m $i
+o0k $1 $2 $3
+o0i o5i
+o0d $3 $2 $1
+o0c *03
+o0c $1 $2 $3
+o0P $1 $2 $3
+o0G o61
+o0B $1 $7
+o0A $0 $7
+i77
+i73 o84
+i71 o85
+i6o o7n
+i64 D4 .3
+i64 $4
+i63 $2
+i60 o75
+i58 i69 o70
+i55
+i54 ,6
+i53 i62 o71
+i4u i5s
+i4j o5k
+i4a o5n
+i45 o54
+i45 i52 o66
+i45 i50 o66
+i44 i50 o69
+i44 i50 o61
+i43 i52 o66
+i3h [
+i3c i4h
+i23 i53
+i1z
+i0t i1r i2e
+i0f i1r i2e
+i0-
+f *A5 '8
+c T5 $9
+c $a
+c $9 $5 $6
+c $7 $4 $1
+c $2 $3 $4
+^z ^e ^j
+^y ^u ^h ^c
+^y ^t ^t ^a ^p
+^y ^s ^s ^e ^j
+^y ^r ^o ^g ^e ^r ^g
+^y ^n ^a ^h ^t ^e ^b
+^y ^c ^r ^a ^d
+^w ^a ^k
+^u ^f ^g ^n ^u ^k
+^t ^s ^m
+^t ^a ^j
+^s ^l ^r ^i ^g
+^r ^a ^n ^u ^l
+^o ^t ^l ^a
+^o ^o ^k
+^o ^n ^u
+^o ^d ^i ^u ^g
+^n ^e ^d ^e
+^n ^a ^l ^l ^a
+^m ^I
+^l ^l ^e ^w
+^l ^i ^e ^n
+^k D4
+^j ^e
+^i ^e ^m
+^i Z1
+^e ^l ]
+^e ^k ^i ^m T4
+^e ^c ^e ^e ^r
+^e ^c ^a ^e ^p
+^d ^e ^m
+^a ^s ^s ^y ^l ^a
+^a ^l ^e ^i ^r ^b ^a ^g
+^a ^c ^c ^e ^b ^e ^r
+^7 ^2 ^1
+^6 ]
+^3 o18
+^3 o12
+^1 ^2 $2 $1
+^1 ^0 ^0 ^1
+^0 ^1 ^3
+[ $1 $2
+D4 *14
+D4 $0 $1
+D3 $1 $9
+D2 D4
+D2 $a
+D2 $7 $1
+D2 $7 $0
+D2 $4 $0
+D2 $1 $5
+D1 $3 $0
+*32 K
+$o $7 $7
+$m -2
+$b $u $m
+$9 $8 $7 $6
+$8 $8 $6
+$7 $3 $7
+$7 $3 $1
+$4 $3 $5
+$2 $6 $9
+$2 $4 $6 $8
+$2 $4 $2 $4
+$1 $0 $1 $1
+t i1H
+sjb E o5A
+sdz E
+o70 Y2
+o4v $a
+o3i $u
+o3a i5u
+o1w o3w
+o1w c
+o1n *36
+o1i k i0B
+o1i i3u
+o1h o3h
+o1e i3o
+o1a o4i
+o0y o1o
+o0v D5
+o0t i2m
+o0o o1p
+o0o o1b
+o0n Y1
+o0i o3i
+o0h $a
+o0S $1 $5
+o0L $6 $9
+o0C $2 $2
+o0A -1
+i79 i50
+i77 i73
+i73 i77
+i69 i78
+i66 r
+i60 i74
+i5u o6m
+i5m
+i5l i6e
+i5d o6i
+i56 i63 o77
+i52 o68
+i51 i62 o75
+i4u i5l
+i4s o0m
+i4k i5a
+i4h o5a
+i49 o54
+i48 o59
+i48 $9
+i45 i55 o66
+i44 o55 $6
+i44 i53 o64
+i43 i53 o67
+i43 i50 o64
+i42 ss2 $2
+i42 i53 o65
+i42 *02
+i3n o4d D5
+i3h o0s *02
+i37 o49
+i36 o48
+i36 i46 ,5
+i35 i44 o56
+i35 i24
+i32 i34
+i2t ,3
+i15 i38
+i0n ^A
+d u 'B
+c '9 $7
+c $9 $4 $5
+c $3 $5 $7
+^y ^m ^e
+^y ^h ^t ^o ^m ^i ^t
+^y ^d ^n ^i ^m
+^u ^o ^d ^u ^o ^d
+^t ^i ^w
+^r ^e ^n ^n ^u ^g
+^r ^a ^h ^s
+^p ^m ^a ^h ^c
+^o ^l ^l ^o ^p ^a
+^o ^k ^a
+^o ^g ^o ^l
+^o ^a ^p
+^n ^s ^m
+^n ^a ^i ^t ^s ^i ^r ^c
+^k D3
+^j +2
+^i ^h ^s
+^g ^p
+^g ^g ^e
+^e ^m ^i ^t
+^e ^c ^n ^i ^r ^p
+^e D3
+^c ^r
+^a ^r ^a ^k
+^3 ^2 ^1 ^0
+^1 ^0 $0 $1
+] K -1
+[ i4l
+[ $1 $5
+R4 siO c
+D6 $3
+D4 o4g
+D3 $8
+D3 $4 $1
+D3 $2 $7
+D2 $9 $6
+D2 $6 $7
+D1 D2 $f
+D1 $8 $8
+D1 $5 $4
+D1 $3 $2
+D0 D1 k
+-4 o0f
++4 {
+$t $u $b $e
+$l $i $u
+$i $t $y
+$h $j
+$g $a $n $g
+$c +0
+$b $w
+$a $c $e
+$8 $9 $7
+$8 $1 $9
+$8 $0 $3
+$7 $9 $1
+$7 $3 $0
+$6 -0
+$5 $8 $5
+$3 $6 $1
+$3 $4 $2
+$2 $8 $8
+$2 $8 $5
+$1 $6 $8
+$1 $5 $5
+$1 $3 $6
+$1 $2 $!
+$1 $0 $3 $0
+$1 $0 $2 $5
+$. $1 $1
+$- d ]
+} $1
+oA| k z2
+o7x -5
+o52 i60 sS0 $4
+o4p $a
+o4o $l
+o4n $i
+o45 i55 i66 ,7
+o3e $1 $2 $3
+o32 i40 ,5
+o2e $1 $2 $3 $4
+o1w o3g
+o1w o2j
+o1o o2y
+o1o -6
+o1k c
+o1k ,2
+o1e i4i
+o0x o1m
+o0t o3a
+o0t o1j
+o0t D3
+o0o o1r
+o0o i1n
+o0j $0 $3
+o0i o3d
+o0i i2a
+o0g $2 $0 $0 $0
+o0d i3u
+o0d $e
+o0T D4
+o0N $1 $2
+o0K D4
+o0K $8 $8
+o0H ,3
+o0F
+o0C T4
+o0B $0 $6
+l i6b o7o o8y
+i84
+i74 i71
+i72 i71
+i70 o85
+i70 o82
+i6t o7h
+i61 i76
+i5s o6a o7n
+i5r i6e
+i5o i6n i7e
+i5m i6a
+i5e o6n
+i57 *50
+i56 ,6 ,7
+i55 o64
+i53 i65 o77
+i53 i62
+i4l i5e
+i4e o5d
+i46 i56 ,6
+i44 ,5
+i43 ss2 $1
+i43 i56 o67
+i43 i51 o69
+i43 i51 o65
+i40 o53
+i3i [
+i38 i75
+i34 ,4
+i33 ,4
+i1f D3
+i19 i33
+i17 i34
+i0D i1e
+c o57
+c o20
+c '8 $7
+c $7
+^y ^t ^t ^a ^f
+^y ^d ^r ^o ^j
+^x ^a ^p
+^s ^s ^i ^w ^s
+^p ^e ^p
+^o ^r ^a ^k
+^n ^n ^e ^l ^g
+^n ^i ^k
+^n ^i ^a ^r
+^n ^a ^m ^r ^e ^p ^u ^s
+^m ^a ^k
+^m ^a ^h ^a ^r ^g
+^l o1I c
+^l ^u ^j
+^i ^v ^i ^v
+^i ^e ^w
+^i ^a ^j
+^h ^t ^r ^a ^e
+^e ^s ^r ^o ^h
+^e ^r ^i ^p ^m ^a ^v
+^e ^l ^e
+^e ^k ^a ^r ^d
+^a ^n ^n ^a ^h
+^a ^l ^i ^m
+^a ^i ^v ^l ^i ^s
+^6 o15
+^0 o10
+^0 ^0 ^9
+[ $3 $6
+T0 o2S
+D5 o4l
+D4 -2 *13
+D4 $0 $5
+D3 $5
+D2 $9 $4
+D2 $5 $6
+D2 $3 $5
+D2 $1 $7
+D1 o1v
+D1 D3 $f
+D1 D2 $b
+D1 $6 $5
+D1 $6 $3
+D1 $3 $6
+D1 $2 $0
+-1 -2 -1
++0 +3 +1
+*46 } '6
+*03 *32 *13
+$p *05
+$m $a $i
+$i $b
+$h $a $c $k
+$f $i $v $e
+$b $u $s
+$a -5
+$T
+$8 $8 $7
+$8 $2 $0
+$7 ^6
+$7 $9 $8
+$5 $9 $0
+$5 $2 $3
+$4 $6 $9
+$3 $9 $7
+$2 $3 $1
+$1 $4 $0
+$1 $0 $1 $3
+$0 $4 $0 $7
+} ^d
+} *53
+{ $g
+sa4
+o8a o9l
+o7l
+o6L
+o6B
+o5f
+o4y $n
+o4n $a
+o3u .4
+o3u $1 $2 $3
+o2u o5u
+o2n $1 $2 $3 $4
+o1u o4p
+o1o i3u
+o1i $1 $2 $3
+o1a $1 $2 $3 $4
+o1V u
+o1H u
+o0z o3a
+o0w o1y
+o0v o1o
+o0v o1g
+o0u i1s
+o0t +2
+o0s $7 $7 $7
+o0k i4o
+o0d $r
+o0a o1u
+o0K $3
+o0I $1 $2 $3
+o0I $1 $2
+o0D $7 $7
+l $8
+i78 i78
+i6u o7r
+i65 *52
+i60 i73
+i5x
+i5n i6o
+i5l o6e
+i52 i71
+i49 i50 o68
+i47 i52
+i45 i50 o64
+i43 i55 o66
+i32 i73
+i30 *21
+i1e +5 [
+i17 i37
+i16 i36
+i0F
+i0E
+i0D i1a
+c $8 $0 $8
+c $4 $1 $1
+c $1 $9 $6 $7
+c $* ^*
+^y ^r ^r ^e ^p
+^y ^k ^o ^o ^p ^s
+^y ^e ^v ^a ^d
+^y ^e ^s ^a ^k
+^y ^c ^a ^t ^s
+^y ^a ^z
+^x ^o ^s
+^u ^c ^a
+^u ^b ^a ^b
+^s ^y ^m
+^s ^u ^n ^g ^a ^m
+^s ^t ^e ^m
+^r ^o ^z ^a ^r
+^p ^e ^t ^s
+^o ^p ^p ^i ^h
+^o ^b ^a ^g
+^n ^o ^s ^b ^i ^g
+^m ^i ^d
+^l ^l ^i ^j
+^j ^b +2
+^i ^n ^o ^t
+^g ^n ^a ^u ^h
+^g ^e
+^d ^3
+^a ^s ^s ^i ^r ^a ^l
+^a ^s ^i ^l ^e
+^a *24
+^X $X
+^9 o18
+^9 D2
+^8 ^1 ^1
+^5 ^5 $5 $5
+^1 $6
+[ $2 $1
+Y2 i4i
+T1 T2 T3 T4
+K o76
+K +4
+D9 D9
+D4 o4z
+D4 o4k
+D4 $j
+D3 k
+D3 $0 $7
+D2 $6 $3
+D2 $4 $1
+D1 o4f
+D0 o1q
++4 -5 -2
+'8 $4
+$k +0
+$9 $3 $1
+$6 [
+$5 $4 $2
+$4 $8 $5
+$4 $7 $2
+$4 $5 $9
+$4 $5 $2
+$2 $9 $5
+$1 $8 $8
+$1 $0 $7
+$0 $9 $1 $1
+$0 $9 $!
+$0 $5 $0 $8
+$. $3
+se3
+o4r $a
+o3z $1 $2
+o2k o3y
+o2C c $5
+o1u ]
+o1o o5i
+o1i $k
+o1e i2k
+o1e -3
+o1d *72 *12
+o1S c o0t
+o0z o3o
+o0x o1u
+o0u o1m
+o0r o2c
+o0n ]
+o0h i2y
+o0e $2 $1
+o0d i4y
+o0M T4
+o0K D3 $1
+o0K D3
+o0J $1 $2
+o0J $0 $8
+o0A D5
+k o3o
+i80 i99
+i76 i72
+i74 i73
+i70 o86
+i6l i7a
+i6a o7l
+i61 Y1 E
+i60 i76
+i5a R4 L4
+i59 o61
+i54 ,6 o75
+i50 ss0 $1
+i50 i76
+i4w [
+i4a i5n
+i47 i50 o62
+i45 i52 o64
+i42 i52 o66
+i41 i53 o60
+i35 o48
+i34 }
+i32 i36
+i2n o3g
+i2l ,3
+i2a o3d
+i25 i33
+i0g i0s
+c so0 se3
+c o7@
+c $9 $6 $7
+c $3 $1 $4
+^y ^u ^g T3
+^y ^t ^s ^o ^r ^f
+^y ^r ^e ^m
+^y ^n ^n ^a ^r ^g
+^t ^e ^m ^h ^a
+^s ^i ^n
+^s ^d ^e
+^p ^o ^h ^c
+^p ^e ^e ^h ^s
+^p ^a ^h ^c
+^o ^s ^o
+^o ^g ^n ^o ^m
+^l ^r ^a ^e ^p
+^l ^i ^s ^a ^r ^b
+^l ^e ^s ^e ^i ^d
+^l ^e ^b ^a
+^i ^t
+^i ^n ^i ^v
+^i ^k ^o ^l
+^h ^a ^m
+^g ^f
+^e ^s ^i ^n ^e ^d
+^e ^k ^o ^m ^s
+^e $e
+^b o1e
+^a ^t ^a ^t
+^a ^r ^t ^x ^e
+^a ^l ^r ^a ^c
+^9 $7
+^6 o17
+] ] ] $a
+[ i5i
+[ $0 $5
+K i5g
+K +4 D3
+D4 o4a
+D4 *02
+D3 $2 $3
+D2 D3
+D2 $5 $5
+D2 $3 $6
+D2 $3 $0
+D1 $1 $8
+D1 $1 $0
+-0 -2 -1
++5 -0 -2
++3 k *23
++3 +1
++2 +4 -1
+*42 *13
+*20 o33
+*04 $a [
+$y +7
+$t $h $o
+$o $k $i
+$j $e $t
+$i $z
+$i $a $m
+$h $y
+$a $o
+$6 $5 $7
+$6 $1 $5
+$5 $6 $4
+$4 $4 $2
+$3 $8 $8
+$1 $5 $4
+$0 $5 $0 $7
+$. $1 $3
+r $b $o $y
+o91
+o8r
+o6s i74 E
+o6m ]
+o5e $e
+o4P l
+o45 $5 $5
+o41 i52 i60 o74
+o3o ,5
+o3a ,5
+o2w o5w
+o1u y3
+o0y D1
+o0o i1g
+o0e o4l
+o0c o6o
+o0c o4y
+o0c $a
+o0a o4a
+o0F $1 $3
+o0E D2
+o0B $1 $4
+o0A +1
+l $0 $1
+k [ o1p
+i8h
+i7i i8n
+i7L c
+i5t i6o
+i5a o6s
+i5a i6n i7t
+i58 ,6
+i56 i67 i78
+i54 o62
+i53 i60 i70 ,8
+i4i i5t
+i4e o5n
+i4d
+i4a o5b
+i49 k
+i48 i50 o63
+i45 o51
+i45 i55 o64
+i45 i50 o65
+i43 i58 o63
+i41 i53 o68
+i41 i53 o67
+i3t o4o
+i3t i4o
+i38 o47
+i36 +2
+i33 o48
+i24 i35 o46
+i24 *50 *34
+i15 z1
+i0t i1r
+i0g i1a i2b
+^y ^t ^l ^a ^s
+^y ^s ^t ^e ^b
+^y ^l ^l ^e ^n
+^y ^e ^s ^r ^e ^j
+^y ^e ^r ^f ^f ^e ^j
+^x ^n ^i ^j
+^u ^T
+^t ^f ^i ^r ^d
+^s ^u ^s ^a
+^s ^i ^s
+^r ^e ^t ^s ^e
+^r ^e ^m ^o ^o ^b
+^r ^e ^k ^c ^u ^t
+^o ^t ^u ^p
+^o ^g ^a ^c ^i ^h ^c
+^o ^c ^i ^x ^e ^m
+^n ^o ^s ^r ^e ^d ^n ^a
+^n ^a ^i ^t ^s ^a ^b ^e ^s
+^k o2o
+^g *13
+^e ^t ^r ^a
+^e ^n ^a ^s ^n ^i
+^e ^k ^a ^n ^s
+^e ^i ^g ^n ^a
+^a ^t ^n ^a ^s
+^a ^m ]
+^P D5
+^L i1u
+[ $2 $6
+Z1 *4B .2
+T1 T3 T5 T7
+T1 T2 T4 T5
+K [
+D6 [ sUx
+D6 +5
+D5 o5d
+D3 o3b
+D3 $c
+D3 $3 $4
+D3 $2 $1
+D2 $7 $3
+D2 $2 $3
+D1 y3
+D1 r {
+D1 $3 $2 $1 r
+D1 $2 $3
+-0 -5 -2
++4 -1
++3 +3 -1
+'7 ] *14
+$m $y
+$l {
+$l $i $n $g
+$l $e $s $s
+$k Z2
+$7 $3 $2
+$6 $3 $6
+$5 $7 $1
+$5 $2 $9
+$3 $k
+$3 $7 $5
+$3 $6 $8
+$3 $5 $6
+$3 $4 $0
+$2 $7 $5
+$2 $6 $2
+$2 $1 $2 $1
+$1 $9 $8
+$1 $7 $5
+$1 $6 $7
+$0 $6 $0 $8
+$0 $3 $0 $4
+o6o Z1
+o5z i61 i72 o83
+o4h $h
+o3i $2 $0 $0 $2
+o3d $1 $2 $3
+o2y ]
+o2u ]
+o2k o4o
+o2k $s
+o2f i4t
+o2f $1 $2
+o1y ]
+o1i i2k
+o1e o5m
+o1a o3i
+o1a o0A
+o1a -3
+o1C u
+o0x ]
+o0t $5
+o0t $2
+o0r +4
+o0q D3
+o0n o2i
+o0j i2y
+o0i o4i
+o0h $1 $2 $3
+o0g i2h
+o0R $4
+o0L *23
+o0K $1 $3
+o0J D2
+o0G $0 $8
+o0C o61
+o0C $3
+o0$
+l i5b o6o ,7
+l ^g ^i ^p
+k o2l
+iA0
+i7d
+i75 -8
+i72 i80
+i72 [ c
+i6l i7i i8n
+i6f *64
+i6d o7a
+i63 i76 o80
+i60 i71
+i5t o6e
+i5o o6u
+i5a o6t
+i59 o60
+i57 o68
+i54 o60
+i52 o60 o71
+i4z i5i
+i4r o5o
+i4e i5t
+i4b o5a
+i48 i50 o64
+i47 i55 ,6
+i47 i50 o66
+i45 i58 o65
+i45 i53 o61
+i43 o56
+i43 i55 o60
+i41 i56 o60
+i3j o4a
+i31 ,4
+i2d o3e
+i1l D5
+i13 i38
+i13 *04
+i1. o3. o5.
+c o56
+c o33
+c $9 $0 $9
+c $6 $1 $9
+^x ^i ^n
+^t ^n ^i ^o ^p
+^t ^l ^o ^b
+^o ^g ^o ^i ^d
+^o ^e ^t ^t ^a ^m
+^o ^c ^c ^o ^r
+^n ^o ^c ^l ^a ^f
+^n ^a ^h ^o ^j
+^m ^n
+^m ^i ^l
+^k D6
+^f ^e ^i ^h ^c
+^e ^n ^i ^h ^s ^n ^u ^s
+^d ^n ^a ^h
+^d ^e ^k ^c ^i ^w
+^a *46
+^6 ^4 ^2
+^5 o14
+^5 ^5 ^1
+^2 ^1 ^2
+^1 $5
+[ o0t +2
+[ $3 $4
+D4 o4d
+D4 $0 $6
+D3 $3 $2
+D3 $2 $8
+D3 $0 $6
+D2 $2 $8
+D2 $1 $1
+D1 o2p
+-0 -3 -2
++2 +2 -0
++0 +1 -2
+*53 $a
+'8 ^4
+$t $r $a $n
+$o $r $o
+$j $a $s $o $n
+$g $a $m $e
+$d $o $s
+$c $r $a $z $y
+$8 $8 r
+$6 $2 $1
+$5 $6 $1
+$5 $3 $2
+$4 $6 $5
+$2 $5 $1 $0
+$2 $1 r
+$1 $8 $6
+$1 $7 $4
+$1 $4 $1
+} i45
+{ o0C ]
+{ $d
+oB3 E
+o7l ]
+o6U c
+o5s t
+o5g ,6
+o4y $a
+o4t $t
+o4a $o
+o3p $1 $2 $3
+o2d Y1 o3e
+o1u o5h
+o1o o3p
+o1o ]
+o1j ,2
+o1i o5g
+o1g i2h
+o1a o3u
+o0z o3z
+o0w o1u
+o0w *05
+o0w $3
+o0t i2r
+o0t $0 $2
+o0s o1y
+o0r u
+o0r o1h
+o0o o1h
+o0n D4
+o0n D3
+o0m i3o
+o0k $2 $0 $0 $0
+o0i o2o
+o0d i2y
+o0a o1q
+o0S $1 $4
+o0B D6
+o0B $1 $8
+l $b $o $o
+k y2 *51
+i87 i98
+i7_ $3
+i78 $7
+i74 i70
+i6g D4
+i60 i77
+i5m o6o
+i5k [
+i53 o65
+i52 o61
+i52 i41
+i4r o5e
+i4f *25 D1
+i49 o56
+i49 i50 o65
+i48 i52 o66
+i44 i50 o68
+i42 i58 o65
+i42 i50
+i4$
+i3e o4r
+i36 i69
+i32 i33
+i2g o3h
+i22 }
+i1c i2h
+i15 i15
+i13 i13
+i0b i1l i2a
+c $9 $7 $0
+c $3 $1 $3
+c $3 $0 $3
+c $3 $0 $0 $0
+c $2 $5 $8
+c $1 $9 $6 $9
+^z ^e ^n ^i ^t ^r ^a ^m
+^y ^t ^n ^i ^m
+^y ^k ^l ^i ^m
+^u ^l ^i ^m
+^s ^u ^i ^l ^u ^j
+^s ^r ^e ^g ^i ^t
+^s ^m ^k
+^r ^e ^g ^g ^i ^t
+^r ^e ^d ^l ^e
+^o ^c ^i ^p
+^n ^r ^o ^c
+^n ^o ^n ^n ^a ^h ^s
+^n ^i ^e ^m ^t ^e ^l
+^l ^e ^m ^a ^c
+^l -1
+^i ^m ^a ^i ^m
+^i ^b ^a ^f
+^e ^d ^n ^a ^r ^g
+^d ^n ^i ^w
+^b ^n
+^a ^j ^n ^a
+^a ^i ^n ^o ^s
+^a ^i ^d ^n ^i
+^W D2
+^O D3
+^3 $5
+^" o0c $4
+] ^n
+[ [ $5
+K srp o4d
+K o0w
+K i5n
+D4 o4p
+D4 $3
+D4 $1 $9
+D2 $2 $6
+D2 $1
+D1 D6
+D1 $2 $4
++4 -0 -0
++4 *20
++3 o0d
+'9 $3
+$o $r $t $i $z
+$l $o $c $k
+$j $o $k $e $r
+$b $a $l $l $s
+$a $g $e
+$9 Y2
+$8 $2 $2
+$6 $0 $7
+$5 $8 $8
+$5 $7 $6
+$4 Y2
+$4 $5 $7
+$4 $0 $3
+$3 $8 $1
+$3 $6 $6
+$3 $2 $1 r
+$2 $0 $0 $1
+$1 $9 $4 $9
+$0 $2 $0 $9
+$# $2
+{ i34
+{ +5 +2
+o8- o9f $r $e $e
+o4y i5p i6o ,7
+o4g $o
+o4e $e
+o4a $r
+o4T T0
+o41 i50 i62 o73
+o3z $1 $2 $3
+o3i i65
+o32 i40 i50 o61
+o2n .5
+o2d y2
+o2b o4o
+o1o o3o
+o1o -5
+o1a i4i
+o1J [
+o0z $4
+o0t u
+o0t o3n
+o0p *21
+o0p $2 $2
+o0n *41
+o0n $5
+o0e -2
+o0d o4y
+o0b i4o
+o0P u
+o0J $0 $9
+o0D $3
+o0D $2 $2
+o0C $!
+l $b $o $y $1
+k Y1 +2
+i67 Y2
+i6. o71
+i6# i71
+i5m o6c
+i5e i5b
+i50 o63
+i50 i75
+i4c o5h
+i49 i52 o69
+i48 +2
+i45 i52 o65
+i44 i55 o64
+i44 i53 o60
+i42 i56 o64
+i40 o56
+i3m i4a i5n
+i36 ,4
+i32 ss2 $2
+i11 i32
+i0k i1e
+i06 K *03
+c sa@ so0 ss$
+c T2 i2.
+c $9 $1 $2
+c $7 $1 $1
+c $2 $4 $6
+c $1 $9 $7 $0
+^z ^i ^l ^e ^f
+^y ^v ^a ^d
+^v ^a ^k
+^t ^t ^a ^y ^w
+^t ^a ^w ^s
+^s ^r ^u ^p ^s
+^s ^k ^a
+^s ^e ^h ^c
+^s ^e ^c ^n ^a ^r ^f
+^s ^d ^n ^e ^i ^r ^f
+^r ^t ^g
+^r ^o ^r ^r ^e ^t
+^r ^e ^t ^o ^o ^c ^s
+^r ^e ^b ^m ^e ^m ^e ^r
+^p ^p ^a
+^o ^g ^a
+^o ^c ^s
+^o ^a ^l
+^m ^a ^i ^r ^i ^m
+^l ^a ^k
+^k ^c ^a ^z
+^k ^c ^a ^r ^c
+^i ^r
+^i ^c
+^f *21
+^e ^k ^a ^l
+^e ^g ^i ^a ^p
+^e ^e ^m ^i ^a
+^a ^s ^a
+^a ^r ^r ^e ^i ^s
+^a ^n ^i ^r ^a ^k
+^a ^i ^c ^i ^t ^e ^l
+^8 ^2 T2
+^6 o16
+^6 ^2 ^1
+^5 ] ]
+^1 ^9 o21
+[ $0 $0 $7
+T3 ^K -0
+D2 *30
+D2 $1 $3
+D1 $f
+D1 $8
+-0 $7 $7
++6 i7.
++2 +4 -0
++1 +4 *35
+*20 }
+*02 o3f
+$j $o $r $g $e
+$h Y1
+$d D5
+$_ $2 $2
+$9 [
+$9 $3 $2
+$8 $5 $6
+$8 $0 $6
+$7 $4 $5
+$7 $0 $8
+$3 $9 $4
+$2 $8 $0
+$2 $2 $!
+$2 $1 $0 $9
+$0 $8 $0 $8
+} D2
+o7d ]
+o4l $i
+o4e $o
+o40 i55 i60 o75
+o3o $2 $0 $0 $5
+o3a $i
+o1u o2y
+o1s o2j
+o1F E
+o0z o2r
+o0x D4
+o0t o1k
+o0s o1w
+o0p i2r
+o0n o62
+o0n o1y
+o0n *23
+o0m $e
+o0k ,5
+o0j o4y
+o0T D2
+o0M $1 $6
+o0G $6
+o0F $6 $9
+o0E $2
+o0B $1 $6
+i8e
+i73 i82 o91
+i72 i77
+i6r o7o
+i6o o7r
+i6c L7
+i5m o6a
+i5i o6l
+i5e i6s
+i5a o6l o7i
+i59 i68 i77
+i54 i66 o78
+i53 i64 ,7
+i53 i60 ,7
+i52 -2
+i4s i5a
+i4r o5a
+i4n i5a
+i4n ]
+i4n T0
+i4m o5y
+i4l '8
+i4c o5o
+i4c i5o
+i47 i56 o67
+i47 i52 o64
+i46 i55 ,6
+i45 i53 o65
+i42 i51 o67
+i40 o55
+i39 o44
+i38 }
+i38 ,4
+i37 o48
+i23 $2
+i0s i1e
+i0k +4
+c sa4
+c K }
+c $3 $1 $1
+^y ^m ^o ^t
+^y ^b ^o ^r
+^y ^b ^b
+^t ^a ^r ^u ^m
+^s ^i ^a ^n ^a
+^r ^e ^v ^a ^e ^b
+^r ^e ^m ^m ^u ^r ^d
+^p t
+^o ^n ^e ^r
+^o ^l ^l ^o ^p
+^o ^c ^s ^i ^c
+^n ^r ^e ^d ^o ^m
+^n ^o ^s ^i ^o ^p
+^n ^i ^m ^s ^a ^j
+^n ^a ^p ^a ^j
+^l ^a ^h
+^k ^e ^r ^a ^m
+^i ^r ^f
+^h ^s ^a ^c
+^g o1e o2r
+^e ^k ^i ^n
+^e ^e ^f ^f ^o ^c
+^e +6
+^c ^t
+^a ^n ^i ^l ^a
+^a ^n ^a ^n
+^T
+^9 ^1 ^1
+^7 ^5 ^1
+^5 o16
+^5 ^1 ^2
+^5 +1
+[ i2a
+[ $4
+D5 o5w
+D5 $s
+D4 $3 $3
+D4 $1 $4
+D4 $0 $7
+D4 $0 $0 $7
+D3 o3q
+D3 $q
+D3 $4 $4
+D3 $2 $4
+D3 $0
+D2 $3 $6 $0
+D2 $2 $4
+D1 o2f
+D1 K k
+D1 $x
+D1 $4 $3
+D1 $3 $3
+-0 $4 $0
++4 o10
++4 -1 -2
++3 -1 -1
+*02 o20
+$z $k
+$m $a $k $e $r
+$l $o $g
+$i $r
+$f $a $m
+$a $p $p $l $e
+$_ $8 $9
+$8 $8 $1
+$7 $9 $7
+$6 $7 $6
+$5 $8 $7
+$5 $8 $2
+$3 $3 $5
+$2 Z3
+$2 $8 $2
+$2 $7 $8
+$2 $0 $2 $1
+$1 $8 $5
+$1 $0 $2 $7
+$0 $3 $0 $8
+$. $4
+o75 Y2
+o6_ D4 c
+o67
+o5p c
+o4y $0 $3
+o4_ *75
+o41 i50 i60 ,7
+o3a $a
+o2u o3e
+o1y o3i
+o1r $1 $2
+o1o o4p
+o1c o3e
+o1,
+o0x +1
+o0v o1c
+o0v D4
+o0s i2m
+o0s D4
+o0q i1w
+o0p $0 $2
+o0k i2v
+o0k i1h D3
+o0k $u
+o0i o2g
+o0i ,1
+o0d $7 $7 $7
+o0N $1 $0
+o0K D2
+o0K $6 $9
+o0F ,3
+o0D $2 $5
+l o6b o7o $y
+l ^k ^o ^o ^b
+i83 -7
+i82 i90 ,A ,B
+i71
+i6i ,5
+i6g o7a
+i5i o6k
+i5e o6d
+i5c i5e
+i55 i65 o76
+i52 i61 o73
+i50 i60 o72
+i4m o5e
+i4e [
+i4_ K
+i49 i50
+i47 i51
+i45 o50
+i43 i55 o67
+i42 i54 o65
+i35 *21
+i34 o46
+i34 o45
+i33 $0
+i0M o1a
+c i63
+c ^5 ^1
+c $m $e
+c $9 $6 $9
+c $7 $4 $7
+c $1 $9 $7 $2
+c $0 $7
+c $-
+^y ^r ^r ^e ^b ^e ^u ^l ^b
+^y ^n ^o ^j
+^y ^m ^m ^e
+^y ^k ^n ^u ^p
+^y ^k ^c ^u ^d
+^t ^i ^a ^c
+^s ^m ^a ^r
+^s ^j ^c
+^s ^i ^r
+^s ^i ^n ^a
+^r ^a ^e ^p
+^p ^r ^a ^c
+^p ^a ^t
+^o ^b ^m ^a ^m
+^n ^e ^r
+^n ^e ^d ^a ^j
+^l ^i ^s
+^i ^l ^o ^p
+^h ^a ^j ^i ^l ^e
+^e ^t ^a ^n
+^e ^m ^l ^l ^a ^c
+^e ^m ^a ^l ^f
+^c ^i ^t ^l ^e ^c
+^c ^i ^r ^t ^c ^e ^l ^e
+^c ^e ^l ^a
+^b D4
+^a ^n ^i ^g
+^a ^l ^i ^l
+^a ^g ^a ^g
+^a ^c ^a ^c
+^9 o18 r
+^9 ^9 ^0
+^5 o17
+^2 ^1 ^0 o33
+] o3_
+[ $0 $1
+D5 o5k
+D5 $3 $3
+D4 $0 $2
+D2 o4f
+D2 D6
+D1 $5 $9
+D1 $5 $2
+D1 $2 $7
+.0 ,2 r
+-1 -2 -3
+-0 -3 -2 -1
+-0 -1 -1
++9 -8
++2 -1 -1
++1 *04 slk
+*45 r
+$t $a $i $l
+$o $m $o
+$o $9 $9
+$f $o $r $d
+$e $v $i $l
+$8 ^2
+$8 $9 $5
+$7 [ -2
+$7 $9 $5
+$5 $6 $0
+$4 $7 $9
+$3 $5 $4
+$2 $6 $0
+$1 $2 $3 $1 $2 $3
+$1 $0 $2 $6
+$1 $0 $2 $2
+$1 $0 $0 $8
+$0 $2 $0 $4
+$- $0 $1
+} x02
+s=C '5 Z2
+oB5
+o8z
+o4I l
+o43 i54 i63 o74
+o40 i59 i60 o79
+o3t $1 $2 $3
+o3_ o0b
+o3_
+o2q ,3
+o1u i3u
+o1a o4o
+o1a o3f
+o0z i1a
+o0x o1p
+o0v $7
+o0t o2s
+o0t $1 $1
+o0t $1 $0
+o0s i4h
+o0s $2
+o0r o1g
+o0r i1c
+o0r $5
+o0q o1w
+o0p o2k
+o0p $5
+o0o o1m
+o0n o3e
+o0j i2i
+o0a o2o
+o0a i2n
+o0W $0 $1
+o0P $7
+o0P $2 $1
+o0K $2
+o0G Z1
+l $y $y $o
+i8a
+i88 $0
+i81 ,9
+i75 i74
+i75 ,8
+i6e ]
+i6c +7
+i63 i72
+i6#
+i5m i6o i7n
+i5l i6i
+i5g o6u
+i5d i6i
+i5d i5a
+i5c o6a
+i54 D8 @s
+i52 i65 ,7
+i50 i61 o74
+i4r E
+i4i ,3
+i4h *04
+i4e o5l
+i4a o5s
+i48 i52
+i48 i50 o69
+i48 i50
+i45 i51 o64
+i45 -1
+i44 i51 o63
+i43 i53 o62
+i43 ,5
+i42 o56
+i41 i57 o63
+i41 i51 o66
+i40 $5
+i3u i4s
+i3e i4r
+i37 i48 o56
+i37 i46 o58
+i34 o49
+i2e o3r
+i16 i16
+i0k i1h
+i0b i1r i2e
+i0A
+c o54
+c $9 $9 $7
+c $9 $5 $2
+c $9 $4 $7
+c $5 ^9
+c $2 Y1
+^z ^e ^h ^c
+^z ^a ^y
+^y ^b ^o ^c
+^x ^y ^n ^o
+^v ^r ^a ^m
+^t ^t ^e ^r ^r ^a ^g
+^t ^i ^o ^r ^t ^e ^d
+^s ^s ^a ^k ^c ^a ^j
+^s ^i ^r ^a ^m
+^s ^a ^l ^b
+^r ^e ^z ^n ^a ^p
+^r ^e ^t ^x ^a ^b
+^r ^e ^s ^s ^a ^w
+^r ^a ^t ^a ^v ^a
+^r ^a ^c ^s
+^o ^x
+^o ^m ^a ^c
+^o ^l ^a ^g
+^o ^j ^e ^l ^a
+^o ^e ^d
+^n ^o ^v ^e ^d
+^n ^o ^t ^l ^a ^d
+^n ^i ^r ^a ^k
+^k $1
+^i ^M
+^g ^n ^i ^c ^n ^a ^d
+^e ^r ^d
+^e ^n ^u ^j
+^e ^i ^s ^o ^r
+^e ^i ^l ^l ^i ^m
+^e ^c ^i ^n
+^b ^e
+^a ^x ^e ^l ^a
+^a ^r ^a ^m
+^a ^i ^l ^e ^m ^a
+^a ^i ^c ^i ^r ^t ^a ^p
+^a ^d ^i
+^8 o17 r
+^7 ^0 ^1
+^6 ^2 ^6
+^4 ^3 ^2 ^1 ]
+^4 ^2 ^1
+^3 $9
+[ i4r
+[ i2j
+T0 i4B
+K .0
+K ,3 *20
+D6 $0
+D5 $1 $5
+D3 $0 $0
+D2 $2 $0
+D1 k
+D1 $3 $5
+D1 $3 $1
+D1 $1
+@v k ^w
++7 $7
++1 -2 -2
++1 +4 +2
+*53 k
+*45 { *25
+$o $j $o
+$m D5
+$i $e $s
+$e $n $d
+$c $a $m
+$b $u $g
+$b $e $l $l
+$a $m $y
+$a $k
+$_ $1 $1
+$8 $9 $9
+$6 $4 $6
+$5 $5 $4
+$4 $9 $3
+$4 $7 $1
+$3 $9 $6
+$3 $9 $1
+$2 $3 $1 $1
+$1 $7 $2
+$1 $4 $9
+$1 $2 $1 $3
+$1 $0 $2 $1
+$1 $0 $1 $8
+} $e
+y2 Z2
+y1 ^y
+u o4_ D0
+r ^A
+o74 Z2
+o5p $o
+o49
+o3i $1 $2 $3 $4 $5
+o1y i2m
+o1s {
+o1o i3b
+o1m ]
+o1e o3y
+o1e $t
+o1a o6a
+o1E Z1 D0
+o0z o2d
+o0x o3o
+o0v ]
+o0u i1m
+o0r $2
+o0k $a
+o0h $3 $2 $1
+o0f $1 $2 $3
+o0e o3e
+o0e +1 ^j
+o0S D5
+o0M $2 $7
+o0L $3
+o0L $0 $5
+o0K o2e
+o0H D5
+o0G o51
+o0C D5
+o0C $2 $5
+o0C $1 $6
+o0C $1 $4
+l o7k o8o
+i97 iA7 iB7
+i90 iA0 iB0
+i85 i96 iA7
+i64 i73
+i62 i71
+i5b i6o
+i57 ,6 ,7
+i51 i64 ,7
+i4t o5e
+i4c i5a i6t
+i4c c
+i42 i54 ,6
+i40 i50
+i3l o4a
+i3A [ *02
+i37 i41 o54
+i33 i48 o56
+i33 i35
+i30 i40 o57
+i0a t
+d 'F
+c sa@ se3 si1
+c -9 scD
+c $e $n
+c $A
+c $9 $7 $1
+c $9 $5 $5
+c $7 $5 $3
+^z ^t ^r ^e ^w ^q
+^y ^e ^r ^b ^u ^a
+^y ^c ^i ^p ^s
+^w ^t ^f
+^w ^o ^l ^g
+^v ^i ^r
+^u i0H
+^t ^r ^u ^c
+^t ^r ^e
+^t ^o ^h ^s
+^s ^s ^e ^h ^c
+^s ^r ^e ^d ^n ^a
+^s ^m ^h
+^s ^m ^d
+^s ^j ^m
+^s ^a ^l ^t ^a
+^r o1r
+^r ^e ^t ^s ^e ^h ^c ^n ^a ^m
+^r ^e ^t ^a ^k
+^o ^g ^n ^i ^d
+^m *02
+^l o1y
+^l ^x ^a
+^l ^i ^f
+^l ^e ^k
+^k i0e
+^k ^c ^i ^s
+^d ^f
+^d $1
+^a ^c ^i ^r ^e
+^O D2
+^6 D2
+^0 ^2 ^0 ^1
+[ i4v
+[ $2
+Y1 y2
+K o4b
+D5 *32
+D5 $2 $3
+D5 $1 $1
+D4 D6
+D4 $3 $4
+D4 $1 $2 $3
+D3 t ]
+D3 $4
+D3 $1 $4
+D2 $9 $3
+D2 $5 $2
+D2 $2 $1
+D1 o2v D3
+D1 o2q
+*25 D1
+'8 $9
+'5 f
+$w $i $z
+$d +6
+$9 $6 $2
+$8 $2 $4
+$6 $9 $2
+$6 $2 $2
+$5 ^4
+$5 $7 $8
+$3 $5 $9
+$2 $8 $7
+$2 $3 $3
+$1 $7 $3
+$1 $6 $3
+$1 $0 $0 $9
+} *41
+t .2
+oB* Y2 y4
+o6A
+o5L u
+o4u $u
+o4! i5! ,6
+o3y $0 $1
+o3p ^s
+o3i $a
+o3c t
+o3b t
+o3a t
+o2k $1 $2 $3
+o2i t
+o2i $1 $2 $3 $4
+o2W u
+o1r o3a
+o1i ,3
+o1A Z1 E
+o0y o2g
+o0t o2g
+o0t i1h o2o
+o0t D2
+o0q o1i
+o0p i1e
+o0o o1s
+o0n i2r
+o0Y $1
+o0U $1
+o0M $1 $5
+o0L $2 $3
+o04 R1 r
+k l .3
+k -3 t
+i8. $0
+i8!
+i76 i70
+i6c o7k
+i65 .4
+i64 o75
+i62 D2
+i5n c
+i5e i6t
+i53 o66
+i53 i66 o70
+i52 o65
+i51 i69 ,7 o84
+i4z [
+i4w o5e
+i4f o5a
+i4e o5g
+i4P l @v
+i49 i58 o69
+i47 i51 o64
+i47 i50
+i46 i52 o66
+i45 i52 o63
+i44 o52
+i44 i51 o62
+i44 i50 o64
+i43 i51 ,6
+i43 i50 o63
+i42 i57 o64
+i3l c
+i39 i46 o53
+i30 ss0 $1
+i30 i37
+i2q o3u
+i2a o3f
+i21 o38
+i0f -1
+i0b $2
+c $9 $5 $4
+c $1 $0 $8
+^z ^r ^a ^m
+^y ^s ^e ^e ^h ^c
+^y ^p ^e ^e ^l ^s
+^y ^k ^n ^a ^r ^f
+^y ^k ^c ^i ^t ^s
+^y ^k ^c ^a ^l ^b
+^y ^c ^a ^l
+^y ^a ^d ^n ^u ^s
+^w ^e ^h ^t ^a ^m
+^t ^u ^l ^a ^s
+^t ^t ^a ^k
+^t ^m ^a
+^t ^e ^m ^o ^c
+^t ^e ^l ^r ^a ^c ^s
+^s ^n ^a ^v ^e
+^s ^n ^a ^e ^b
+^s ^e ^l ^b ^b ^u ^b
+^s ^a ^e
+^r ^e ^m ^m ^o ^s
+^p ^i ^l ^s
+^o ^r ^d ^n ^a ^s
+^o ^o ^b ^o ^o ^b
+^o ^m ^o ^d
+^o ^d ^e ^r ^f ^l ^a
+^o ^c ^s ^a ^v
+^n ^i ^j
+^m t
+^m ^u
+^l ^l ^o ^r ^t
+^l ^e ^h
+^k ^i ^m
+^k ^c ^i ^m
+^i ^p
+^i ^m ^o ^a ^n
+^i ^j ^u ^f
+^g ^n ^i
+^e ^v ^i ^t ^a ^e ^r ^c
+^e ^n ^i ^l ^n ^o
+^d Y1
+^c $1
+^a ^t ^e ^m
+^a ^s ^i ^u ^l
+^_ o6_
+^X u
+^S u
+^9 o13
+^9 ^7 ^5 ^3 ^1
+^2 o11
+^1 ^0 ^1 T3
+] ^Z
+[ [ $e
+[ $1 $4
+D5 $j
+D4 o4u
+D4 o4m
+D3 $m
+D2 o2p
+D2 D2 $1
+D2 +0 y2
+D2 $9 $9
+D2 $6 $0
+D2 $0 $5
+D1 D2 $j
+D1 $7 $7
+D1 $6
+D1 $4 $2
+D1 $0 $7
+D0 y3 *35
++5 +1
++4 +1
++0 $8 $9
+*71 *60
+*31 +2
+'8 $0
+$u $1 $2 $3 $4
+$s $k $u $l $l
+$r i7t
+$r $t $y
+$m $o $o
+$l -6
+$c $h $e
+$b $i $g
+$_ $2 $1
+$8 Z1 k
+$7 $9 $2
+$7 $7 $1
+$5 $9 $2
+$4 $1 $8
+$3 $0 $3 $0
+$2 $4 $9
+$2 $4 $1 $0
+$1 r ^3
+$1 $7 $8
+$1 $6 $4
+$1 $2 $0 $2
+$1 $0 $.
+$. $9
+$- $1 $2 $3
+o4l u
+o4i $o
+o4g $u
+o4c $o
+o46 i56 i66 ,7
+o3j r
+o3e $e
+o2o ]
+o1y o3y
+o1a o3e
+o0z $5
+o0y i1o
+o0t i1g
+o0t D7
+o0s i1a
+o0r +3
+o0n i1g
+o0k i2b
+o0j +2
+o0j *64
+o0i o1z
+o0h $0 $4
+o0e i2r
+o0T $5
+o0P D4
+o0L $2 $2
+o0L $2 $1
+o0K D6
+o0J D6
+o0G T3
+o0E $1 $2
+l $i $i $i
+i81
+i73 i74
+i72 i80 i90 ,A
+i71 i81
+i5n o6o
+i5n i6e
+i59 K
+i56 ,6
+i55 i66 o77
+i51 i60 i72
+i50 i60 o79
+i4l o5i
+i49 i50 o63
+i47 i51 ,6
+i46 o57
+i43 i53 o66
+i43 i50 o62
+i42 o54 o66
+i42 i53 o67
+i40 o59
+i39 ss9 $9
+i37 ss7 $7
+i34 ss4 $4
+i2p o3p
+i2o .1
+i2A E
+i0m i1i i2c
+c o62
+c T7 ]
+c $9 $6 $5
+c $5 $2 $1
+c $4 $2 $6
+c $0 $9 $!
+^z ^l ^o ^l
+^z ^e ^l ^a ^z ^n ^o ^g
+^y ^r ^u ^f
+^y ^p ^p ^i ^k ^s
+^y ^g ^g ^e ^p
+^y ^b ^a ^b ^y ^m
+^u ^e ^l ^b
+^t ^i ^a ^k
+^s ^u ^m ^i ^x ^a ^m
+^r ^m ^j
+^r ^e ^c ^n ^a ^c
+^r ^a ^k ^s ^o
+^o ^n ^u ^n
+^o ^i ^p
+^o ^g ^i ^m ^a
+^o ^d ^i ^f
+^n ^u ^a ^h ^s
+^n ^o ^s ^y ^t
+^n ^o ^l ^l ^i ^d
+^n ^o ^d ^r ^o ^g
+^n ^e ^h
+^n ^a ^c ^i ^x ^e ^m
+^k ^r ^a ^m T4
+^k ^i ^l ^a ^m
+^k ^c ^a ^m
+^i ^x ^e ^l
+^i ^v ^a
+^i ^r ^a ^r ^r ^e ^f
+^i ^m ^a ^c
+^i ^e ^l
+^g ^n ^i ^n ^r ^u ^b
+^e ^r ^r ^e ^i ^p
+^e ^n ^y ^a ^w
+^a ^r ^a ^i ^h ^c
+^a ^k ^i ^m
+^a ^e
+^P $1
+^7 o19
+^6 ^5 ^4 ^3 ^2 ^1 ]
+^3 ^2 ^1 D5
+Y5 o3g
+T0 o4C
+D5 o5p
+D5 $1 $4
+D4 $c
+D4 $2 $2
+D3 $f
+D3 $2 $6
+D1 D2 o2q
+D1 D2 $1
+D1 D1 +2
+D1 $q
+D1 $5
+D1 $4 $4
+D1 $3 $9
+-0 $5 $0
++5 -0 +5
++4 -0 -2
++1 -2 +4
+*76 }
+*35 *04
+*30 *20
+$n $a $m $e
+$l $i $a
+$d $o $n
+$d $1
+$8 $6 $9
+$8 $2 $9
+$8 $2 $6
+$7 $9 $0
+$7 $0 $3
+$6 $4 $5
+$5 ^2
+$5 $3 $5
+$4 $8 $9
+$4 $7 $5
+$4 $6 $2
+$4 $5 $3
+$3 $6 $2
+$3 $4 $9
+$2 $7 $7
+$2 $7 $0
+$2 $5 $0 $1
+$2 $3 $0 $8
+$1 $6 $6
+$1 $0 $1 $9
+$- $1 $3
+} ^0
+{ +2
+syq Z1 o9y
+sa@
+s0)
+o5n @o o5u
+o5a ,6
+o5a $a
+o50 ^B
+o4y ,5
+o4u t
+o44 u
+o41
+o3u y2
+o3u $1 $2 $3 $4
+o3i $s
+o3a $1 $2 $3
+o3_ c
+o2y o5a
+o2y o4o
+o2r
+o2o o4a
+o1u -3
+o1o o5f
+o1o $n
+o1e o5u
+o1a o3z
+o1a o0Y
+o0u o1s
+o0u i1r
+o0s o2a
+o0s i2r
+o0m $1 $2 $3
+o0j i3o
+o0j ,5
+o0g $a
+o0D $2 $4
+o0C $0 $5
+o0B .2
+l z2 *14
+i83 i94 iA5
+i77 i71
+i74 ,8
+i6u o7m
+i6r o7a
+i6m i7e
+i6d o7e
+i6a o7m
+i61 i75
+i5t i6e
+i5a o6c
+i5a i6s
+i59 i69 o70
+i54 Y1
+i50 i60 i77
+i4t
+i49 ,5
+i45 i56 o65
+i45 i51 o65
+i43 o50
+i42 o54
+i41 o54
+i3t o4a
+i3t [
+i3i i4n i5g
+i3f ,4
+i3e i4n
+i3b o4e
+i35 ss5 $5
+i2d i3a
+i18 i58
+i11 i34
+i0s i1t i2e
+i0j i1a i2c
+c ^9 ^9
+c $2 $0 $2
+c $1 $9 $6 $6
+^y ^n ^a ^m ^r ^e ^g
+^t ^f ^i ^w ^s
+^s ^k ^r ^a ^m
+^r ^y ^m
+^r ^i ^a ^l ^b
+^r ^e ^v ^i ^l
+^o ^p ^i ^p
+^o ^n ^e ^g
+^o ^l ^i ^l
+^o ^j ^a ^m
+^o ^a ^b
+^n o1y
+^n ^o ^s ^l ^e ^n
+^n ^o ^r ^a ^h ^s
+^n ^i ^v ^l ^a ^c
+^n ^i ^a ^m
+^n ^a ^n ^a ^b
+^m ^r ^a
+^k D5
+^i ^k ^u ^y
+^i ^j ^n ^e ^b
+^e ^e ^b
+^d ^o ^o ^w
+^c ^x ^z
+^c ^i ^x ^o ^t
+^a ^l ^l ^e ^b ^a ^s ^i
+^a ^i ^v
+^4 *14
+[ i2k
+[ $1 $2 $3
+K $i
+E o4M
+D9 D6
+D4 R3
+D3 $6
+D2 $j
+D2 $3 $2
+D2 $1 $6
+D2 $0 $4
+D2 $0
+D1 o4w
+D1 o1d D3
+D1 $1 $6
+D1 $0 $1
+-1 ^3
+-1 -2 -2
+-0 $9 $0
+-0 $8 $8
++8 -7 -7
++3 -0 -2
++2 -1 +2
+*24 {
+*23 *15 *04
+$o $y
+$n o7a
+$m o2r
+$m $i $l $e
+$g $a $m $e $r
+$e $l
+$b $u $d
+$b $1
+$N l {
+$7 $8 $9 $0
+$4 $6 $4
+$3 $8 $7
+$3 $5 $3
+$2 $9 $8
+$2 $8 $1
+$1 $9 $1 $9
+$1 $8 $1
+$1 $4 $8
+$1 $0 $1 $7
+$0 $7 $1 $1
+$0 $2 $0 $7
+{ +1
+t ^D
+o5l $a p3
+o4p $o
+o4l $l
+o4b $o
+o41 i55 i61 o75
+o3c ]
+o3K u
+o2y o4u
+o2o ,3
+o2g $1 $2 $3
+o2e o3y
+o2A u
+o1y o3o
+o1r o3h
+o1o o3y
+o1o $s
+o1k $1 $2
+o1i i4i
+o1e o5i
+o1e o4k
+o0v o1t
+o0u o1p
+o0l i2k
+o0k i2d
+o0k $p
+o0k $i
+o0j o1y
+o0j i2j
+o0g .3
+o0e $s
+o0d o6o
+o0b $1 $2 $3
+o0a o3e
+o0T $0 $8
+o0P +8
+o0L $1 $8
+o0H $1 $3
+i9r o8e
+i6d o7i
+i60 i70 i81
+i5v
+i5r o6i
+i5g o4a
+i57 o60
+i55 o60
+i54 i64 ,7
+i52 i60 o71 o82
+i4m o5o
+i4j o5u
+i4g ]
+i4b i5o
+i4a i5t
+i48 i52 o65
+i46 o51
+i46 i55 o64
+i45 i51 o62
+i45 i50 o61
+i44 o56
+i43 o57
+i43 o51
+i43 i51 o63
+i42 o53
+i3g .2
+i3e o4k
+i37 i44 o57
+i33 i41 o56
+i32 o47
+i31 i36
+i1z } .2
+i0l i1u i2c
+c T3 i3.
+c $3 $6 $0
+c $1 $9 $6 $5
+^z ^n ^o ^g
+^y ^a ^j ^y ^a ^j
+^x ^e ^p ^a
+^u ^g ^u ^g
+^t ^n ^i ^l ^c
+^s ^y ^s
+^s ^e ^l ^p ^p ^a
+^s ^e ^i ^p
+^s ^a ^n ^a
+^s ^a ^i ^d
+^r ^o ^m ^a ^i ^m
+^r ^e ^g ^n ^a ^r
+^r ^a ^u ^g ^a ^j
+^o ^p ^a ^s
+^o ^l ^a ^t ^i
+^o ^a ^s
+^o ^S
+^n ^o ^i ^r ^o
+^n ^i ^w ^t
+^n ^a ^i ^r ^a ^m
+^n ^a ^e ^b
+^m ^a ^m
+^k }
+^k ^c ^o ^c
+^j D3
+^i ^r ^u ^y
+^e ^u ^q
+^e ^l ^l ^e ^i ^n ^a ^d
+^e ^e ^r ^h ^t
+^d ^w ^p
+^d ^n ^a ^l
+^a ^n ^i ^l
+^a ^k ^u ^l
+^a ^i ^d ^y ^l
+^V -1
+^8 o14 r
+^5 ^1 ^1
+^3 ^< ^I
+^2 ^1 o23
+^2 ^1 ^2 ^1
+^0 D2
+] ] ] $i
+[ i2s
+[ $0 $6
+Y1 ^M
+Y1 .4 u
+T0 T2 T7
+K o6r
+K o1v
+D6 o6a
+D4 $s
+D3 D5
+D3 $0 $3
+D2 $4
+D2 $3 $8
+D1 $9
++3 -1 -2
++1 -4 -2
++1 +2 +3
+*9B $3 ^j
+'8 *70
+$o i6x
+$o $k $o
+$m $8
+$l $u $c $k $y
+$k $1 $2
+$h $a $m
+$d +3
+$b $e Y2
+$9 ^c
+$8 $8 $0
+$8 $0 $7
+$7 $8 $5
+$7 $0 $6
+$6 $8 $4
+$5 $9 $5
+$5 $7 $0
+$4 $5 $1
+$3 $9 $5
+$3 $9 $2
+$3 $4 $5
+$3 $1 $1 $0
+$2 $9 $7
+$2 $8 $4
+$2 $7 $2
+$2 $6 $1 $0
+$1 $9 $1
+$1 $7 $0
+$1 $2 $2
+$0 $1 $0 $1
+o8s
+o7m ]
+o6M
+o5i u
+o4a i52 i60 i70 o85
+o2y o4i
+o1i o5p
+o1e ]
+o1a o5r
+o0z o3i
+o0z i1e
+o0y D3
+o0w i2s
+o0v *23
+o0t i1a
+o0t D4
+o0t +5
+o0t $0 $1
+o0s $1 $2
+o0k ]
+o0k $3 $2 $1
+o0T $0 $9
+o0R $0 $8
+o0N $1 $2 $3
+o0L $1 $5
+o0H $6 $9
+k o51
+k ^d
+k ]
+i86 l
+i77 p4 $8
+i6r o7i
+i6n o7e
+i6k i7a
+i6c c
+i64 i75 o86
+i63 i72 o81
+i60 i70 o81
+i5u o6r
+i5t i6a
+i54 i65 i76
+i52 i63 i71
+i52 i61 o72
+i52 i60 ss0 $7
+i50 ss0 $0
+i4r i5a
+i4d o5a
+i4d *04
+i4a i5s
+i49 i50 o61
+i48 i57 ,6
+i47 o52
+i46 *75
+i45 ,5
+i42 o58
+i41 i58 o62
+i3z
+i3h o4a
+i37 i40 o57
+i33 i79
+i32 o43
+i2r o3d
+i0z i1e
+i0g -3
+i0g +5
+c i76
+c i72
+c ^7 ^2
+c $8 $0 $0
+c $5 $5 $5
+c $3 $6 $5
+c $2 $1 $0
+c $1 $4 $3
+c $0 $0 $0
+^z ^n ^e ^b
+^y ^r ^r ^u ^c
+^y ^e ^s ^d ^n ^i ^l
+^x ^n ^y ^l
+^x ^i ^l ^a
+^w ^o ^r ^r ^a
+^s ^y ^o ^b
+^s ^r ^c
+^s ^n ^i ^w ^t
+^s ^g ^u ^b
+^r ^e ^t ^s ^e ^j
+^r ^e ^h ^t ^a ^f
+^r ^e ^d ^r ^u ^m
+^r ^e ^b ^b ^u ^r
+^r ^a ^l ^o ^p
+^p ^v ^m
+^p ^j ^d
+^p ^e ^e ^l ^s
+^o ^t ^a ^t ^o ^p
+^o ^l ^s
+^o ^h ^t
+^o +1
+^l ^o ^k
+^l ^i ^k
+^k ^i ^n
+^i ^l ^a ^m
+^i ^k ^i ^m
+^g ^r ^e ^b
+^g D3
+^e ^v ^a
+^e ^n ^o ^m ^i ^s
+^e ^m ^r ^e ^h ^l ^i ^u ^g
+^d ^e ^e ^p ^s
+^d ^c ^b ^a
+^d ^a ^r
+^c ^i ^m ^o ^t ^a
+^b ^a ^f
+^a ^w
+^a ^v ^i ^d
+^7 o18 r
+^6 o18
+^6 ^1 ^0
+^6 $3
+^4 o18
+^4 +1
+[ $g
+T2 T0 y2
+K t o8o
+K +8
+E s03
+D6 o6d
+D5 $2 $2
+D5 $1 $2
+D4 sk/ i71
+D4 sVP +4
+D4 o4h
+D4 o4c
+D3 $1 $2 $3
+D2 $9
+D2 $5 $0
+D1 o2w
+D1 K
+D1 *40
+D1 $h
+-2 -2 -3
++1 -3
++1 +3 +3
++0 +1 -3
++0 $6 $7
+*34 r
+$r $o $b $o $t
+$n k
+$n $u $t $s
+$l $a $r
+$h $a $t
+$f $a $l $l
+$e $y $e
+$c $y
+$_ $1 $4
+$R L9
+$M c @K
+$6 $8 $0
+$6 $7 $9
+$6 $7 $5
+$6 $2 $8
+$6 $0 $8
+$5 $4 $7
+$3 $9 $3
+$3 $6 $3
+$3 $5 $1
+$2 k
+$2 $8 $6
+$2 $8 $1 $0
+$1 $9 $1 $0
+$1 $7 $6
+$1 $2 $3 $@
+$1 $0 $1 $6
+$0 $9 $0
+$0 $6 $0 $9
+$0 $5 $0 $6
+$0 $3 $0 $6
+$0 $2 $3
+$0 $2 $0 $5
+$"
+{ ^m
+o9u
+o8S c
+o6o i7i o8d
+o5i
+o5K
+o4n $o
+o4k $o
+o40 i54 i60 o74
+o3l $1 $2 $3
+o3k $r
+o32 i44 i56 o68
+o2n $1 $2 $3
+o2g Y2
+o1e o4j
+o1e $1 $2 $3 $4
+o0y o2h
+o0v $2
+o0r i1k
+o0b i3o
+o0a o6a
+o0a i2a
+o0T $4
+o0L $1 $6
+o0K D5
+o0K $7
+o0,
+k o1v
+i8d
+i7m i8e
+i78 D3 c
+i72 D4
+i70 i53
+i6s i7t
+i6o o5l
+i6c o7a
+i6c
+i6a i7t
+i67 o78 o89
+i67 *87 $1
+i5g
+i5a i6n
+i55 i60 ,7
+i54 o65
+i51 i60 o72
+i4t i5a
+i4m o5a
+i4l o5o
+i4k o5a
+i4g o5a
+i4c o5a
+i47 i51 o63
+i47 ,5
+i42 i55 o68
+i41 o55
+i41 i54 ,6
+i3z o4e
+i3z [
+i3d i4a
+i38 ss8 $8
+i37 i48 o57
+i36 i58
+i2l o3a
+i2a i3n i4d
+i1o o2n
+i1l o2a
+c ^5 ^2
+c $5 $1 $2
+c $5 $0 $5
+c $1 $9 $6 $3
+c $0 $0 $0 $0
+^z ^a ^f
+^y ^e ^n ^d ^o ^r
+^w o1w ,2
+^v -1
+^t ^y
+^t ^e ^v
+^t ^e ^k ^c ^i ^r ^c
+^t ^e ^i ^l ^u ^j
+^s ^u ^r ^i ^v
+^s ^s ^i ^p
+^s ^n ^o ^g ^a ^r ^d
+^s ^a ^v ^i ^h ^c
+^r ^e ^d ^n ^a
+^p ^o ^l
+^o ^s ^n ^o ^l ^a
+^o ^h ^c ^n ^a ^p
+^o ^d ^o ^t
+^n ^i ^v ^r ^a ^m
+^m ^o ^b
+^m ^l ^a
+^m ^a ^p ^s
+^l ^o ^o ^t
+^l ^l ^a ^c
+^k ^r ^i ^k
+^j $4
+^i ^d ^i ^d
+^h ^c ^i ^r
+^g ^n ^o ^s
+^e ^l ^o
+^a ^r ^a
+^a ^h ^t ^n ^a ^m ^a ^s
+^9 i34 C
+^3 ^2 ^3
+^1 $7
+^0 ^2 ^2
+] i7A E
+] K +0
+] K $u
+T0 i5H -5
+K $s
+D5 $0 $4
+D4 $0 $0
+D3 o3z
+D3 o3w
+D2 $c
+D2 $2 $2
+D1 R1
+D1 D2 o3x
+D1 D2 $x
+-0 o4f
+-0 $6 $6
++5 -3 -0
++3 -4 -0
+*43 ^a
+*24 *02
+$y $e $a
+$l $e $y
+$i $u
+$f $i
+$@ D5
+$9 $6 $1
+$8 $6 $5
+$8 $4 $2
+$8 $4 $0
+$6 $9 $3
+$4 $5 $5
+$3 $7 $6
+$3 $3 $8
+$2 $6 $5
+$2 $5 $2 $5
+$1 T1
+$1 $8 $4
+$1 $6 $9
+$1 $6 $1
+$1 $4 $2
+$1 $2 $3 $0
+$0 $6 $0 $7
+$0 $2 $0 $6
+$- $1 $0
+{ z4 }
+o8w
+o5o $o
+o32 i40 i50 o65
+o2a $2 $0 $0 $3
+o1y i2s
+o1u -5
+o1o $1 $2 $3 $4
+o1d D2 ^s
+o1U [
+o0y o1e
+o0s i1j
+o0s D5
+o0s $2 $0 $0 $1
+o0r ^E
+o0r ]
+o0p D4
+o0o i1c
+o0k i1a ]
+o0g $i
+o0e ,2
+o0W D3
+o0T D5
+o0N D2
+o0M $9
+o0L ]
+o0G
+o0E $1 $2 $3
+l $1 $2 $3 $4 $5
+i8l
+i8a D6
+i7t .6
+i7i i8s
+i6r i7e
+i67 o78
+i64 i73 i82
+i64
+i5l i6o
+i5i i6c
+i5d i6o
+i57 o62
+i55 L6 L5
+i54 o60 ,7
+i52 o63 o74
+i51 o63
+i51 i64 o77
+i4s o5e
+i4d o5i
+i45 i51 ,6
+i3l i4a
+i3d o4e
+i3c o4k
+i37 ,4
+i36 i42 o57
+i36 i40 o53
+i34 i44 ,5
+i2u o3r
+c ^2 $2
+c $9 $0 $0
+^y ^t ^t ^o ^c ^s
+^y ^r ^g ^n ^u ^h
+^y ^m ^m ^u ^y
+^y ^l ^l ^e ^b
+^y ^e ^n ^d ^i ^s
+^y ^e ^l ^r ^i ^h ^s
+^y ^e ^b
+^y ^a ^d ^h ^t ^r ^i ^b
+^t ^t ^e ^j
+^t ^r ^o ^c
+^t ^e ^s ^n ^u ^s
+^p ^a ^l ^s
+^o ^n ^i
+^o ^l ^a ^p
+^o ^j ^n ^a ^b
+^n ^y ^l ^e ^v ^e
+^m o2i
+^l ^l ^u ^k ^s
+^l ^i ^a ^g ^i ^b ^a
+^k ^o ^o ^l
+^j ^a ^m
+^i o2o
+^i ^s ^s ^e ^j
+^e ^x ^a
+^e ^m ^o ^c ^l ^e ^w
+^e ^i ^n ^n ^o ^b
+^d ^n ^a ^s
+^b $1
+^a ^n ^n ^e ^j
+^a ^n ^i ^t ^s ^i ^r ^c
+^a ^n ^i ^m
+^a ^n ^a ^m
+^a ^i ^l ^u ^i ^g
+^a ^g ^i ^g
+^a ,2
+^4 K
+[ o0O
+[ $0 $0
+T0 T1 T4 T5
+E *64 *53
+D8 o8t
+D5 $2 $4
+D4 o5m
+D4 $1 $5
+D3 $s
+D3 $1 $2
+D2 o2v
+D2 $d
+D2 $1 $4
+D1 o3b
+D1 o2b
+D1 D2 $k
+D1 $t
+D1 $4 $5
+D1 $1 $2
+D1 $0 $6
+-1 -1 -3
+-0 -1 -0
++2 -5 -5
++1 -3 -3
++1 +3 -5
++1 +2 +2
+*64 *20
+*43 {
+*31 *34
+*30 C [
+*20 .1
+$t $w $i $n $s
+$o $5
+$i $r $o
+$a $q
+$_ $1 $7
+$_ $1 $5
+$E u
+$9 $9 $!
+$9 $5 $9
+$8 $7 $4
+$7 $8 $0
+$7 $7 $0
+$7 $5 $6
+$6 $3 $2
+$5 $6 $5
+$4 $8 $7
+$2 $1 $0 $6
+$1 $9 $6
+$1 $9 $3
+$1 $2 $0 $6
+$1 $2 $0 $5
+$1 $2 $.
+$0 $3 $0 $7
+$0 $2 $4
+$0 $2 $0 $3
+$. $n $e $t
+$- $1 $1
+$! u
+t o0X
+o5m i7d
+o4i o5h
+o42 i55 i62 o75
+o3o $s
+o3c $1 $2 $3 $4
+o2t Z2
+o1y -2
+o1o $d
+o1e o3o
+o1e i4u
+o0z o4i
+o0w o2f
+o0u D2
+o0t o3e
+o0s i1h o2u
+o0s ]
+o0n $2
+o0k +1
+o0i i2s
+o0g -2
+o0e D4 *01
+o0b l
+o0T $1 $3
+o0R $8 $8
+o0P o2t
+o0N $2
+o0K $7 $7
+o0D $1 $8
+o0A D6
+l $l $e $a
+i91 ,A
+i82 i94
+i7k o8a
+i77 i70
+i6u i7s
+i6k +7
+i6j o7a
+i6e .5
+i64 $8
+i5e o6m
+i5d *05
+i5b i5a
+i59 i61 ,7
+i55 o66
+i55 i75
+i50 o67
+i4k i5o
+i4I c
+i48 i50 o65
+i46 i50 o66
+i45 i52 ,6
+i44 i54 ,6
+i44 ,5 ss4 $4
+i41 ,5
+i3m i4e
+i3b i4a
+i38 i47 o56
+i36 i53
+c o31
+c $a $1
+c $6 $0 $0
+^y ^r ^a ^c ^s
+^y ^k ^s ^u ^h
+^y ^k ^n ^a ^p ^s
+^y ^d ^a ^e ^r
+^x ^l ^a
+^x ^h ^t
+^s ^e ^n ^n ^a ^h
+^r ^e ^t ^t ^e ^b
+^r ^e ^k ^i ^b
+^r ^e ^h ^s ^i ^f
+^r ^e ^b ^m ^e ^v ^o ^n
+^r ^e ^b ^a
+^p ^a ^r ^t
+^o ^i ^c ^r ^a ^m
+^o ^a ^k
+^n ^o ^t ^h ^s ^a
+^n ^e ^v ^a ^e ^h
+^n ^a ^u ^l
+^m ^d ^a
+^i ^g ^a ^m
+^h ^t ^o ^g
+^h ^s ^i ^l ^g ^n ^e
+^g ^r
+^e ^l ^a ^v
+^e ^d ^i ^h
+^e ^c ^y ^o ^j
+^a ^y ^m
+^a ^r ^i ^m
+^a ^n ^i
+^a ^n ^a ^j
+^a ^m ^r ^a ^k
+^a ^d ^u ^d
+^V ]
+^9 o19 r
+^9 ^0 $0 $9
+^7 $8
+^4 ^3 o25
+^3 ^9 ^0
+^2 ^1 ^3
+[ $9 $1 $1
+Y3 y2
+T2 T4 T6 T8
+K -3
+D5 $2 $1
+D5 $0 $1
+D4 o4b
+D4 *12
+D4 $2 $3
+D3 o4v
+D3 $t
+D1 o2t
+D1 o2b D3
+D1 $,
+-2 *12 +0
++2 -4 -0
++2 -1 -3
++2 -0 +5
+*51 D2
+$w $e $e
+$m $o $b
+$i $m $a
+$h D3
+$f $o $o $d
+$e $y
+$b *34
+$a ^A
+$a *16
+$Y
+$9 $3 $5
+$8 $6 $2
+$8 $6 $0
+$6 ^3
+$6 $8 $7
+$5 $4 $1
+$4 $6 $7
+$4 $0 $0 $0
+$3 $5 $5
+$2 $9 $1
+$2 $1 $0 $7
+$1 $8 $3
+$1 $7 $7
+$1 $2 $2 $5
+$1 $0 $8 $0
+$0 $7 $0 $9
+{ $e
+oB5 E
+oB1 iC2 oD3
+oAi
+o7s ]
+o5y $o
+o4y i51 i62 o73
+o4o *03
+o4c i4s k
+o4Y c ]
+o42 i54 i62 o74
+o3o $o
+o3o $0 $0
+o3_ +4
+o3Y u
+o3'
+o2i $i
+o2O u
+o1i o4x
+o0z i2r
+o0y o2r
+o0t D5
+o0s i1h i2a
+o0s $3
+o0o o1t
+o0o o1i
+o0n o2w
+o0c $o
+o0M +3
+o0M $1 $8
+o0H $0 $8
+o0G +2
+o0E D4
+o0@ T1
+i75 i85
+i75 i70
+i67
+i5w o6a
+i5l o6i
+i5l E
+i5k o6o
+i5i
+i52 o60 i71 o84
+i51 o60 i71 o80
+i51 i62 o78
+i4i o3z
+i4d i5o
+i4a i5s i6s
+i49 o52
+i48 i52 ,6
+i47 i51 o60
+i46 i50 o64
+i43 i50
+i42 i53 ,6
+i40 o57
+i3l i4i
+i3F o3d
+i37 -9 }
+i34 i42 o53
+i33 i41 o55
+i31 o43
+i31 i35
+i2z ,3
+i2m o3a
+i2l o3i
+i23 o34
+c i4-
+c $9 $6 $4
+c $9 $4 $1
+c $8 $1 $2
+c $7 $1 $4
+c $4 $1 $9
+c $1 $1 $7
+c $. $.
+^y ^m ^m ^a ^t
+^y ^l ^l ^o ^l
+^y ^a ^w ^e ^t ^a ^g
+^y ^a ^k ^o
+^v ^a ^t ^s ^u ^g
+^u ^s ^o
+^t ^r ^e ^g
+^t ^i ^g ^e ^l
+^s ^w ^o ^d ^n ^i ^w
+^s ^e ^l ^y ^m
+^r ^a ^y
+^o ^r ^r ^o ^z
+^o ^p ^o ^t
+^o ^l ^o ^n ^a ^m
+^o ^k ^o ^y
+^n ^o ^t ^s ^a
+^n ^o ^t ^r ^u ^b
+^n ^a ^m ^a
+^l ^i ^s ^a ^b
+^l ^i ^a ^h
+^k ^n ^a ^t
+^k ^a ^e ^r ^b
+^h ^s ^a ^r ^c
+^h ^c ^a ^e ^b
+^e ^l ^g ^n ^u ^j
+^e ^i ^l ^e ^m ^a
+^e ^c ^y ^r ^b
+^e ^c ^n ^a ^l
+^e ^b ^a ^g
+^e ^b ^a
+^a ^d ^g ^a ^m
+^_ o5_
+^7 ^1 ^2
+^6 $5
+^5 o19
+^2 ^2 ^2
+^2 ^1 ^0
+^1 ^1 ^3
+^0 ^2 ^3
+[ D2 D3
+[ *54 +2
+K $t *75
+D5 r
+D3 $7 $7 $7
+D3 $0 $5
+D2 $3 $1
+D1 o3d
+D1 $g
+D1 $1 $4
+D1 $0 $5
+D0 o3m
+-1 -3
+-0 *31
+-0 $0 $8
++5 o37
++3 +5 -0
++3 +3 -0
++1 o0b
++1 +3 +1
+*53 -5 [
+*41 -3
+*03 o27
+$y $5 $5
+$s $o $m $e
+$n +0
+$l $l $a
+$i $n $s
+$8 $5 $8
+$6 $9 $8
+$5 $6 $7
+$4 $9 $4
+$4 $8 $4
+$4 $8 $2
+$4 $6 $0
+$3 ^7
+$3 $1 $0 $8
+$2 $9 $2
+$2 $4 $1 $1
+$2 $2 $1 $2
+$1 [
+$1 $6 $5
+$0 Z3
+$0 $5 $0 $5
+$0 $4 $0 $8
+{ *20
+u $2 $0 $0 $3
+o5o $t
+o4p $e
+o4_ o51
+o4O u
+o49 ss9 $9 $9
+o3o o4y
+o2v $1 $2
+o2k i4a
+o1y i2a
+o1i o3z
+o0w o4s
+o0v ^A
+o0s i2u
+o0q o2q
+o0n o1s
+o0n $1 $1
+o0k $d
+o0i $i
+o0g ]
+o0b $i
+o0W $8
+o0S ]
+o0S D4
+o0R $2 $3
+o0N $8
+o0M
+o0J $8
+o0J $2 $3
+o0D $0 $7
+i7n
+i74 i75
+i72 i82
+i6o o7u
+i6e i7s
+i5s o6e
+i5a o6b
+i5a i6r
+i5a i6l o7i
+i58 o69
+i56 o67
+i51 i67 E
+i50 o68
+i50 i79
+i4s o5h o6a
+i4m o5a o6i
+i4j o5o
+i4h o5u
+i4b i5u
+i4b i5i
+i4b i5e
+i4a *50
+i49 o58
+i48 i51 o63
+i47 o58
+i46 i57 o68
+i46 *35
+i45 i55 o69
+i44 o51
+i42 i58 o61
+i3g o4u
+i3e o2f
+i3e i3b
+i3a o4n
+i3_ ]
+i37 i46 o55
+i37 -2
+i33 o47
+i2t o3e
+i2e i3r
+i2c o0l
+i2c k
+i1t o2h
+i1r o2i
+i1r o2e
+i1b [ ^A
+c o50
+c $9 $1 $0
+c $0 $1
+^y ^l ^o
+^y ^k ^c ^u ^b
+^y ^g ^g ^i ^p
+^y ^e ^s ^o ^j
+^y ^e ^m
+^y ^e ^k ^a ^j
+^y ^d ^n ^i ^w
+^y ^a ^d ^i ^l ^o ^h
+^u ^l ^e ^p
+^s ^n ^o ^i ^l
+^s ^i ^r ^p
+^r ^e ^n ^n ^a ^t
+^r ^e ^b ^l ^a
+^o i4o
+^o ^r ^t ^s ^a ^c
+^o ^m ^i ^m
+^n ^t
+^n ^i ^p
+^n ^e ^i ^m ^a ^d
+^n ^e ^i ^l ^u ^j
+^m ^i ^t T3
+^m Y1
+^i ^s ^p ^e ^p
+^h ^t ^i ^m ^s
+^g ^n ^a ^y
+^e ^t ^e ^p
+^e ^n ^o ^b
+^e ^n ^e ^r
+^e ^m ^s ^t ^i
+^e ^l ^l ^a ^k
+^d ^i ^r ^g ^n ^i
+^d ^e ^t ^i ^n ^u
+^c ^r ^a
+^c $2
+^a ^v ^a ^j
+^a ^k D5
+^R
+^9 o15
+^6 o19 r
+^5 ^4 ^3 ^2 ^1 ]
+^4 o19
+^2 ^3 ^1
+^1 o61
+[ $0 $3
+RB .1 c
+K o4e
+K +5
+D5 o5b
+D5 K
+D3 $@
+D3 $1 $0 $0
+D3 $0 $4
+D2 $0 $3
+D1 o2x
+D1 -2 o3f
+-3 *03 +1
++6 ^a
++4 -0 -5
++3 *41 [
++2 -3 +4
++0 +4 +1
++0 +2 ^1
++0 +1 +2
+*74 *65 c
+*03 o0l
+$l $o $t
+$l $a $m
+$e $g $g
+$d $r $e $w
+$d $e $e
+$8 $9 $6
+$8 $7 $0
+$7 $4 $3
+$6 k
+$4 $9 $1
+$3 $5 $2
+$3 $2 $1
+$2 $9 $4
+$2 $9 $3
+$2 $7 $1 $1
+$2 $1 $0 $8
+$1 $9 $4 $4
+$1 $2 $2 $3
+$1 $0 $0 $5
+$0 $8 $1 $0
+$0 $7 $0 $7
+$# o69
+o8d
+o6b
+o4z i51 i62 o73
+o4g i6y
+o41 i54 i61 o74
+o3o $i
+o3b $1 $2 $3
+o3a $t
+o3a $e
+o2k $a
+o2i o5m
+o2e $s
+o2+
+o1s ,2
+o1e o2y
+o0s +5
+o0s $1
+o0r $2 $3
+o0r $1 $1
+o0n $1 $3
+o0k $7 $8 $9
+o0j $1 $2 $3
+o0i +1
+o0g $e
+o0e i2i
+o0R $0 $7
+o0K o51
+o0K $6
+o0K $0 $8
+o0I -1
+o0H $3
+l $1 $2 $3 $4
+i7e i8r
+i6h o7o
+i5o o6k
+i52 o60 ,7
+i4r o5u
+i4r o3c
+i4p o5a
+i4o i5r
+i4l i5i
+i49 i55 o64
+i44 i52 o63
+i43 o74 K
+i43 i56 o60
+i42 i51 ,6
+i3l [
+i37 i42 o58
+i33 i45 o57
+i30 o47
+i30 o44
+i2p o3h
+i2m +1
+i2f
+i1o o2u
+i1b o2c
+c o59
+c i62
+c ^1 ^1 ^0 ^2
+c $9 $4 $2
+c $7 $2 $0
+c $6 $2 $6
+c $5 $0 $1
+^y ^r ^o ^t ^c ^i ^v
+^y ^k ^n ^i ^b
+^y ^b ^a
+^y ^T
+^v ^a ^h ^c
+^s ^u ^i ^r ^i ^s
+^s ^s ^a ^l ^c
+^s ^r ^a ^c
+^s ^i ^s ^u ^s ^e ^j
+^s ^e ^m ^r ^e ^h
+^r ^o ^l ^i ^a ^s
+^r ^e ^t ^t ^o ^p
+^r ^e ^k ^c ^o ^r
+^r ^e ^d ^e
+^r ^e ^a
+^r ^c ^a
+^r ^a ^d ^a ^r
+^p ^l ^e
+^p ^a ^n ^s
+^p ^a ^n
+^o ^b ^l ^i ^b
+^n ^i ^r ^a ^m
+^n ^a ^r ^b
+^l ^l ^a ^b ^b
+^l *03
+^i o2e
+^i ^g ^i ^u ^l
+^g ^n ^i ^h ^t ^e ^m ^o ^s
+^f o1u
+^e o2o
+^e ^n ^i ^m
+^e ^m ^i ^l
+^e ^i ^l ^l ^o
+^d ^u ^m
+^d ^o ^r
+^b -3
+^a ^m ^m ^a ^m
+^Z *31
+^T $2
+^R D2
+^J ^D
+^E u
+^8 o13 r
+^4 $3
+^0 ^0 ^5
+[ i2x
+[ i2n
+Y2 o4i c
+T0 o5W
+T0 ,1
+K i3t
+E D4 +3
+D8 $2
+D6 $1 $2
+D4 ]
+D4 $v
+D3 o5f
+D3 *02
+D2 o2m t
+D2 $1 $8
+D1 $j
+-2 ^a
+-0 -4 -4
+-0 -1 -3
++6 +1
++5 -0 -0
++4 r
++2 *45 k
++1 -0 -5
++0 $7 $8
+*97 ^c K
+*50 $q
+*01 *41
+'7 $3
+$p $o $i
+$l *64
+$k $i $l $l $s
+$i $l $l
+$g $h
+$d D6
+$c t
+$c $a $t $s
+$a *46
+$8 $9 $8 $9
+$7 l -0
+$7 $6 $4
+$7 $6 $2
+$6 $6 $4
+$2 $7 $4
+$2 $5 $9
+$2 $3 $1 $0
+$2 $2 $0 $2
+$1 $9 $0 $7
+$1 $9 $0 $5
+$0 -7
+o8A
+o4y $1 $2 $3
+o4I u
+o49 i50 i69 o70
+o3i $o
+o3h $1 $2 $3
+o2c $1 $2 $3 $4
+o1w o4w
+o1i $2 $0 $0 $2
+o1e o4y
+o0u D3
+o0t o3i
+o0t i4e
+o0s i1o
+o0p ,3
+o0p *34
+o0k $5 $5 $5
+o0R $6 $9
+o0R $2 $1
+o0P D2
+o0P $0 $7
+o0M $1 $7
+o0H $2 $3
+l r -5
+l $5
+i82 i92
+i7t
+i7l '8
+i72 -2
+i6a i7n i8g
+i65 Y2 K
+i61 o79
+i5t i6h
+i5i o6c
+i5g o6a
+i5c i5a
+i57 *62
+i53 i64 o75
+i52 o63
+i51 ,6
+i50 o61
+i50 i69 o78
+i4m i5i
+i4l i5o
+i4j K
+i4a o5l
+i4a o5c
+i4B c
+i45 +2
+i44 i51 ,6
+i44 *75
+i42 i56 o67
+i3m o4e
+i3h *03
+i3b ]
+i36 i44 o55
+i34 i41 o57
+i33 o44
+i32 o40
+i23 ,3
+i0M i1a i2r
+c o55
+c o48
+c o30
+c $S
+c $9 $6 $8
+c $7 $2 $5
+c $2 $5 $6
+c $1 $2 $3 $4 $5
+^y ^d ^n ^a ^h
+^w ^o ^h ^c
+^u ^m ^u ^m
+^u ^A
+^s ^y ^r ^k
+^s ^y
+^s ^u ^x ^e ^l
+^s ^u ^t ^u ^r ^b
+^s ^s ^u ^r
+^s ^s ^o ^r ^g
+^s ^m ^o ^m
+^r ^g ^a
+^r ^e ^t ^s ^g ^n ^a ^g
+^r ^a ^d ^e ^c
+^q ^a ^z
+^o ^m ^i ^k
+^o ^l ^a ^f ^f ^u ^b
+^n ^w ^o ^l ^c
+^l ^l ^i ^h
+^l ^a ^w
+^i ^k ^i ^n
+^i ^e ^k
+^g ^u ^b
+^g ^n ^u ^y
+^e ^z ^a ^l ^b
+^e ^s ^u ^o ^m
+^e ^m ^o ^s
+^e ^l ^p ^m ^i ^s
+^e ^i ^p
+^b ^i '9
+^a ^y ^a
+^a ^r ^u ^k ^a ^s
+^a ^m ^o ^r
+^a ^m ^i ^t ^a ^f
+^a ^m ^i ^l
+^[ o8]
+^9 o16 r
+^8 o16 r
+^7 o18
+^5 $6
+^4 $9
+^3 o19 r
+^3 ^2 ^1 D4
+^1 i62
+^1 -1
+] i4z
+[ o0n D3
+[ $o
+c i4G
+K o2k
+D8 D8 D8
+D5 o5m
+D4 sah K
+D4 o4y
+D4 $2 $1
+D2 $m
+D2 $9 $8 $7
+D2 $2 $9
+D2 $2 $7
+D2 $1 $5 $9
+D1 o1g D3
+D1 D1 -1
+@k ^w -1
+-0 -3 -4
+-0 $3 $2
++6 -0 -4
++5 -1 -1
++5 +5 -3
++5 $7
++3 -2 +3
++2 }
+*64 l *57
+*61 D0
+*52 [ k
+*32 o0l
+*14 }
+*04 {
+'6 i3-
+$v $i $d $a $l
+$o $n $l $y
+$o $2
+$i $c $o
+$i $1
+$g $y
+$g $u $s
+$b $l $a $d $e
+$9 $5 $8
+$8 $7 $2
+$8 $6 $4
+$8 $6 $1
+$7 $8 $8
+$7 $5 $5
+$4 $7 $7
+$3 ^d
+$3 $4 $6
+$2 $3 $0 $7
+$2 $0 $1 $5
+$1 $5 $1 $5
+$1 $3 $2 $4
+$1 $0 $0 $3
+} +6
+} $o
+} $3
+s1# u o2P
+o7L
+o6i -7
+o5y u
+o5_ $8
+o5C
+o4z $o
+o4c $e
+o49 i50 i60 ,7
+o3y $0 $4
+o3Y +7 l
+o2l $1 $2 $3
+o2c $1 $2 $3
+o2a $1 $2 $3 $4 $5
+o1y *54
+o1o o5o
+o1o o4u
+o1k o3o
+o1e i3p
+o1a *14
+o0v -5
+o0p *53
+o0p '8
+o0p $0 $1
+o0o i1m
+o0a i3e
+o0T $2 $3
+o0S D2
+o0P D7
+o0M *13
+k +1 y2
+i92 oA3
+i92 oA1
+i80 i90 iA1
+i7p -6
+i7d .6
+i75 i69 ,6
+i74 i85 o96
+i73 ,8
+i6t o7i
+i6'
+i5t seu
+i5n i6a
+i5h i6e i7r
+i51 o60
+i50 i74
+i50 i60 o73
+i4n o5e
+i4h o5o
+i4c i5h
+i4E l
+i45 i60
+i43 i54 o60
+i43 i51 o66
+i42 i58 ,6
+i41 o58
+i41 i54 o60
+i41 i50 o65
+i3e o4n
+i3B l
+i35 o40
+i35 i40 o55
+i35 i40 o54
+i34 i44 o57
+i34 i40 o55
+i2d o3a
+i0g i1l
+i0H i1a
+c i70
+c ^9 $8
+c D4 $2
+c *65 $!
+c $9 $4 $8
+c $8 $1 $1
+c $8 $1 $0
+c $4 $8 $9
+c $4 $0 $2
+^z ^i ^u ^r
+^y ^k ^e ^e ^h ^c
+^y ^e ^n
+^u ^o ^y ^e ^t ^a ^h ^i
+^t ^s ^i ^t ^r ^a
+^t ^r ^e ^b ^r ^e ^h
+^t ^e ^m ^h ^e ^m
+^s ^u ^x ^e ^n
+^s ^t ^r ^o ^p ^s
+^s ^t ^e ^j
+^r ^e ^h ^s ^a
+^r ^e ^g ^r ^u ^b
+^o ^t ^u ^l ^p
+^o ^t ^n ^a ^s
+^o ^r ^u ^t ^r ^a
+^o ^i ^v ^a ^l ^f
+^n ^n ^e ^j
+^n ^e ^t ^t ^i ^k
+^n ^a ^m ^t ^i ^h
+^n ^a ^i ^r ^o ^l ^f
+^m ^o ^t ^n ^a ^h ^p
+^l ^e ^a ^r ^s ^i
+^i ^a ^l
+^h ^c ^t ^i ^m
+^g ^a ^j
+^e ^o ^m
+^e ^e ^l T3
+^d -3
+^c o2k
+^a ^s ^e ^r ^e ^t
+^a ^r ^i ^k ^a
+^a ^r ^b ^o ^c
+^a .5
+^W D3
+^9 o11 r
+^5 ^1 $1 $5
+^3 *02
+^1 D3 r
+D5 D7
+D4 D7 l
+D3 o5d
+D3 o4w
+D3 $x
+D1 D2 $p
+D1 $k
+D1 $2 $2
+D1 $2 $0 $0 $8
+D1 $1 $1
+D0 -2 -2
+-2 o04
++4 -0 +4
++4 *40
++3 *31
++1 +2 -3
++0 $9 $6
+$m {
+$l $l $o
+$l $a $x
+$g t
+$e $o
+$e $2
+$d $y
+$c *B8 +5
+$_ $1 $6
+$8 $8 $4
+$7 $5 $4
+$7 $5 $1
+$6 $9 $5
+$3 $4 $1
+$3 $0 $0 $3
+$2 $7 $1 $0
+$2 $4 $0 $8
+$2 $2 $1
+$1 $4 $0 $8
+$1 $2 $0 $1
+$1 $0 $4
+$1 $0 $0 $4
+$0 $6 $9
+$0 $3 $1 $0
+} -4
+u i62 o7K o87
+u i3_
+o7u o8l
+o6w ] c
+o64
+o4o o5y
+o3o $t
+o3o $a
+o2z u
+o2m i0A
+o2f o0R
+o1s c
+o1r i3a
+o1i o4c
+o0y i1a
+o0y D2
+o0x o1z
+o0w *14
+o0v o3o
+o0t *31
+o0r i2d
+o0o i1p
+o0n o2o
+o0j $a
+o0g $r
+o0c i2w
+o0M i1M
+o0J $8 $8
+o0H .2
+o0G $6 $9
+o0B ]
+k y2
+k .2
+i82 i90 iA0
+i82 i90
+i80 o95
+i77 i87
+i6m i7a
+i5o
+i5k i6i
+i5g o6h
+i5e o6r
+i5e i6l
+i5a i6l
+i5a ]
+i56 o61
+i50 o69
+i4s o6a
+i4g o5e
+i4f o5i
+i4e i5r ]
+i4d o5o
+i4b o5i
+i4a $1
+i47 i58 o66
+i45 o52 o60
+i45 i53 o60
+i45 i50 o69
+i44 i52
+i43 o63
+i41 $6
+i40 $9 +4
+i3l o4e
+i3e i4k
+i38 i41 o56
+i33 i46 o55
+i33 i46 ,5
+i30 ss0 $0
+i30 o49
+i2z o3e
+i2r o3t
+i2o o3u
+i0c i1l i2a
+i0a ^l $1
+d $2
+c o5b
+c ^9 $3
+c $9 $2 $6
+c $5 $1 $1
+c $4 $1 $4
+c $3 $0 $5
+c $2 $1 $7
+c $2 $1 $6
+^z ^e ^d ^n ^a ^n ^r ^e ^h
+^y ^r ^r ^o ^s
+^y ^r ^e ^t ^s ^y ^m
+^y ^k ^c ^u ^h ^c
+^y ^e ^l ^s ^e ^l
+^t ^s ^a ^o ^t
+^t ^e ^k ^c ^o ^p
+^t ^a ^e ^r ^g ^e ^h ^t
+^s ^p ^o ^p
+^s ^k ^r ^a ^d
+^s ^e ^n ^n ^a ^h ^o ^j
+^r ^e ^x ^o ^b
+^r ^e ^v ^e ^l ^c
+^r ^e ^d ^a ^v
+^p o1p
+^p ^o ^h ^s ^i ^b
+^p ^m ^e
+^p ^j ^a
+^o ^s ^a ^m
+^o ^n ^i ^l
+^o ^m ^a ^d
+^o +3
+^n ^i ^u ^g ^n ^e ^p
+^n ^a ^m ^e ^c ^i
+^n ^a ^b ^e ^t ^s ^e
+^n D4
+^m ^m ^e
+^l ^a ^i ^c ^e ^p ^s
+^k ^r ^o ^w
+^k ^n ^a ^h
+^h ^s ^a ^l ^s
+^h ^a ^c ^i ^m
+^g ^n ^i ^v ^i ^l
+^e ^t ^a ^m ^i ^t ^l ^u
+^e ^r ^p
+^e ^d ^r ^e ^v
+^e ^L
+^a ^n ^i ^t ^r ^a ^m
+^a ^k ^a ^b
+^T +1
+^9 o14 r
+^4 }
+^2 ^3 o25
+T2 '4
+E i6S
+D6 o5x
+D6 ^b
+D3 o1z [
+D2 $9 $1 $1
+D2 $4 $5
+D2 $3 $3
+D1 o1v D3
+D1 o1b D3
+D1 D2 o3v
+D1 $3 $4
+-0 $s
++6 +6 -0
++4 *23
++2 +5 +3 +4
++1 +1 +4
+*B1 *15 *63
+*53 [
+*52 o0g p5
+*51 *54
+*25 o0m
+*25 *03
+*24 o0l
+*20 *03
+*10 o1.
+*02 ^f
+$x t
+$t $i $t $a $n
+$l *43
+$i $r $e
+$h $o $w
+$g +6
+$f $l $o $w
+$b $e $a $n
+$a $r $m $y
+$a $n $d $r $e
+$F
+$9 $3 $8
+$8 $9 $3
+$8 $4 $3
+$7 $7 $9
+$6 $9 $9
+$6 $8 $3
+$6 $5 $9
+$6 $0 $3
+$5 $9 $7
+$5 $5 $7
+$4 $7 $6
+$2 $9 $9
+$2 $8 $1 $1
+$2 $7 $3
+$2 $6 $4
+$2 $6 $3
+$2 $5 $0 $5
+$2 $4 $1 $2
+$1 $9 $4 $1
+$1 $3 $1 $0
+$0 $9 $1 $0
+$0 $9 $0 $7
+$0 $8 $9
+$0 $5 $1 $1
+$0 $4 $0 $9
+{ {
+x32 +2
+o7M
+o75
+o6o o7i o8d
+o4z $1 $2 $3
+o4y o5x
+o4p $1 $2 $3
+o3p u
+o3o $e
+o3g E *54
+o32 i40 i50 o63
+o30 t ,4
+o2u $1 $2 $3
+o2m $1 $2 $3
+o1z ^j
+o1u $1 $2 $3
+o1o -3
+o1i $1 $2 $3 $4
+o0v i2g
+o0v *31
+o0s o2e
+o0r D4
+o0o i1s
+o0m $y
+o0k $y
+o0e *10
+o0Z D5
+o0T $6
+o0R D2
+o0R $5
+o0N $5
+o0L $1 $4
+o0K $!
+o0J $0 $7
+o0H $2 $1
+o0F +7
+o0F +3
+o0E -1
+o0D $1 $5
+o0C $1 $5
+o0B $9
+i90 iB1
+i6b i7o i8y
+i5s i6e
+i5e o6v
+i5b o6a
+i53 i62 i71
+i50 t 'A
+i50 +2
+i4u o5m
+i4r o5i
+i4m i5o
+i4j o5e
+i4e o5h
+i4e ,5
+i41 o50
+i40 ^3
+i3o [
+i3m o4a
+i36 i45 o54
+i35
+i32 i41 o55
+i30 o46
+i2m o3u
+i2f ]
+i2f *03
+i1r ]
+i1a o2w
+i14 i34
+i0a i1n i2g
+c o37
+c o34
+c $9 $6 $0
+c $6 ^9
+c $6 $1 $6
+c $6 $1 $0
+c $5 $1 $5
+c $4 $3 $2 $1
+c $4 $1 $5
+c $4 $1 $0
+c $4 $0 $0
+c $3 $2 $4
+c $2 ^9
+c $2 $0 $8
+c $1 $5
+^z ^z ^a
+^y ^s ^o ^r
+^y ^r ^r ^e ^h ^s
+^x ^i ^p
+^w ^a ^r ^d
+^t ^t ^o ^i ^l ^l ^e
+^s ^m ^i ^s
+^r ^e ^m ^a
+^r ^e ^h ^p ^o ^t ^s ^i ^r ^h ^c
+^r ^e ^b ^o ^t ^c ^o
+^o ^n ^o ^n
+^o ^k ^c ^a ^j
+^o ^c ^a ^c ^a ^m
+^n ^o ^i ^h ^s ^a ^f
+^n ^i ^t ^s ^u ^d
+^n ^e ^r ^b
+^n D5
+^m ^i ^x ^a ^m
+^l ^e ^t ^n ^i
+^l ^e ^o ^n
+^l ^a ^c ^s ^a ^p
+^k o1y
+^k o1u
+^k
+^i ^h ^b ^a
+^i ^b ^a ^b
+^g ^n ^i ^z ^a ^m ^a
+^e ^l ^l ^e
+^e ^b ^o ^k
+^b ]
+^a o3r
+^a ^n ^e ^r ^o ^l
+^a ^n ^e ^l ^e ^h
+^a ^i ^d
+^a ^g ^a ^g ^y ^d ^a ^l
+^a ^d ^n ^a ^n ^r ^e ^f
+^a ^d ^i ^v
+^a $1 $1
+^9 o17 r
+^8 $1
+^5 ^0 ^2
+^4 $8
+^3 o12 r
+^2 $9
+] t $X
+] ^b y1
+[ i4u
+[ i3f -1
+[ $e $r
+D7 +7
+D5 o5j
+D5 o5c
+D5 ^g
+D5 $2 $0
+D4 $w
+D3 D2
+D3 $0 $0 $7
+D2 $1 $2
+D1 o3g
+D1 o2d D3
+D1 D3 o3f
+D1 D3 -4
+D1 D2 o3c
+D1 -2 o3b
+D1 $2 $8
+D0 u ^E
+-1 -5 -2
+-0 o4b
+-0 $5 $5
++8 $7
++2 -0 -3
++1 +5 +5
++0 +5 +1
+*4A } ^9
+*41 +0
+*40 K *13
+*23 t
+*10 i38
+*02 k *13
+$o $f $f
+$n $2
+$l $o $g $a $n
+$e [
+$b r
+$_ $2 $3
+$7 $6 $9
+$6 r +5
+$5 [ *20
+$5 $8 $3
+$3 $8 $3
+$2 $9 $0 $9
+$2 $3 $0 $5
+$2 $2 $0 $8
+$1 $0 $1 $5
+$0 $4 $0 $4
+$0 $3 $0 $3
+$& o67
+t ,5
+r ^K
+o8s Z1
+o4g u
+o4a $y
+o45 i55 i65 ,7
+o3o $2 $0 $0 $1
+o3a o5v
+o3a ,4
+o3a $u
+o2y $1 $2
+o1s ]
+o1o +6
+o1o $t
+o1e $n
+o1a o5u
+o0z i1o
+o0u +1
+o0t i1s
+o0s *35
+o0p D5
+o0n o2h
+o0n $1 $4
+o0m $o
+o0l $e
+o0k D3 $1 $2 $3
+o0e i3s
+o0T $0 $6
+o0P $3
+o0N $0 $9
+o0J $4
+o0G ,3
+o0G $2 $2
+o0G $2 $1
+o0D $1 $7
+o0D $1 $4
+o0D $!
+o0B $1 $9
+l ] $e $s
+l $2
+k o0c
+k i1m
+k ^z
+k Y2
+i91
+i8t
+i84 o95
+i81 i92
+i7d o6a
+i6u o7s
+i6u +5
+i6p
+i6i i7l i8l
+i6h c
+i63 o76
+i61 i70 o81
+i5u o6n
+i5r o6o
+i5h i6e
+i5g i6o
+i5_ *67
+i58 i60 o78
+i55 i60 o75
+i55 E
+i54 i60 o74
+i52 o63 i74 o85
+i50 i70
+i50 i60 o75
+i4y
+i4u o5r
+i4t i5h
+i4r i5e
+i4j ]
+i4h ]
+i4e o5m
+i4e i5m
+i4b o5u
+i4a o5m
+i43 i51 o62
+i3u o4m
+i3s o4e
+i3l o2e
+i3k i4a
+i3i o4d
+i3f
+i3a i4l
+i3R E
+i33 i58
+i32 o46
+i32 ,4
+i0r ^o
+c i4s
+c d '7
+c $8 $0 $5
+c $6 $9 $6
+c $6 $5 $0
+c $5 $0 $3
+c $3 $0 $2
+c $2 $5 $0
+c $1 $9 $6 $4
+c $1 $4 $7
+c $0 $0 $9
+^z ^e ^r ^i ^m ^a ^r
+^z ^a ^w
+^y ^t ^r ^e ^w
+^y ^e ^l ^t ^n ^e ^b
+^w ^d ^e
+^u ^h ^c ^a ^k ^i ^p
+^t ^r ^e ^b ^u ^h
+^t ^e ^t
+^s ^t ^j
+^s ^r ^e
+^s ^o ^l ^i ^m
+^s ^l ^l ^u ^b
+^s ^e ^d ^a ^h
+^s ^a ^l ^o ^g ^e ^l
+^r ^d ^d
+^o ^n ^i ^t
+^o ^n ^a ^c
+^o ^m ^a ^s
+^o ^d ^n ^a ^m ^r ^a
+^o ^b ^e ^b
+^n ^y ^l ^k ^o ^o ^r ^b
+^n ^i ^n
+^l ^l ^i ^h ^c
+^l ^l ^e ^w ^x ^a ^m
+^l ^l ^a ^b ^t ^e ^k ^s ^a ^b
+^k ^n ^i ^h ^t
+^k ^i
+^i o4o
+^g ^t
+^g ^n ^i ^r ^p ^s
+^f ^e ^e ^b
+^e ^r ^a ^u ^o ^y
+^e ^n ^i ^l
+^e ^B
+^d ^n ^e
+^a ^t ^a ^n ^e ^r
+^a ^n ^i ^r ^i
+^a ^i ^h ^p ^o ^s
+^a $1 $3
+^T i1r
+^R $1
+^9 ^8 ^0
+^0 ^1 o20
+^( o7)
+[ *21
+[ $@
+Z3 Y4
+L7 i4t
+K o75
+K o0s
+E oA1
+D7 o6b
+D6 *15 o0w
+D5 o5t
+D5 ]
+D4 $2 $0 $0 $0
+D3 $0 $2
+D2 o4p
+D2 $t
+D1 -1 D2
+D1 $r
+D0 t *01
+-3 r l
+-0 -4 -2
++7 +7 +7 +7
++1 ^a
++1 -3 -2
+*51 -3
+*45 o0d
+*43 [ {
+*31 ] -0
+*20 o3s
+*20 *43
+'8 +3 s2+
+$t $o $t
+$o $r $e $o
+$n $i $a
+$l $e $t
+$i r
+$h -3
+$g $r $e $a $t
+$d $u $k $e
+$c $1
+$L
+$8 $5 $1
+$8 $4 $1
+$6 $7 $1
+$6 $7 $0
+$6 $5 $8
+$5 $9 $8
+$5 $9 $6
+$5 $8 $4
+$4 $7 $3
+$4 $4 $3
+$4 $3 $7
+$2 $9 $1 $1
+$2 $6 $6
+$2 $5 $0 $8
+$2 $3 $1 $2
+$1 $3 $6 $9
+$1 $2 $3 $$
+$1 $2 $2 $8
+$1 $2 $2 $4
+$0 $8 $!
+$0 $4 $1 $0
+$0 $3 $0 $9
+$. $1 $4
+} x02 p1
+} o1o
+o6x Z1
+o54 +6
+o4o -5
+o4o $g
+o42 i58 i62 o78
+o3g $1 $2 $3
+o3e -4
+o3L u
+o3D E ,2
+o2b i4o
+o2b $1 $2 $3
+o2a
+o1u $1 $2 $3 $4
+o1e $1 $2 $3
+o1a o5o
+o1D c
+o0z +7
+o0t $9 $9
+o0t $2 $1
+o0s i3h
+o0s i1g
+o0s *13
+o0r o1y
+o0n o2a
+o0g ,6
+o0T $6 $9
+o0K +3
+o0K $8 $9
+o0G $2 $3
+o0D $9 $9
+l ^i ^p ^e
+k y3
+i95 +8
+i91 oA0
+i82 i91
+i6s i7o i8n
+i6s D0
+i6a ]
+i61 o72
+i5t o6i
+i5n o6e
+i5b i6a
+i51 i63 o75
+i51 i62 o76
+i4o [
+i4h i5a
+i4f ,8
+i4a o5r o6a
+i42 i54 o60
+i41 $3
+i40 i59 ,6
+i40 i54 ,6
+i3s ]
+i3m i4i
+i3k o4e
+i39 i42 o57
+i34 i42 o50
+i31 i45 o57
+i2p o3e
+i1u o2r
+i15 r
+i0B i1a
+c o3S
+c i58
+c i4_
+c '7 $2
+c $9 $4 $9
+c $9 $4 $0
+c $9 $1 $6
+c $8 $5 $6
+c $7 $8 $6
+c $6 $6 $7
+c $6 $1 $2
+c $4 $0 $8
+c $3 $0 $9
+c $3 $0 $4
+c $2 $1 $9
+c $0 $1 $2 $3
+^z ^z ^i ^f
+^y ^p ^o ^o ^l
+^y ^d ^e ^r ^f
+^u ^n ^o ^s
+^t ^i ^u ^c ^s ^i ^b
+^s ^t ^n ^i ^a ^s
+^s ^p ^a
+^s ^m ^s
+^r ^u ^n ^o
+^r ^e ^l ^l ^a ^b
+^r ^e ^k ^l ^a ^w
+^o ^n ^i ^m ^o ^d
+^n ^i ^g ^o ^l
+^n ^i ^b
+^n ^e ^d ^r ^a ^g
+^n ^a ^t ^r ^a ^p ^s
+^n ^a ^l ^c
+^n ^a ^h ^s
+^m ^A
+^l ^a ^t ^a ^f
+^l ^a ^g
+^k +6
+^j $1
+^i ^t ^r ^a ^m
+^i ^t ^a ^m
+^i ^h ^s ^u ^s
+^h ^e
+^h ^c ^r ^a
+^h ^a ^e ^y
+^g +2
+^f ^f ^o
+^e ^i ^s ^s ^a ^c
+^e ^e ^w
+^e ^c ^n ^a ^h ^c
+^d ^n ^a ^b
+^d ^a ^s
+^a ^n ^a ^i ^l ^u ^j
+^a ^i ^k ^o ^n
+^a ^b ^m ^i ^s
+^3 ^2 ^1 r
+] ,9 *13
+[ i3i
+[ i2w
+[ [ [ $1 $2 $3
+[ $3 +1
+K Y2 Y2
+K $e +3
+D8 $7
+D7 D5 c
+D5 D7 ^i
+D4 D4 ]
+D4 $0 $0 $1
+D2 i5f
+D2 D4 $1
+D2 $7 $8 $9
+D2 $0 $1
+D1 o2m D3
+D1 D2 o3m
+D1 +2 D4
+D1 $p
+D1 $6 $5 $4
+D0 o3n
+-2 -5 -4
++5 k o0j
++3 -5 -2
++3 -0 +4
++1 -5
++0 -1 -3
++0 +3 +4
+*51 D1 *12
+*41 -0
+*41 *52
+$r Z1 T6
+$m $i $l $o
+$h $e $l $l $o
+$g $i $r $l $s
+$f $a $i $t $h
+$d *23
+$a $g
+$8 $8 $2
+$8 $6 $3
+$7 $4 $2
+$6 $3 $7
+$5 $8 $1
+$4 $4 $7
+$3 $7 $0
+$2 $1 $0 $4
+$1 $9 $9
+$1 $2 $3 $?
+$0 $9 $0 $3
+$0 $3 $0 $2
+$0 $2 $0 $2
+$. *45
+$. $0 $9
+} ^e
+t Y2 [
+o6V o9i E
+o4i +5
+o4e u
+o42 i50 i61 o74
+o32 i40 i50 ,6
+o2u o6u
+o2o i4m
+o2i o4z
+o1i $a
+o1e o4z
+o0z o2i
+o0x o1j
+o0s *24
+o0s $a
+o0p $2 $1
+o0g $1 $2 $3
+o0a $1 $2 $3
+o0P D1
+o0N +2
+o0E +2
+o0D o1J
+o0D *13
+i82 ,9
+i80 o93
+i7j
+i6z ,7
+i6s o7i
+i6i i7s i81
+i6a c .7
+i6a $x
+i5s i6o i7n
+i5q
+i5l i6i i7n
+i5c i6h o7e
+i5c +6
+i5b i6o o7y
+i5a o6l
+i53 o64
+i50 o64
+i4o i5l o6a
+i4k o5l
+i4e o5t
+i4d o5u
+i4d i5o i6g
+i4a i5r
+i49 i51 o60
+i45 o52
+i43 o55
+i41 o52
+i41 i55 o64
+i40 i51 o63
+i3r [
+i3h c
+i35 i44 o53
+i35 i41 o57
+i31 o42
+i2s o3a
+i2j o3u
+i1u i2b
+i1r o3d
+i1i o2e
+i0w i1h
+c i73
+c ^0 ^0 ^0 ^1
+c '7 $7
+c '7 $3
+c $5 $0 $2
+c $4 $1 $2
+c $3 $4 $9
+c $3 $1 $0
+c $3 $0 $1
+c $1 $9 $6 $0
+c $1 $8 $0
+c $1 $5 $7
+c $1 $3 $3 $7
+^y ^o ^b ^y ^a ^l ^p
+^y ^m ^r ^o ^t ^s
+^y ^m ^m ^i ^k
+^y ^l ^z ^z ^i ^r ^g
+^y ^l ^l ^a ^e ^r
+^w ^o ^d ^n ^i ^w
+^t ^u ^n ^o ^d
+^t ^s ^i ^r ^c
+^s ^y ^l
+^s ^k ^m
+^s ^d ^i ^v ^a ^d
+^s ^a ^l ^k ^i ^n
+^p ^u ^c
+^p ^m ^a ^v
+^o ^n ^e ^r ^o ^m
+^o ^m ^s
+^o ^d ^l ^a ^n ^o ^r
+^o ^b ^a ^c
+^n ^o ^t ^t ^o ^c
+^n ^a ^k
+^l ^t ^a
+^l ^o ^h
+^l ^l ^a ^h
+^k ^e ^l ^a
+^k +3
+^j ^j ^j
+^g ^f ^m ^o
+^g $1
+^e ^n ^a ^k
+^c ^i ^t ^s ^y ^m
+^b -2
+^a o2o
+^a ^t ^a ^m
+^a ^s ^u
+^a ^r ^a ^t
+^a ^l ^o ^a ^p
+^a ^h ^t ^r ^a ^m
+^a .3
+^T ,3
+^7 ^6 ^5
+^3 }
+^1 -5
+^. ^w ^w ^w
+[ o3a
+Y2 Y4
+T0 T4 T6 T5 T3
+L7 o6h
+L6 $d
+K o40 Z1
+K i4a l
+K T0 +2
+E $R
+D5 o5z
+D4 $1 $0 $0
+D3 o5c
+D3 o2_
+D3 $w
+D2 o2s
+D2 $r
+D2 $g
+D2 $1 $9 $9 $8
+D1 o4b
+D1 o3q
+D1 o3k
+D1 o3h
+D1 D2 o3f
+D1 D2 $m
+D1 D2 $g
+D1 $5 $5
+D1 $2 $1
+-0 ^m
+-0 *21
++6 +2
++5 s'$ *30
++5 [ -2
++5 -1
++5 -0
++2 -1
++2 +3 +3
++2 *04
++0 -1 -1
++0 $9 $0
+*51 *25 ]
+*32 -1
+*31 o32
+*24 *30
+'8 *74
+$w i7q
+$p $i $o
+$o $1 $2 $3
+$m $1 c
+$k $i $t
+$i $n $n
+$i $k $a
+$h r
+$h $o $r $s $e
+$h $o $p
+$d $x
+$a +0
+$_ $7 $7
+$U T4
+$9 $3 $3
+$8 $8 $3
+$8 $7 $3
+$7 i76
+$7 *03 [
+$7 $5 -2
+$6 $4 $0
+$5 $7 $7
+$4 ^3
+$4 $3 $1
+$3 $0 $1 $0
+$2 $7 $0 $9
+$2 $6 $8
+$2 $6 $1 $1
+$2 $4 $1
+$2 $2 $0 $6
+$2 $2 $0 $5
+$1 $9 $3 $7
+$1 $9 $1 $1
+$1 $3 $!
+$0 $6 $1 $0
+$0 $1 $0 $9
+oBe
+o4y $o
+o4e .5
+o47 i57 i67 ,7
+o3y .4
+o3m $1 $2 $3
+o2u $i
+o1u $d
+o1s u [
+o1o *13
+o1. ]
+o0z ]
+o0z $3
+o0v i1e
+o0t o2u
+o0s i3i
+o0r $0 $2
+o0k i1k i2k
+o0P D5
+o0M *43
+o0K $2 $4
+o0J $1 $4
+o0E +1
+l $h $e
+k o0d
+i80 o92
+i7y
+i7l
+i71 i82 o93 oA4
+i6w o7a
+i6k o7o
+i6g i7i
+i6b o7a
+i6a o7k
+i6a i7s
+i6a i7l
+i6a i7d i8e
+i65 -8
+i5u o6l
+i5r o6u
+i5n o6y
+i5m i6o
+i5f K
+i5d o6u
+i54 K
+i52 i61 i73
+i50 i61 o75
+i50 i61 ,7
+i4t o5a
+i4s o5a
+i4s i5e
+i4q
+i4p o5e
+i4o i5n i6e
+i4n
+i4e $1
+i49 o50
+i48 o52
+i47 o51
+i45 i54 o65
+i42 i53 o64
+i41 i52 o63
+i3u o4d
+i3u i4l
+i3s $1
+i3n ]
+i3m i4a
+i3f ]
+i3c o4o
+i3b i4o
+i3a i4s
+i32 i44 o57
+i2t ]
+i2n i3d
+i2i i3n
+i2e o3n
+i2b o3u
+i1a o2c
+i00 z3
+c o7B
+c ^B
+c $9 $2 $0
+c $9 $0 $4
+c $8 $2 $8
+c $7 $1 $3
+c $7 $1 $0
+c $4 $2 $7
+^z ^e ^k
+^y ^s ^s ^i ^r ^h ^c
+^y ^p ^p ^o ^l ^f
+^t ^s ^e ^d
+^t ^r ^o ^w ^s ^s ^a ^p
+^t ^n ^a ^l ^p
+^s ^u ^i ^r ^a ^d
+^s ^e ^s ^i ^o ^m
+^r ^a ^t ^s ^k ^c ^o ^r
+^p ^o ^o ^l
+^o ^t ^a ^k
+^o ^n ^a ^d
+^o ^g ^r ^a ^m
+^o ^b ^e ^d
+^o *32
+^n ^o ^r ^a ^b
+^n ^i ^l ^l ^o ^c
+^n ^a ^c ^n ^u ^d
+^m ^a ^f
+^l ^l ^a ^f
+^l ^e ^f
+^l ^a ^r ^t ^n ^e ^c
+^l ^a ^i ^c ^o ^s
+^k ^u ^f
+^k -6
+^j }
+^j .4
+^j -5
+^i ^l ^e ^f
+^i ^h ^c ^i ^m
+^i *31
+^h ^s ^u ^k
+^e ^u ^q ^i ^r ^n ^e ^h
+^e ^l ^t ^r ^u ^t
+^e *32
+^a ^r ^r ^e ^t
+^a ^n ^a ^i ^r ^d ^a
+^a ^i ^r ^e ^l ^a ^v
+^a ^c ^n ^a ^l ^b
+^a ^c ^i ^h ^c
+^X D2
+^8 k ^8
+^4 $1
+^3 o17 r
+^2 ^2 ^1
+^2 ^1 o61 o72
+^,
+] i53
+[ i2y
+[ +0 D3
+Z1 i0J
+E o5L D6
+D6 $s
+D5 o5g
+D4 Z2 D0
+D2 $z
+D2 $5
+D1 o3s
+D1 o2z
+D1 o2g
+D1 -2 -3
+D1 $1 $9
+-5 r
+-2 k t
+-2 -3 -3
+-1 -4 -3
+-1 -2 -3 -4
+-0 -2 -6
++6 $7
++4 +5 +6 +7
++2 +4 +3
++2 +3 .1
+*63 *45
+*45 *23
+*40 *34
+*30 o0b
+'6 T0 o5*
+$t $h $a $i
+$j Z2
+$h $o $e
+$f $o $r
+$e r
+$d *21
+$d $o $o $m
+$c $o $n
+$b $o $i
+$_ $9
+$@ $1 $2
+$9 $3 $4
+$8 $4 $5
+$5 $9 $1
+$5 $6 $7 $8
+$5 $3 $8
+$4 $9 $7
+$3 $7 $3
+$3 $7 $2
+$3 $6 $4
+$2 $7 $1
+$2 $3 $0 $9
+$2 $2 $0 $3
+$1 $9 $4
+$1 $9 $0 $8
+$1 $3 $5 $7 $9
+$1 $1 $2 $9
+$1 $1 $1 $2
+$0 $4 $2 $0
+$(
+o6X c
+o57 R4 @4
+o4y u
+o4u ,5
+o4k t
+o4f $f
+o3y $1 $2 $3
+o3e Y2
+o3a -4
+o3a +4
+o31 i42 i53 i64 i75 o86
+o2R T0
+o1y o3u
+o1y o3a
+o1e *31
+o1e $e
+o0z $2
+o0w ,1
+o0w $1 $2
+o0v *25
+o0u ]
+o0s o3a
+o0s ^E
+o0r ,3
+o0r $2 $2
+o0n $4
+o0e $1 $2
+o0c .3
+o0T $2 $2
+o0T $2 $1
+o0N D3
+o0J o1B
+o0J $8 $7
+o0D ,3
+o0C $1 $7
+k Z2 +2
+i87
+i7o o8n
+i6n c
+i6d s$# c
+i6c i7h
+i6a i7i
+i62 i70 i81 o93
+i5c i6h o7i
+i5a i5f
+i58 o60
+i57 i67 i77
+i54 i76
+i4s i5i
+i4o o5r
+i4o o5p
+i4a o5k
+i44 i52 o60
+i3l o4o
+i3e i4s
+i3e i4l
+i35 i57
+i35 i44 ,5
+i33 i45 o56
+i33 i43 o57
+i33 i42 i51
+i31 o45
+i31 i41 o57
+i31 i37
+i30 ,4
+i3$
+i2r i3e
+i2l o3e
+i2d o3o
+i2c i3h
+i2b o3i
+i2b i3e
+i1x
+i1e o2f
+i1a o2b
+i0M i1e
+i0H
+i09 i31 p4
+d '8 $1
+c i57
+c '8 $4
+c $9 $4 $6
+c $9 $2 $8
+c $7 $5 $0
+c $6 $3 $6
+c $6 $2 $5
+c $5 $7 $9
+c $3 $1 $8
+c $3 $0 $0
+c $2 $4 $2
+c $1 $9 $9 $9
+c $1 $9 $6 $8
+^z ^u ^c
+^y ^m ^o ^r
+^y ^e ^c ^a ^r ^t
+^y ^d ^d ^a
+^u ^t ^a ^t
+^u ^k ^a ^t ^o
+^t ^u ^n ^o ^c ^o ^c
+^r ^o ^i ^r ^r ^a ^w
+^r ^e ^v ^o ^l ^c
+^o ^c ^l ^a ^f
+^o ]
+^n ^o ^t ^r ^e ^v ^e
+^n ^o ^i
+^n ^i ^v ^o ^l
+^m ^l ^e
+^m ^e ^s
+^m ^e ^d
+^i ^b ^i ^h ^c
+^i ^a ^c
+^h ^s ^u ^b
+^g -6
+^e ^n ^i ^r ^a ^m
+^e ^l ^i ^m ^s
+^e ^g ^d ^e
+^e ^g ^a ^s
+^e $1
+^d ^i ^s
+^d ^e ^e ^w
+^b ^e ^s
+^b ^a ^c
+^a ^l ^r ^a ^k
+^9 ^9 o79 ,8
+^8 *60
+^7 o17 r
+^7 o12 r
+^6 o14 r
+^5 o19 r
+^5 o13 r
+^4 ^1 $1 $4
+^3 ^2 ^2
+^3 *25 *13
+^2 }
+^2 o19 r
+^0 ^5 ^0
+] i43 s9|
+] $9
+[ i41 i52 o63
+[ $7 $8 $6
+[ $7 $7 $7
+L7 i6d
+K Y2 *12
+E D9
+D6 $4
+D5 $9 *43
+D4 o5w
+D2 o4v
+D1 o2z D3
+D1 i54
+D1 D2
+D1 D1 D2
+D1 $l
+D1 $9 $9
+D1 $0
+.0 ] r
+-1 -3 -3
+-0 -4 -0
+-0 $3 $3
++6 k D4
++5 -2 -3
++5 *42
++3 -1
++3 *52
++3 *42
++2 -1 +3
++1 -2 +5
++0 +5 +4
+*42 *25 r
+*20 *97 -3
+*14 o2b
+*12 i0a
+$r $a $c $k
+$q $1 $2 $3
+$p $a $u
+$m o0g
+$l *23
+$l $a $u
+$f $a $s $t
+$e $v $e
+$d $a $m
+$c r
+$_ $9 $9
+$7 $8 $4
+$7 $7 $3
+$7 $5 $2
+$7 $4 $0
+$6 $6 $0
+$6 $4 $8
+$6 $4 $3
+$4 $2 $4 $2
+$2 $8 $3
+$2 $$
+$- $1 $2
+$' K
+siE u
+si1 u sE3
+o6K
+o5o t
+o4y $i
+o4o i51 i62 i73 o84
+o4f $o
+o41 i51 i61 ,7
+o3b $r
+o32 i40 i50 o62
+o2r $a
+o2S c *35
+o1z o3z
+o1u o5y
+o1i $i
+o1i $e
+o1e $1 $2 $3 $4 $5
+o0z o5z
+o0y o2s
+o0v i1o
+o0v .2
+o0r $0 $1
+o0g $y
+o0W $1 $2
+o0T D6
+o0T $8 $9
+o0N $0 $8
+o0K $2 $1
+o0K $0 $0
+o0J $8 $9
+o0E .1
+i9e oAr
+i99
+i8s
+i82 i93
+i73 i76
+i7!
+i6l o7i
+i6e i7n
+i62 i73 i84
+i5r o6t
+i5r ]
+i5f o6o
+i5c i6o
+i59 o68
+i4z o5a
+i4t o5i
+i4t i5e
+i4h i5o
+i4e i5k
+i4e .3
+i4d i5i
+i4c o5e
+i4a o5t
+i4a o5r o6i
+i4a o5f
+i49 i58 o67
+i48 i59 o60
+i41 -7
+i40 -1
+i4- ,7
+i4#
+i3v D6
+i3p ]
+i3o o4r
+i3o o4b
+i3n o4e
+i3n i4e
+i3k ]
+i3b o4a
+i3T E
+i3D l ]
+i37 i51
+i37 i43 o57
+i34 i55
+i34 i42 o57
+i32 o44
+i2s o3i
+i2d o3i
+i2b o3e
+i2a D5
+i1z ]
+i0p i1e
+i0J i1a
+i0C i1a
+c i44
+c ^0
+c $9 $1 $8
+c $5 $1 $0
+c $4 $0 $4
+c $1 $2 $1 $2
+c $1 $0 $0 $1
+^y ^r ^r ^e ^g
+^y ^l ^l ^i ^h ^p
+^y ^l ^a ^t ^i
+^y ^g ^g ^o ^r ^f
+^y ^g ^g ^a ^h ^s
+^y ^b ^a ^f
+^t ^t ^i ^p
+^t ^i ^m ^r ^e ^k
+^t ^f ^a ^r ^c
+^t ^a ^b ^m ^o ^c
+^s ^h ^a
+^s ^e ^r ^r ^o ^t
+^s ^a ^l ^i ^s
+^r ^e ^v ^n ^e ^d
+^r ^e ^v ^i ^d
+^r ^e ^n ^n ^o ^c
+^r ^e ^m ^o
+^r ^e ^g ^o ^o ^b
+^r ^a ^a
+^p ^o ^o ^n ^s
+^o ^p ^p ^i ^p
+^n ^o ^i ^t ^c ^a
+^m ^a ^p
+^l ^u ^a ^p T4
+^l ^o ^g
+^l ^l ^a ^w
+^j o51
+^i z1
+^i ^r ^o ^l
+^i ^r ^a ^k
+^i ^m ^a ^m
+^i ^b ^o ^t
+^g ^n ^i ^m ^a ^l ^f
+^e ^t ^t ^o ^l ^r ^a ^h ^c
+^e ^p ^o ^d
+^e ^l ^b ^b ^u ^b
+^e ^i ^d ^a ^s
+^e ^i ^b ^r ^a ^b
+^a i5a
+^a ^s ^l ^e
+^a ^d ^a ^d
+^a ^c ^i ^n ^o ^r ^e ^v
+^a .4
+^8 o18 r
+^4 o15 r
+^3 $2
+^3 $1
+^1 ^9 ^0
+^0 ^0 ^4
+[ k .2
+[ $6 $1 $9
+[ $1 $0 $0
+L6 $r
+K ,7 k
+E o5S
+D5 o6m
+D4 o4n
+D4 $0 $4
+D3 o4l
+D2 o3j
+D2 $0 $2
+D2 $0 $0
+D1 o3m
+D1 o2v
+D1 D2 o3b
+-1 -5
+-0 $0 $9
+-0 $0 $7
++6 -2 -0
++5 r
++5 o3k
++4 -2 +4
++3 +5 -4
++2 o1b
++2 o0v
++0 +2 +3
++0 +1 +1
++0 $9 $8
+*65 [ {
+*51 [
+*51 *31
+*40 *02
+*32 *04
+*04 D1
+'B $1
+$s $o $y
+$r $e $p
+$n $o $e $l
+$m $1 $2 $3
+$g $e
+$c $h $o
+$a $r $e
+$a $n $t
+$J
+$@ $7
+$@ $0 $1
+$8 $9 $4
+$8 $6 $8
+$8 $6 $7
+$8 $4 $8
+$7 $5 $9
+$6 $8 $5
+$6 $3 $1
+$4 $6 $6
+$3 ^m
+$3 $7 $1
+$3 $4 $8
+$2 $9 $1 $0
+$2 $7 $6
+$2 $0 $3 $0
+$1 $s $t
+$1 $4 $1 $4
+$1 $4 $1 $1
+$1 $2 $0 $7
+$0 $3 $1 $2
+$0 $3 $0 $5
+$0 $1 $.
+x52
+t i2P
+s}, i6z E
+si1
+r $t $y
+o5p t
+o4x $1 $2 $3
+o43 i52 i63 o72
+o3o $2 $0 $0 $2
+o3i $e
+o3f $1 $2 $3
+o3e +4
+o31 i42 i53 i64 o75
+o2z r
+o2i $a
+o2e +3
+o25 Y1 *02
+o1y o4y
+o1u o4j
+o1i o4h
+o0t $0 $3
+o0o D4
+o0n o4a
+o0n i2e
+o0W $1 $2 $3
+o0V $0 $1
+o0T $0 $5
+o0R $1 $3
+o0N $2 $3
+o0M $1 $1
+o0K o3g
+o0K i1e
+o0K ,3
+o0J +2
+o0J $6
+o0J $1 $3
+o0H $2 $4
+l o6b i7o ,8
+i8n
+i8k D6
+i7e o8n
+i76
+i72 i83 i94
+i7+ .7 [
+i6t o7o
+i6l i7e
+i6a i7y
+i64 ske ]
+i62 i98
+i5o o6w
+i5o i6r
+i5k o6i
+i5i o6d
+i52 i62 ,7
+i51 i62 o70
+i4u i5r
+i4o o5l
+i4o i5l
+i4m o5i
+i4l o5u
+i4i i5k
+i4g i5o
+i4c *04
+i4a o5d
+i4M E
+i45 Z1 c
+i42 o55
+i42 i51 o65
+i42 i51 o60
+i4'
+i3r o4a
+i3o i4n
+i3e o4l
+i3a o4b
+i38 i49 o58
+i35 i47 o55
+i33 i46 o53
+i31 o47
+i2l i3a
+i2k o3e
+i2g o3a
+i2d '6
+i1l ]
+i1f ]
+i1e o2r
+i1e i2l
+d D4 'B
+c $l
+c $9 $6 $6
+c $8 $0 $3
+c $7 $1 $7
+c $7 $0 $4
+c $6 $2 $0
+c $4 $8 $5
+c $4 $0 $9
+c $4 $0 $3
+c $3 $2 $5
+c $2 $3 $5
+^z ^i ^r
+^y ^x ^a ^m
+^y ^t ^r ^a
+^y ^t ^i ^n ^e ^r ^e ^s
+^y ^k ^r ^a ^m
+^y ^k ^i ^m
+^y ^a ^r ^t
+^y ^a ^r ^r ^u ^m
+^t ^o ^r ^r ^a ^c
+^s ^m ^a ^e ^r ^d
+^s ^l ^l ^i ^b
+^r ^c ^s
+^o ^x ^o ^x
+^o ^t ^r ^o ^p
+^o ^o ^r
+^o ^l ^l ^e ^c
+^o ^l ^j
+^o ^c ^i ^m
+^n ^o ^i ^r ^a ^m
+^n ^i ^l ^a
+^n ^i ^g
+^n ^a ^m ^i
+^k ^n ^o ^m
+^i ^n ^m ^o
+^h o1y
+^f ^e
+^e ^u ^s
+^e ^i ^v ^e
+^b ^m ^o ^b
+^b ^a ^l
+^b -6
+^a o2i
+^a ^s ^l ^a ^s
+^a ^r ^t ^s ^a
+^a ^r ^e ^v
+^a ^h ^n ^i ^n ^a
+^a ^d ^n ^a ^r ^i ^m
+^O D5
+^O D4
+^L
+^5 o12 r
+[ i4e
+K i3k
+K $3 i90
+D6 o6t
+D6 o6k
+D6 o6f
+D6 o6e
+D5 *21
+D5 $z
+D5 $1 $2 $3
+D3 o4s
+D3 o4b
+D3 D8
+D2 o4b
+D1 o4g
+D1 o45
+D1 o3w
+D1 D2 o2g
+D1 D2 $v
+D1 $1 $7
+D0 t *30
+-0 +1
++7 i7_
++6 E $*
++5 -2 -2
++5 -1 -2
++5 *12
++3 ^h
++2 -4 -4
++2 +4 +5
++1 Z1 D3
+*52 +1
+*41 +5
+$g +4
+$g $o $a $t
+$d $2
+$_ $9 $0
+$K $e c
+$? +5
+$7 i63
+$6 $6 $3
+$6 $6 $1
+$5 o78
+$5 $3 $6
+$4 $9 $8
+$4 $4 $1
+$4 $3 $3
+$3 $@
+$3 $1 $0 $3
+$2 $7 $0 $7
+$2 $5 $1 $1
+$1 $9 $1 $7
+$1 $6 $2
+$1 $1 $2 $1
+$0 $9 $0 $8
+$0 $7 $1 $0
+$0 $4 $0 $6
+$0 $1 $1 $0
+{ *03
+o9a c
+o6F
+o5T u
+o52 i60 sS0 $5
+o4a +5
+o3n $1 $2 $3
+o3a $o
+o2i $1 $2 $3
+o2f $1 $2 $3
+o2a $a
+o1o $1 $2 $3
+o1i o3y
+o1i $1 $2 $3 $4 $5
+o1a o4v
+o1A D2
+o0z o4o
+o0z $1 $2
+o0z $1 $1
+o0y i1u
+o0w o1s
+o0t i1k
+o0t ]
+o0p $0 $0
+o0o D2
+o0h $i
+o0f $o
+o0d $o
+o0b $o
+o0V $1 $2
+o0T $9 $9
+o0D $0 $5
+l $@ $g $m $a $i $l $. $c $o $m
+k i3l
+k -2 y3
+k ,3
+k $p
+i7i i8s i91
+i73
+i72 i81
+i6| $8 ,6
+i6r o7u
+i6f .5
+i6e o7l
+i6d i7e i8r
+i67 l K
+i66 o79
+i62 i71 o83
+i5n o6i
+i5n i6i
+i5h T0
+i5d o6o ,7
+i5c o6o
+i59 i60 ,7
+i52 i60 i70 i80
+i4w i5a
+i4u o5n
+i4u i5n
+i4t i5r
+i4q [
+i4p i5o
+i4p ]
+i4o i5s
+i4h c -9
+i4e o5y
+i4e o5v
+i4a i5l
+i49 i51 ,6
+i48 o50
+i47 i57 i67
+i43 i56 o69
+i42 i51 o62
+i40 i50 o61
+i3t o4e
+i3a o4p
+i3a o4d
+i33 i40 o53
+i32 i45 o58
+i30 o42
+i2q
+i2m i0a
+i2d o3u
+i2d i3o
+i2a o3r
+i1u o2l
+i1t i0a
+i1o o2l
+i1l o2i
+i1c +2
+i1b ]
+i0d i1r i2a
+c o47
+c i5$
+c ^9 $4
+c T6 i6_
+c $m $a $n
+c $8 $3 $1
+c $7 $3 $1
+c $7 $0 $1
+c $6 $3 $0
+c $5 $1 $3
+c $4 $5 $1
+c $3 ^8
+c $2 $4 $1
+c $1 $2 $!
+^z ^t ^a ^k
+^y ^x ^e ^l
+^y ^a ^h ^c
+^u ^r ^i ^p
+^s ^r ^e ^v ^o ^l
+^s ^r ^e ^l ^e ^e ^t ^s
+^r ^e ^b ^i ^c
+^q ^b ^b
+^p ^o ^o ^c
+^p ^a ^d
+^o ^t ^i ^l
+^o ^n ^i ^h ^r
+^o ^l ^a ^s
+^o ^a ^y
+^o -3
+^n ^o ^l ^r ^a ^m
+^n ^o ^i ^z
+^n ^a ^r ^t
+^m ^u ^l ^p
+^l ^e ^u ^q ^a ^r
+^k ^r ^o ^y ^w ^e ^n
+^k ^a ^z
+^i ^t ^s ^a ^b
+^h o2h
+^h +6
+^g ^i
+^e o2a
+^e ^r ^p ^m ^e ^i ^s
+^e ^r ^m ^e
+^e ^m ^e ^r ^t ^x ^e
+^e ^i ^n ^a ^l ^e ^m
+^e ^i ^b ^b ^a
+^c ^n
+^c -3 -3
+^b o1u
+^a ^r ^t ^n ^o ^c
+^a ^l ^e ^m ^a ^p
+^a ^h ^t
+^a ^c ^c ^e ^b
+^X D2 D3
+^R D5
+^7 $5
+^5 o15 r
+^4 o13 r
+^4 ^2 ^3
+^2 o17 r
+^0 }
+] } ^Z
+[ [ ]
+[ E K
+[ +5 k
+[ $2 $0 $0 $8
+Y2 c *AB
+K i2l
+D8 +8
+D4 $t
+D2 o4k
+D1 o2d
+D1 D3 o3v
+D1 D2 D3
+-3 $a
+-0 -6 -6
++5 $g
++4 }
++4 ^a
++3 y4
++3 ^j
++3 -0 +6
++2 -4 +3
++1 $a
++0 $9 $1
+*50 *24
+*41 *32
+*40 D3
+*35 *41
+*34 o2f
+*34 ^m
+*02 ^0
+$n $1 $2
+$l $e $g $a $l
+$g {
+$g $e $e $k
+$f $a $r $t
+$d $e $m $o $n
+$_ $0 $0
+$8 $3 $2
+$7 ^5
+$7 $9 $4
+$6 $6 $8
+$6 $5 $4 $3 $2 $1
+$4 $6 $4 $9
+$4 $4 $8
+$3 $1 $0 $7
+$2 $6 $1
+$1 $3 $5 $7
+$1 $2 $1 $4
+$1 $2 $1 $1
+$1 $2 $0 $4
+$0 $9 $0 $2
+$0 $5 $1 $2
+} i1g
+{ C [
+sS- $I $I $I
+o5k $a
+o5N
+o3z $z
+o2s $a
+o2e
+o2&
+o2$
+o1y o3z
+o1e +3
+o1c $1 $2 $3
+o1a o5i
+o1a $1 $2 $3
+o0y o1i
+o0t o2o
+o0s i1r
+o0s +6
+o0o o2k
+o0j +1
+o0f $a
+o0_ $_
+o0K $2 $2
+o0J $2 $1
+o0J $!
+l i6l o7e ,8
+k i2v
+i80 i92
+i72 $8
+i71 i85
+i6s o7e
+i6n i7o
+i6l o7u
+i6k T0
+i61 i70 ,8
+i5r i6u
+i5m i6a o7u
+i5b ,6
+i5a o6k
+i52 +4
+i50 i61 o72
+i4k o5o
+i4h o5i
+i4g i5e
+i4f ,5
+i4c
+i48 o51
+i47 i56 o65
+i42 i54 o67
+i41 i50 o63
+i40 o52
+i3i o4e
+i3b i3a
+i3a o4r
+i37 i41 o58
+i33 i46 o59
+i30 o48
+i2r u
+i2k o3u
+i2b i3a
+i1i i2g
+i1g i1a
+i0n ^k
+i0i o3k
+i0R ^M
+c '9 T3
+c '7 $6
+c $X
+c $9 $4 $4
+c $9 $2 $7
+c $8 $7 $9
+c $8 $4 $8
+c $8 $1 $6
+c $7 ^1
+c $6 $1 $1
+c $5 $8 $1
+c $5 $3 $0
+c $5 $2 $5
+c $4 $8 $6
+c $4 $2 $5
+c $3 $3 $0
+c $3 $1 $7
+c $2 $7 $8
+c $2 $0 $4
+c $2 $0 $3
+c $1 $3 $1 $3
+c $1 $3 $0
+c $0 $9 $8
+^y ^t ^i ^n ^i ^f ^n ^i
+^y ^o ^c
+^y ^n ^n ^i ^v
+^u ^c ^u ^c
+^t ^e ^c
+^s ^r ^e ^g ^n ^a ^r
+^s ^p ^i ^h ^c
+^s ^o ^m ^a ^r
+^s ^g ^i ^p
+^s ^e ^e ^k ^n ^a ^y
+^s ^d ^l
+^r ^e ^t ^n ^u ^o ^c
+^p y2
+^p ^c ^m
+^p ^a ^p
+^p ^a ^h
+^o ^t ^c ^o
+^o ^r ^e ^i ^u ^q
+^o ^n ^a ^k
+^o ^d ^a ^d
+^o ^c ^s ^e
+^n ^u ^h
+^n ^i ^d ^o
+^n ^i ^d
+^i ^l ^e ^d
+^i ^h ^s ^o ^y
+^i ^a ^h
+^e ^s ^a ^e ^l ^p
+^e ^n ^i ^a ^l ^e
+^e ^i ^s ^s ^e ^j
+^e ^d ^e ^d
+^d ^n ^o ^c ^e ^s
+^c ^i ^s ^s ^a ^l ^c
+^b ^l ^a
+^a ^l ^y ^a ^l
+^a ^k o3i
+^a ^c ^i ^r ^e ^m ^a
+^a -1
+^X D4
+^@ ]
+^9 o13 r
+^9 ^0 ^2 ^1
+^8 +1
+^5 o17 r
+^3 ^2 ^1 -3
+^2 ^2 ^1 ^1
+^1 r *02
+^1 o51
+^0 ^9 ^1
+] D1 u
+] $8
+[ t ]
+[ i3y
+T2 T4
+K o2l
+K T2 o0M
+E *32
+D6 $8
+D5 o5y
+D5 o57
+D4 $n
+D3 o4m
+D3 $9 $9 $9
+D3 $2 $0 $0 $0
+D2 o3x
+D2 $5 $0 $0
+D1 D3 -3
+D1 $0 $4
+D1 $0 $0
+-5 o0h
+-1 *20
+-0 $1 $7
++5 o3t
++5 ] $9
++4 -2 -2
++3 r
++3 $c }
++0 -2 +3
+*64 D0 +1
+*41 *25 D5
+*31 D2
+*03 *32 +3
+$s $w $o $r $d
+$m { k
+$j $o $b
+$d $o $p $e
+$d $a $d $d $y
+$c $u $p
+$b $r $a
+$J c
+$9 i73
+$6 s19
+$6 $8 $2
+$5 $3 $7
+$4 $9 $6
+$4 $7 $0
+$3 $3 $9
+$3 $1 $1 $2
+$2 $4 $0 $6
+$1 $9 $0 $9
+$1 $9 $0 $3
+$1 $4 $0 $2
+$1 $3 $0 $7
+$0 $7 $0 $5
+$0 $6 $0 $6
+$0 $5 $0 $4
+$0 $4 $0 $2
+$0 $2 $1 $1
+t i5T
+o7y ]
+o4r $r
+o4o $r
+o4o $p
+o4Z K c
+o3u $o
+o3a $r
+o2r $1 $2 $3
+o2a $1 $2 $3
+o1v .2
+o1i $t
+o1g ]
+o1a $e
+o0w i3g
+o0v o3a
+o0v $1 $0
+o0s o4e
+o0p o2e
+o0n $2 $1
+o0Y l *53
+o0T $7 $7
+o0H -5
+o0H $0 $6
+o0G $0 $7
+o0D -6
+o0B i1B
+o01 z2
+k ^g
+k ^H
+i98 s18
+i72 $4
+i6n o7o
+i6l i7a i8n
+i6e i7t
+i6e ,7
+i69 o78 o87
+i60 i70 i80
+i5t i6i
+i5r i6a
+i5o i6v
+i5g i6a
+i5c o6k
+i5c -4
+i51 o65
+i50 o65
+i4t i5u
+i4p o5h
+i4p i5e
+i4n i5i
+i4n i5e
+i4m -3
+i4l i5i i6n
+i4k i5i
+i4i o5k
+i4e $e
+i4b i5o i6y
+i4a o5r
+i4a $a
+i49 o51
+i44 i51 o64
+i43 i52 o60
+i43 i52 ,6
+i41 i51 o67
+i41 i50 o67
+i41 $2
+i40 o51
+i3u o4n
+i3s o4i
+i3r o4o
+i3p o4h
+i3a o4c
+i36 i48 ,5
+i36 i41 o55
+i32 i41 o53
+i2u o3t
+i2n o3a
+i2l i3l i4e
+i2l i3i
+i2h ]
+i2f D5
+i2b i3i
+i2a o3t
+i2a o3s
+i24 {
+i1o o0C
+i1h D5
+i1g o3n k
+i0t i1r i2a
+f '9 $x
+c ^1 $3
+c $7 $2 $9
+c $6 $1 $7
+c $5 $8 $4
+c $4 ^8
+c $4 $4 $4
+c $3 $1 $9
+c $3 $0 $8
+c $2 $1 $8
+c $2 $1 $2
+^y ^r ^o ^t
+^y ^l ^l ^e
+^w ^o ^d ^a ^e ^m
+^u ^k ^i ^r
+^t ^u ^h
+^t ^t ^o ^h
+^t ^r ^a ^p
+^t ^i ^b ^b ^o ^h
+^t ^e ^p ^m ^u ^r ^t
+^s ^s ^e ^l
+^s ^l ^e ^i ^n
+^s ^a ^i ^h ^t ^a ^m
+^r ^o ^r ^r ^o ^h
+^r ^e ^t ^s ^o ^f
+^r ^e ^i ^k
+^r ^e ^b ^o ^r
+^o ^t ^g
+^o ^t ^e ^n
+^o ^t ^a ^m ^o ^t
+^o ^i ^n ^u ^j
+^o ^d ^n ^e ^t ^n ^i ^n
+^n ^i ^u ^q ^a ^o ^j
+^m ^o ^t ^a
+^l ^a ^p
+^k o1i i2m
+^k ^r ^a ^h ^s
+^i ^t ^i ^t
+^i ^s ^a
+^i ^l ^e ^m
+^i ^h ^c ^r ^a
+^i ^e
+^h ^t ^i ^d ^e
+^h ^c ^i ^m
+^h -2
+^g ^n ^e
+^g ^e ^l
+^f ^e ^t ^s
+^e ^s ^i ^l ^e
+^e ^l ^p ^a ^m
+^e ^l ^l ^a ^c
+^e ^k ^i
+^e ^i ^n ^a ^h ^p ^e ^t ^s
+^e ^i ^l ^s ^e ^l
+^e ^i ^l ^l ^a
+^e ^i ^c ^a ^r ^g
+^d o2c
+^d ^o ^m
+^d ^e ^k ^a ^n
+^c +3
+^a ^t ^e ^r ^g
+^a ^n ^u
+^a ^i ^n ^a ^t
+^a ^h ^s ^a ^t ^a ^n
+^a ^g ^n ^a ^m
+^a ^d ^a ^n ^a ^c
+^R D3
+^9 o10 r
+^8 ^9 ^0 o37
+^7 o57
+^7 o13 r
+^6 o16 r
+^5 o11 r
+^5 ^0 ^5 ^0
+^3 ^2 ^1 i74 i85 o96
+^2 o14 r
+[ $9 $8 $7
+[ $0 $2
+T1 T2 T3 T4 T5
+T1 T2
+K o7t
+K i3m
+K i2k
+K .3
+E *B7 *34
+D8 o8u
+D6 o6o
+D6 o67
+D5 K *43
+D4 o5d
+D3 o4g
+D3 o4c
+D3 $3 $2 $1
+D2 o4t
+D2 D7
+D2 $s
+D1 i3b
+D1 D3 o3p
+D1 D2 o3q
+D1 $0 $3
+-1 -1 -4
+-0 $2 $5
+,1 o2_
++6 k
++5 o4v
++5 -3 -3
++3 ^d
++3 ] Y1
++3 -2 -2
++3 -0 -5
++3 -0 -0
++3 +7
++3 +5 +6 +4
++3 +4 -5
++2 o5k
++2 +5
++2 *30
++1 { *21
++1 i4z D3
++0 o44
++0 +4 +0
+*30 ,3 *52
+*27 ^a *34
+*20 r
+*20 o0l
+*12 r
+*10 i03
+*03 *54 *32
+'8 *56
+'5 $x
+$x Z3
+$s ^S
+$s $m $a $s $h
+$r $o $c $k $y
+$i $a $1
+$f $o
+$b $e $r $r $y
+$_ $3
+$8 $7 $1
+$7 $6 $8
+$7 $3 $6
+$6 $8 $8
+$6 $6 $2
+$6 $4 $9
+$5 $6 $3
+$5 $5 $8
+$5 $3 $9
+$4 $4 $6
+$4 $3 $6
+$4 $3 $4
+$3 Z3
+$3 $7 $7
+$3 $0 $0 $6
+$2 $9 $6
+$2 $4 $0 $9
+$2 $1 $1 $0
+$1 $3 $1 $1
+$1 $1 $2 $5
+$1 $0 $0 $7
+$1 $#
+$0 $9 $1 $2
+$0 $8 $1 $2
+$0 $5 $0 $3
+$0 $2 $5
+$0 $1 $0 $5
+$. $2 $1
+} -2
+} *04
+{ $i k
+{ $9
+o7Y c
+o6y $1 $2 $3
+o6s *51 E
+o5z $1 $2 $3
+o5l $l
+o5A
+o53 -6
+o4h Y2
+o42 i50 i61
+o3w $1 $2 $3
+o3i Z2
+o3A D4
+o32 i40 i50 o64
+o2u $k
+o2m y2
+o2#
+o1y i3a
+o1u i3o
+o1a ,2
+o0z i2c
+o0v y2
+o0r $1 $3
+o0p o4a
+o0n $0 $1
+o0h $r
+o0W $5
+o0K -3
+o0K $9 $9
+o0K $9 $0
+o0K $2 $3
+o0J $2 $4
+o0I +1
+o0H $1 $5
+o0F ]
+o0F $3
+o0E D5
+o0A o1B
+i85 Z1
+i7i
+i6r
+i6d o7o
+i6c o7o
+i6a o7s
+i6I E
+i60 i70
+i5r +4
+i5e o6p
+i5e i6m
+i5a i6t
+i52 i61 i72
+i52 ,6
+i50 i60 i79
+i50 i60
+i4v i5a
+i4u i5t
+i4s $2
+i4n o5o
+i4k o5i
+i4j i5a
+i4f i5a
+i4e i5s i6t
+i4b o5e
+i4a i5n i6t
+i4_ ]
+i48 i51 o68
+i47 i58 o67
+i42 i55 o66
+i3u o4r
+i3t i4e
+i3t i4a
+i3s i4e
+i3p o4a
+i3o o4n
+i3l o4i
+i3h *20
+i3g o4e
+i3a o4l
+i3a i4s i5s
+i3G c
+i35 i41 o54
+i34 i45 o58
+i33 i41 o57
+i31 o49
+i2u k
+i2e o93
+i21 i32 o43
+i1u i2d
+i0s i1h i2e
+i0I
+c ^8 $7
+c $9 $2 $9
+c $7 $6 $5
+c $7 $0 $6
+c $6 $0 $6
+c $5 $1 $7
+c $5 $0 $4
+c $4 $8 $0
+c $4 $2 $2
+c $3 $2 $0
+c $3 $*
+c $2 $4 $0
+c $2 $0 $0
+c $1 $5 $2
+c $1 $0 $9
+^y ^p ^p ^i ^z
+^y ^n ^o ^t ^n ^a
+^y ^n ^o ^r
+^w ^e ^s
+^u ^a ^i ^m
+^t ^u ^r
+^s ^u ^o ^i ^c ^e ^r ^p
+^s ^s ^i ^m T4
+^s ^i ^n ^a ^d
+^p ^i ^t
+^o ^v ^e ^d
+^o ^k ^c ^o ^r
+^o ^i ^h ^o
+^o ^d ^n ^a ^r ^b
+^o ^P
+^n ^y ^s
+^n ^u ^m
+^n ^o ^s ^i ^l ^l ^a
+^n ^o ^m ^a ^d
+^n ^i ^l ^t ^i ^a ^c
+^n ^e ^l ^e ^b
+^n ^a ^w
+^i ^m ^a ^s
+^i ^l ^l ^a
+^i ^k ^a ^m
+^h ^g ^u ^h
+^g o1h
+^g D2
+^e ^v ^a ^s
+^e ^r ^a ^l ^c
+^e *54
+^a ^t ^a ^c
+^a ^r ^e
+^a ^m ^a ^l ^l
+^a ^i ^t
+^a ^d ^i ^r ^f
+^B o1l
+^7 o15 r
+^7 $2
+^4 s24
+^3 o53
+^2 o13 r
+^1 ^0 ^1 o30
+^0 o19 r
+^0 ^5 o20
+^0 ^2 $2 $0
+^) $( r
+[ *43 +1
+[ *20
+[ $2 $0 $1 $2
+Z3 Z5
+Z1 i8y
+K o3z
+K o3g
+K Y2 t
+K $w
+D4 ^z
+D3 o5g
+D3 $z
+D2 o4g
+D2 o4d
+D2 Y2 y3
+D1 $1 $5
+-3 o0w iB`
+-3 o0a
+-1 o24
+-0 -2 -2
+-0 $4 $5
+-0 $2 $0
++6 o0l }
++5 -2 +5
++5 *05
++4 $a
++2 -4 -3
++2 -0 -0
++2 +4 +4
++2 +3 +5
+*64 *65 [
+*03 o0h
+'6 *51
+$x $1 $2 $3 $4
+$s $p $y
+$p $u $g
+$o $3
+$g $3
+$d $e $a $n
+$c Z2
+$c $x
+$c $h $i $k
+$c $a $p
+$b {
+$_ $1 $8
+$9 i68
+$9 *20
+$6 $4 $7
+$6 $3 $3
+$5 [
+$5 $7 $3
+$5 $4 $8
+$3 *12
+$3 $7 $4
+$3 $0 $1 $1
+$2 $7 $1 $2
+$2 $5 $0 $9
+$2 $4 $0 $7
+$2 $2 $0 $7
+$1 $9 $1 $2
+$1 $7 $0 $1
+$1 $3 $1 $2
+$1 $1 $1 $0
+$0 $8 $6
+$0 $1 $0 $2 $0 $3
+$$ K
+{ *41
+sa@ se3 si1
+o9g
+o5t o6v
+o4g $g
+o4c $i $o
+o4a -5
+o3z $a
+o3x o1F [
+o2h $1 $2 $3
+o1e $i
+o0w .2
+o0t o2e
+o0s -2
+o0r $1 $0
+o0p -1
+o0n $0 $5
+o0k $o
+o0d $z
+o0Z D4
+o0Z D3
+o0V K
+o0R $0 $5
+o0P $9 $9
+o0P $2 $2
+o0P $1 $8
+o0N D4
+o0F l
+l o8- o9b $o $r $n
+l $1 $2 $3 $4 $5 $6 $7
+i70 i80 i98
+i6a i7b
+i64 $1
+i63 o72
+i62 i70 ss0 $5
+i5w i6a
+i5s i6a
+i5_ ]
+i52 i60
+i50 o62
+i4y i5o i6u
+i4t o5u
+i4s r
+i4p o5i
+i4p i5a
+i4n t
+i4n o5y
+i4j
+i4c i5a
+i49 i52 o60
+i48 i52 o60
+i47 i52 o60
+i45 i54 o63
+i44 i51 o65
+i43 i52 o61
+i42 i52 o68
+i42 i52 o65
+i3r i4e
+i3p *02
+i3o o4w
+i3a i4s i5d
+i36 i41 o54
+i35 i46 o54
+i35 i42 o54
+i35 i42 o53
+i33 i48 o59
+i33 i47 o55
+i32 o48
+i32 i35
+i2s o3u
+i2e D5
+i1n D4
+i1l o2e
+i1b
+i0n i1i i2c
+d o0p
+c o35
+c ^2 ^1 ^0 ^2
+c $e $1
+c $9 $4 $3
+c $9 $0 $7
+c $9 $0 $3
+c $8 $9 $1
+c $8 $8 $6
+c $8 $2 $0
+c $7 $8 $7
+c $6 $0 $9
+c $5 $0 $9
+c $4 $5 $2
+c $3 $2 $6
+c $2 $3 $8
+c $2 $2 $0
+c $2 $1 $4
+c $2 $0 $9
+c $2 $0 $1 $3
+c $1 $9 $6 $2
+c $1 $9 $6 $1
+c $0 ^9
+^y ^t ^s ^a ^t
+^y ^r ^a ^k
+^y ^e ^l ^r ^a ^h ^c
+^y ^e ^h ^s ^r ^e ^h
+^u ^t ^i ^p
+^t ^f ^o ^s ^r ^i ^a
+^t ^a ^l ^o ^c ^o ^h ^c
+^s ^u ^t ^i ^t
+^s ^u ^r ^y ^c
+^s ^t ^g
+^s ^r ^e ^t ^e ^p
+^s ^o ^k ^i ^n
+^s ^i ^s ^e ^m ^e ^n
+^s ^d ^a ^d
+^r ^j ^m
+^r ^e ^v ^e ^t ^a ^h ^w
+^r ^e ^k ^c ^u ^f
+^p ^a ^b
+^o ^r ^e ^k
+^o ^m ^u ^s
+^o ^i ^c ^a ^n ^g ^i
+^o ^c ^i ^t
+^o ^c ^a ^m
+^n ^o ^r ^y ^b
+^n ^a ^n ^e ^r
+^l ^l ^i ^l
+^i ^m ^a ^k
+^g ^n ^i ^l ^l ^i ^k
+^e ^r ^d ^n ^a ^x ^e ^l ^a
+^e ^i ^l ^a ^t ^a ^n
+^e ^i ^k ^n ^a ^r ^f
+^e +3
+^c ^c ^c
+^a ^t ^i ^k ^i ^n
+^a ^n ^n ^a ^o ^j
+^a $1 $2
+^9 o59
+^8 ^2 ^2
+^7 o16 r
+^4 ^3 ^1
+^2 ^1 $3
+^2 $1
+^0 o10 r
+[ o0S
+[ -6
+[ +4 ^a
+Z2 .2
+E $G
+DA D5
+D6 o6g
+D6 o6c
+D5 *25
+D4 o5p
+D2 o3v
+D2 $0 $0 $9
+D1 o3j
+D1 o2m
+D1 D3 +3
+D1 -5
+-5 $t
+-2 o1x
+-2 i0m
+-1 K {
+-0 o4l
+-0 -7 -7
+-0 -5 -5
+-0 $1 $9
++7 u
++5 *32 *75
++4 -5 -6
++3 o0v
++2 *41
++0 -2 +4
++0 +0 +5
+*63 [ -3
+*43 $a
+*23 o1f
+'7 ^@
+$o Z2
+$o $2 $2
+$i D2
+$i $k $o
+$g $e $m
+$a $i
+$_ $0 $8
+$8 $5 $4
+$7 $7 $!
+$7 $4 $9
+$5 $7 $4
+$5 $5 $2
+$4 k
+$3 $9 $8
+$3 $8 $4
+$2 $7 $2 $7
+$2 $5 $1 $2
+$2 $2 $0 $4
+$2 $1 $0 $5
+$1 $7 $9
+$1 $2 $2 $0
+$0 $6 $0 $3
+$0 $5 $0 $2
+$0 $2 $1 $2
+$0 $1 $0 $6
+} x32
+u $! Y1
+t o3X
+sa) o0(
+o6C
+o5F
+o4n i6o
+o3o $1 $2 $3
+o3e $o
+o3U u
+o2u $a
+o2l $1 $2 $3 $4
+o2e $1 $2 $3
+o1y $1 $2
+o1o $i
+o1i $d
+o1e +8
+o0y $7
+o0x o1d
+o0x -1
+o0t o3u
+o0p o2u
+o0n o3i
+o0l $o
+o0j $3 $2 $1
+o0h $y
+o0W $1 $0
+o0V $1 $2 $3
+o0T $2 $0
+o0T $1 $5
+o0K $0 $5
+o0J $7
+o0H $2 $2
+o0D $0 $6
+k ^r
+i83 o94
+i7z
+i7r
+i73 i82
+i6_ $2
+i63 o70
+i62 i70 ,8 o97
+i5s i6t o8r
+i5s D1
+i5i i6k
+i5e i5f
+i5c i6a
+i59 i61 i71
+i53 o62
+i51 i69 ,7 o88
+i51 i62 o73 o84
+i4x ,5
+i4t i5i
+i4s o5k o6i
+i4s o5h
+i4r $1
+i4f i5o
+i4d ]
+i4a i5m
+i4a i5d o6a
+i4H D3 c
+i44 o53 i62 o71
+i43 o52
+i42 o55 o64
+i40 i50 o63
+i3t o4u
+i3l ]
+i3i o4k
+i3i o4c
+i3c o4e
+i3a o4g
+i3a i4t
+i38 i43 o51
+i33 i42 o56
+i31 i41 o53
+i31 i40 o57
+i2s D5
+i2r o3e
+i2m D5
+i2k o3a
+i2g i3e
+i2c i3a
+i2b o3a
+i2R E
+i26 *25
+i20 i30 o47
+i15 i55
+i15 i36
+c i5a
+c $9 $6 $2
+c $9 $3 $0
+c $9 $2 $5
+c $9 $1 $9
+c $9 $0 $1
+c $8 $4 $0
+c $7 $1 $2
+c $6 $7 $8
+c $6 $1 $8
+c $5 $4 $6
+c $4 $8 $8
+c $4 $0 $5
+c $3 $3 $1
+c $2 $@
+c $2 $1 $5
+c $1 $8 $6
+c $1 $4 $4
+c $0 $1 $3
+^y ^x ^e ^l ^a
+^y ^t ^f ^e ^l
+^y ^t ^e ^e ^w ^s
+^y ^t ^a ^c
+^y ^e ^s
+^s ^s ^a ^k
+^s ^e ^p ^o ^l
+^r ^e ^d ^n ^a ^x
+^o ^z ^n ^e ^r ^o ^l
+^o ^l ^l ^e ^m
+^o ^k ^r ^i ^m
+^o ^g ^i ^h ^c ^i
+^o ^a ^t
+^n ^a ^m ^r ^o ^n
+^n -1
+^m ^e ^j
+^l ^i ^r ^b ^a
+^k o2i
+^k ^r ^a ^p
+^k ^n ^a ^b
+^k D2 D3
+^h ^a ^l ^b
+^g ^a ^w ^s
+^f o2a
+^f ^a ^e ^l
+^e ^l ^t ^s ^a ^c
+^e ^g ^n ^a ^h ^c
+^d ^a ^e ^d ^n ^u
+^b ^o ^k ^a ^j
+^a ^r ^b ^e ^z
+^a ^n ^a ^u ^l
+^a ^l ^o ^c
+^a ^k D4
+^a ^i ^l ^i ^m ^e
+^a ^g ^e ^v
+^S $2
+^4 o54
+^4 o14 r
+^3 o19
+^3 o13 r
+^3 ^2 ^1 o81 i92 oA3
+^3 -5
+^$ ^$
+[ $7 $8 $9
+[ $0 $0 $1
+K o3d
+K ^s
+DA sgb
+D7 $5
+D5 o5o
+D5 *24
+D3 o4x
+D3 o3u
+D3 $3 $3 $3
+D3 $0 $0 $1
+D2 $3 $0 $0 $0
+D2 $0 $0 $1
+D1 o3l
+D1 o2s o3b
+D1 D2 o3k
+D1 *23
+D1 *13
+D1 $z
+D0 i3g
+-2 ^f
+-1 -4
+-0 $0 $6
++8 '9
++6 p4 $6
++6 p1 'A
++5 $t
++4 $t
++3 -5
++3 -2 -4
++3 $2 $4
++2 -5 -0
++0 -2 +0
++0 $8 $8
+*65 { {
+*65 o2t *24
+*51 +1
+*50 +2
+*30 ^3
+*23 -0
+*20 ^c
+*20 $5
+*15 *05 *5A
+'5 q
+$s $w $a $g
+$p Z2
+$p $y .7
+$l *53 *32
+$h $e $r
+$f $u $l
+$b $2
+$7 $6 $1
+$7 $4 $4
+$6 $5 $1
+$3 $9 $9
+$2 T4
+$2 $9 $0 $5
+$2 $8 $0 $3
+$2 $6 $0 $9
+$1 $0 $1 $4
+$0 *20
+$0 $9 $0 $6
+$0 $7 $0 $4
+$0 $2 $1
+$# $$
+t ,4
+so0 u sI1
+r o5x o3z
+o7u ]
+o3k $o
+o2t $1 $2 $3
+o2r $i
+o2o
+o2a o3o
+o1r ^H
+o1o +2
+o1o $u
+o0z o3e
+o0z o2y
+o0z i2e
+o0y o3i
+o0u *23
+o0t o4u
+o0t o3o
+o0t i3i
+o0p Y2
+o0o D3
+o0n i1n
+o0k ,3
+o0c $2 $0 $0 $1
+o0T D1
+o0T $0 $7
+o0T $0 $0
+o0R .2
+o0R -7
+o0P $1 $4
+o0K -4
+o0K $0 $2
+o0I
+o0G $3
+l +2 i2r
+i9e
+i91 c
+i75 Z1
+i6u -5
+i6t o7e
+i6m o7a
+i6l i7i
+i6k D4
+i5u ]
+i5s i6t i7a
+i5o o6l o7a
+i5o i6p
+i5i i6e
+i5i ]
+i5e o6t
+i5e ]
+i5b ]
+i56 i76
+i55 i66 i77 o88
+i50
+i4w o5i
+i4s o5i
+i4l D7
+i4k ]
+i4j i5o
+i44 i55 o66
+i44 i50
+i43 i55
+i43 +6
+i42 o50 ss0 $8
+i41 i55 ,6
+i40 ,5
+i3u o4l
+i3n c
+i3m o4i
+i3m ]
+i3k o4i
+i3j
+i3e i4t
+i3d i4e i5r
+i3b o4i
+i37 i42 o56
+i35 i49 ,5
+i35 i42 o58
+i34 i46 o55
+i34 i45 o57
+i34 i42 o58
+i33 i48 ,5
+i2z i3i
+i2u o3d
+i2l i3e
+i2c i3h i4i
+i1r D4
+i1h o2i
+i1h $1
+i1a o0H
+i0c ^i
+i0[ i6]
+c i6$
+c i53
+c ^6 ^2
+c $9 $0 $5
+c $9 $0 $2
+c $8 $7 $1
+c $6 $2 $8
+c $5 $2 $6
+c $5 $1 $5 $0
+c $5 $0 $7
+c $4 $2 $8
+c $. $0
+^y ^e ^v ^o ^l
+^y ^e ^j
+^t ^a ^k ^t ^i ^k
+^s ^t ^o ^o ^b
+^s ^n ^i ^t ^r ^a ^m
+^r ^r ^a ^c
+^r ^e ^t ^t ^i ^l ^g
+^o ^r ^t ^s ^e ^a ^m
+^o ^n ^u ^j
+^o ^l ^o ^b
+^o ^g ^i ^f
+^o ^d ^i ^m
+^o ^b ^m ^i ^b
+^n ^y ^l
+^n ^u ^k
+^n ^i ^v ^l ^a
+^n ^a ^t ^i ^t
+^n ^a ^s ^a ^h
+^n ^a ^i ^s ^s ^u ^r
+^m ^a ^h ^s
+^l ^w ^o
+^l ^k ^j
+^k ^r ^a ^p ^n ^i ^k ^n ^i ^l
+^k ^c ^i ^k
+^k $2
+^i ^t ^n ^a ^s
+^g ^n ^o ^r ^t ^s
+^f +1
+^e ^l ^p ^i ^r ^t
+^e ^i ^x ^i ^d
+^e ^i ^b ^b ^o ^r
+^e ^e ^s
+^e ^d ^i ^r
+^e ^R
+^a o5a
+^a ^t ^i ^l ^o ^l
+^a ^r ^i
+^a ^p ^u ^s
+^a +8
+^X D3
+^J u D3
+^@ D2
+^7 o19 r
+^7 ^6 ^5 ^4 ^3 ^2 ^1
+^4 ^2 $2 $4
+^3 o11 r
+^2 o11 r
+^0 ^0 ^7 r
+^0 Z1 }
+] i6s
+] $3
+[ *20 $1
+T1 T3
+K {
+K o4t
+E o6M
+E o4L
+E ^C
+E .5 K
+D9
+D6 $5
+D5 p4 o5u
+D5 o5i
+D5 K +2
+D4 o5c
+D3 o4t
+D3 o4q
+D3 Y2
+D3 -1 c
+D2 i49
+D2 $l
+D1 o4m
+D1 o2s -3
+D1 $1 $2 $5
+D1 $1 $2 $3
+.0 *13
+-1 -4 -4
++7 o0m
++5 -3 +2
++3 -2 +4
++3 +3 *10
++1 o3c
++1 i23
++1 -4 -4
++1 -3 +1
++1 $1
++0 +2 -3
++0 $2 $5
+*A7 -6 Y1
+*61 D6
+*61 *25
+*53 *12
+*50 +3 {
+*42 k ^3
+*34 +1
+*31 D4
+*24 o0k
+*23 *05
+*20 o44
+*10 o2h
+*05 *12
+'9 se2
+'6 $8
+$p $i $p
+$c $h $i
+$_ $5
+$; $)
+$8 $3 $8
+$8 $3 $5
+$7 $8 $1
+$7 $5 $8
+$7 $4 $1 $0
+$6 +0
+$5 $4 $9
+$5 $3 $4
+$4 $7 $4
+$3 $4 $4
+$2 $2 $0 $1
+$1 $9 $0 $0
+$1 $5 $1 $1
+$1 $1 $0 $1
+$1 $0 $0 $6
+$0 $8 $0 $5
+$0 $8 $0 $3
+$0 $6 $0 $5
+$0 $5 $1 $0
+$0 $5 $0 $9
+$0 $4 $0 $3
+x02 d
+t +3 ,2
+o6p $o
+o6D
+o5E
+o56
+o4d Y2
+o4a $z
+o41 i52 i63 i74 i85 i96 oA7
+o2y o5y
+o2s $1 $2 $3
+o1u $i
+o1t .0
+o1p
+o1g T0
+o1e $a
+o1a o3o
+o1a $i
+o0z $1 $0
+o0y D4
+o0r o3e
+o0p $0 $3
+o0o o1c
+o0k i2y
+o0k ,4
+o0e +1
+o0T $0 $3
+o0T $!
+o0R $1 $4
+o0R $0 $4
+o0O $1 $2
+o0L D6
+o0J $5
+o0J $3
+o0J $0 $6
+o0I .1
+o0E D6
+o0E $1 $3
+o0D $1 $6
+k ^r k
+i92 iA0
+i8t o9h
+i81 i90
+i7n o8e $s
+i7l o8i
+i7a o8l
+i6u *64
+i6o o7v
+i6l o7o
+i5r i5c
+i5o i6l o7a
+i53 i63 ,7
+i52 i63 i74
+i50 i61 o70
+i4s i5h
+i4o i5w
+i4n o0l
+i4a i5l o6a
+i4a i5l i6l
+i45 i56 o67
+i44 ,5 ,6
+i42 i59 o60
+i41 o59
+i3o o4f
+i3h o4e
+i3d o4r
+i3d i4o i5g
+i3d i4i
+i3a o4k
+i34 i41 o54
+i34 i41 ,5
+i33 i44 o56
+i32 ,6
+i31 i46 o53
+i31 i44 ,5
+i31 i43 o54
+i2v o3a
+i2u o3l
+i2t o3i
+i2s i3t i4a
+i2m i3a i4r
+i2l D5
+i2k ,3
+i2g i3a
+i2e o3d
+i2c i3h i4a
+i2a o3p
+i2a o3l
+i1o i2b
+i1h o2o
+i1a i2n i3d
+i17 .2
+i10 *14
+i0J i1a i2n
+i0C i1h
+c T5 i5.
+c '9 $0
+c '7 $9
+c $9 $6 $1
+c $9 $1 $3
+c $8 $8 $7
+c $8 $7 $4
+c $8 $0 $9
+c $7 $5 $4
+c $7 $3 $2
+c $6 $2 $4
+c $5 ^8
+c $5 $1 $8
+c $5 $1 $4
+c $4 $9 $2
+c $3 $2 $3
+c $2 $9 $1
+c $2 $9 $0
+c $1 $7 $5
+c $1 $4
+^y ^t ^t ^i ^k ^o ^l ^l ^e ^h
+^y ^t ^a ^t
+^y ^l ^l ^u ^b
+^y ^e ^b ^o
+^y ^d ^o ^b ^o ^n
+^x ^o ^f ^e ^r ^i ^f
+^w ^e ^r
+^w ^e ^k
+^u ^g ^n ^i ^p
+^t ^s ^e ^u ^q
+^t ^r ^e ^p ^u ^r
+^t ^r ^e ^b ^l ^i ^g
+^s ^s ^a ^k ^c ^i ^k
+^s ^k ^w ^a ^h
+^s ^k ^n ^a ^h ^t
+^s ^e ^s ^r ^o ^h
+^s +3
+^r ^e ^z ^a ^l
+^r ^e ^e ^h ^c
+^r ^e ^c ^n ^a ^d
+^r ^a ^e ^g
+^p ^r ^a ^h ^s
+^p ^i ^l ^l ^i ^h ^p
+^o ^t ^s ^i ^r ^c
+^o ^r ^o ^m
+^o ^l ^e ^i ^c
+^o ^h ^j
+^o ^g ^o ^p
+^n ^r ^e ^f
+^n ^o ^t ^l ^i ^m
+^n ^i ^m ^s ^a ^y
+^n ^e ^v ^e
+^n ^e ^p ^s ^a
+^l *05
+^k ^r ^a
+^j $s
+^i ^z ^a ^n
+^i ^a ^t
+^h ^c ^a ^e ^l ^b
+^g ^n ^o ^d
+^g ^f ^e ^d ^c ^b ^a
+^e ^w ^w
+^e ^u ^s ^o ^j
+^e ^g ^a ^v ^a ^s
+^e ^e ^r ^t
+^d ^l ^a ^n ^o ^d
+^d ^A
+^c ^e ^d
+^b +3
+^a i4a
+^a ^r ^k
+^a ^l ^k
+^a ^i ^v ^a ^l ^f
+^a ^i ^c ^r ^a ^g
+^a ^h ^a ^m ^a ^y
+^R D4
+^6 $1
+^4 o16 r
+^0 o15 r
+[ $5 $0 $0
+R3 E .4
+K o2z
+K o1i
+K .7 ,5
+E $$ Y1
+D6 o6l
+D5 ^A
+D2 o4c
+D2 o3b
+D2 $k
+D2 $6 $7 $8
+D2 $3 $4 $5
+D2 $1 $2 $3
+D1 o3x
+D1 o3t
+D1 i3g
+D1 D2 o3g
+D1 D2 $q
+D1 $0 $2
+-5 t
+-4 r
+-3 -5 -5
+-2 o0d
+-2 $3 [
+-1 i28
+-0 } iBN
+-0 o3x
+-0 -6
+-0 $2 $7
++6 K +4
++6 -3 -3
++5 o2v
++4 -3 +5
++3 -5 -4
++2 -4 +5
++1 i24
++0 -1 +3
+*98
+*42 +4
+*35 t
+*35 +1
+*30 { *35
+*30 i24
+*25 *40
+*20 +2
+*03 +1
+'9 *76
+$m $1 $2
+$l $o $u $i $s
+$l $o $p
+$k {
+$i $z $e
+$i $k $i
+$f $o $r $c $e
+$e ^a
+$e $3
+$d Z2
+$a *26
+$_ $2 $7
+$X $D
+$@ $2 $2
+$8 $8 $5
+$8 $5 $5
+$7 $9 $9
+$7 $8 $3
+$7 $6 $3
+$6 $5 $3
+$6 $5 $2
+$6 $4 $4
+$6 $4 $2
+$6 $3 $8
+$5 $7 $2
+$4 ^7
+$2 $8 $0 $8
+$2 $3 $0 $1
+$2 $1 $0 $3
+$1 *02
+$1 $8 $1 $2
+$1 $8 $1 $0
+$1 $5 $1 $2
+$1 $4 $1 $2
+$1 $1 $2 $4
+$0 $9 $0 $5
+$0 $9 $0 $4
+$0 $6 $1 $2
+$0 $3 $8
+$0 $3 $0
+} ,1
+o7r o8y
+o79 T5 $G
+o4w u
+o48 i58 i68 ,7
+o42 i57 i62 o77
+o3o $u
+o3c $1 $2 $3
+o2i $o
+o2i $e
+o2i $1 $2 $3 $4 $5
+o1y o5y
+o1y
+o1u $u
+o1o o6o
+o1o o6i
+o0z o4z
+o0y o1s
+o0y $1
+o0w o3w
+o0v i2r
+o0t $1 $2
+o0s o4i
+o0s o1j
+o0s $e
+o0s $0 $0
+o0r o2j
+o0p o4o
+o0p +7 *45
+o0n o3u
+o0n $0 $2
+o0k .3
+o0g $o
+o0a .1
+o0V $1 $0
+o0S $1 $2 $3 $4
+o0N y2 l
+o0J ,3
+o0J $2 $2
+o0D D6
+o0D $9
+k ^t D4
+i7d o8s
+i71 i82 i93
+i6t i7a
+i6m
+i6j o7o
+i6C
+i60 i71 i82
+i5t c
+i5m o6i o7a
+i5m *53
+i5d o6o
+i5b o6u
+i5b i6e i7r
+i5a i6g
+i57 -7
+i56 $4
+i52 o64
+i52 i60 i70 R8
+i52 i60 i70 ,8
+i50 i61 i70
+i4v o5a
+i4r i5i
+i4i i5n i6h
+i4i $1
+i4b
+i47 i58 o69
+i43 i50 ,6
+i42 i52 o63
+i40 i59 o60
+i3z i4e
+i3w o4a
+i3v o4o
+i3r o4e
+i3r
+i3k i4i
+i3d o4a
+i33 i44 o57
+i33 i44 ,5
+i33 i42 o55
+i32 i45 o54
+i31 i46 o55
+i30 o43
+i2r o3i
+i2m i3e
+i2k o3o
+i2g i3o
+i2f o3i
+i1o i2l
+i1g ,2
+i1f ,2
+i1c ^a
+i1a o2l
+i0s i1t i2a
+c o5F
+c o5@
+c $9 $3 $9
+c $8 $9 $6
+c $8 $6 $5
+c $7 $5 $9
+c $7 $2 $3
+c $7 $0 $9
+c $7 $0 $7
+c $6 $8 $8
+c $6 $5 $1
+c $6 $3 $2
+c $5 $6 $2
+c $5 $1 $6
+c $3 $7 $9
+c $3 $5 $1
+c $2 $7 $0
+c $2 $2 $6
+c $2 $2 $5
+c $1 $8 $4
+c $1 $3 $7
+c $1 $3 $1 $4
+c $1 $2 $7
+c $1 $0 $1 $1
+^y ^t ^t ^i ^m ^s
+^y ^s ^u ^s
+^y ^p ^m ^u ^r ^g
+^y ^n ^n ^e ^d
+^y ^n ^n ^a
+^t ^n ^a ^t ^u ^m
+^s ^t ^l ^o ^c
+^s ^o ^e ^l
+^s ^k ^c ^o ^r
+^s ^e ^s
+^s ^e ^b ^b ^o ^h
+^s ^c ^c
+^s ^a ^m ^t ^s ^i ^r ^h ^c
+^r ^e ^h ^s
+^r ^e ^d ^n ^e
+^r ^a ^l ^i ^p
+^p ^p ^i ^l ^i ^h ^p
+^o ^t ^i ^p
+^o ^s ^n ^o ^f ^l ^a
+^o ^r ^a ^m
+^o ^n ^o ^j
+^o ^n ^i ^p
+^o ^l ^e ^h
+^o ^j ^o ^r
+^o ^h ^c ^a ^m
+^o ^d ^l ^i ^d
+^n ^i ^h ^s
+^n ^i ^a ^l ^a
+^n ^e ^w ^g
+^n ^a ^t ^s ^i ^r ^t
+^l ^u ^h ^a ^r
+^l ^l ^a ^t
+^l ^a ^d
+^k ^u ^l
+^k ^l ^u ^h
+^k ^c ^i ^u ^q
+^k -2
+^j ^a ^r
+^i ^l ^o ^l
+^i ^i ^w
+^i ^e ^r
+^h ,1
+^g ^n ^a ^t ^s ^u ^m
+^e ^m ^k ^c ^u ^f
+^e ^k ^i ^b
+^b ^o
+^a ^t ^s ^o ^c
+^a ^t ^a ^g
+^a ^r ^d ^n ^a ^x ^e ^l ^a
+^a ^r ^d ^n ^a ^j ^e ^l ^a
+^a ^l ^e
+^a ^i ^d ^a ^n
+^a ^f ^i ^f
+^a ^b ^a
+^a $1 $4
+^R -1
+^8 o10 r
+^5 $3
+^1 o12 r
+^1 ^9 ^1
+[ i4i
+K y2 c
+K s!} ,3
+K o0p
+D7 $0
+D5 o6u
+D5 o5r
+D5 o5e
+D5 $t
+D5 $n
+D5 $0 $2
+D4 o5v
+D4 ^x
+D4 $3 $2 $1
+D3 o5m
+D2 $8 $9 $0
+D1 i3r
+D1 D3 o3j
+D1 $0 $0 $1
+-2 D1 $2
+-2 -2 -4
+-1 -5 -5
+-0 $9
++4 o0z
++3 +6 +6
++1 o2b
++1 ^l
++1 -5 +2
+*60 *71 K
+*54 [ *24
+*53 +2
+*51 r K
+*51 ]
+*51 -0
+*32 y4
+*30 o0p
+*20 y3
+*20 $2
+*04 +3
+*02 $8
+$l $i $e
+$k $1 $2 $3
+$g r
+$f $u $r $y
+$f $a $k $e
+$a $v $a
+$X Z2
+$@ $1 $0
+$8 $4 $6
+$7 D7
+$6 $9 $9 $6
+$6 $8 $1
+$5 Z1 *30
+$5 $5 $1
+$5 $0 $5 $0
+$4 $3 $2
+$3 $0 $1 $2
+$2 $8 $1 $2
+$2 $5 $0 $4
+$2 $4 $0 $5
+$2 $3 $0 $4
+$1 d ]
+$1 $9 $3 $6
+$1 $4 $1 $0
+$1 $3 $0 $8
+$1 $2 $1 $8
+$0 ^d
+$0 $9 $9
+$! $1 $2 $3
+} -0
+{ *15 R9
+oBa
+o4p $i
+o4i -5
+o3o +2 y2
+o3j $1 $2 $3
+o1o o4y
+o1c ^p
+o1a o3a ]
+o0w z1
+o0p o3e
+o0p Z1
+o0T $7
+o0T $2 $4
+o0R $2 $4
+o0K +4
+o0J o51
+o0J $0 $2
+o0E
+k y2 -4
+k ^v
+i90 iA0 iB1
+i88 ,5 $0
+i7v
+i7o o6y
+i6r -5
+i6r ,7
+i6q -9
+i6e
+i5v o6a
+i5u o4s
+i5s o6i
+i5p i6a
+i5h o6a
+i5h i6o
+i5f o6e
+i58 i78
+i58 i68 ,7
+i57 i67 ,7
+i55 Y2
+i53 Y2
+i4q o5u o6e
+i4i o5t
+i4i i5c
+i4h i5a i6n
+i4h
+i4g i5a
+i4d *42
+i4b o5o
+i4a o5p
+i4a i5d
+i4Z L9 E
+i3t i4i
+i3t @c
+i3q o4u o5i
+i3n o4i
+i3k ,4
+i3f i4a i5n
+i3d o4u
+i37 i42 o51
+i33 i43 o56
+i31 i40 o53
+i2t i3h i4e
+i2p D5
+i2m o3e
+i2l o3u
+i2i E +A
+i2e o3k
+i2c o3a
+i2L E
+i1l D4
+i1i i2n
+i1f o2e
+i1d ]
+i1d
+i12 i34
+c o4_
+c o4P
+c o3R
+c o2@
+c $9 $1 $7
+c $8 $7 $8
+c $8 $5 $0
+c $8 $1 $8
+c $8 $0 $2
+c $7 $6 $0
+c $7 $2 $6
+c $7 $1 $8
+c $6 $8 $9
+c $6 $0 $3
+c $6 $0 $2
+c $5 $5 $6
+c $5 $3 $1
+c $5 $0 $8
+c $4 $4 $1
+c $1 $8 $3
+c $1 $7 $0
+c $1 $4 $5
+^z ^n ^e ^r ^o ^l
+^y ^p ^p ^i ^h
+^y ^n ^o ^c
+^y ^l ^o ^l
+^y ^d ^n ^a ^k
+^w ^l ^a
+^t ^f ^a ^r ^k
+^s ^o ^r ^b
+^s ^n ^e ^v ^a ^r
+^r ^e ^k ^l ^a ^t ^s
+^r ^e ^d ^n ^a ^v
+^r ^e ^b ^a ^s
+^r ^a ^m ^a ^l
+^p ^u ^o ^s
+^p ^m ^a ^w ^s
+^o ^t ^s ^e ^n ^r ^e
+^o ^t ^i ^n ^e ^b
+^o ^r ^e ^i ^u ^q ^e ^t
+^o ^k ^c ^e ^g
+^o ^k ^a ^k
+^o ^i ^p ^r ^o ^c ^s
+^o ^i ^l ^e
+^o ^b ^m ^a ^l
+^n ^o ^n ^a ^c
+^n ^o ^i ^n ^u
+^n ^o ^h ^j
+^n ^o ^h
+^n ^i ^s ^s ^a ^s ^s ^a
+^m o1y i2s
+^m ^n ^m
+^l t
+^k ^i ^n ^i ^m ^o ^d
+^k ^c ^e ^b
+^i o3r
+^i ^s ^u ^s
+^i ^r ^s
+^i ^r ^o ^t
+^i ^r ^e ^m
+^i ^c ^e ^c
+^i ^c ^c ^u ^g
+^g ^o ^l
+^g ^l ^m
+^e ^k ^o ^c
+^e ^i ^n ^r ^e
+^e ^g ^d ^o ^d
+^e ,2
+^d ^e ^t
+^d ^a ^m ^h ^a
+^d $4
+^c $3
+^b ^a ^r ^c
+^a i2f
+^a ^z ^i ^u ^l
+^a ^t ^g
+^a ^r ^o ^r ^u ^a
+^a ^l ^e ^d
+^a ^l ^a ^b
+^a ^i ^d ^i ^l
+^a ^h ^o ^l ^a
+^a +1
+^W ]
+^T $7
+^S +3
+^9 ^0 T2
+^6 o56
+^6 o12 r
+^6 o11 r
+^3 o10 r
+^0 o13 r
+] o8s
+] i56
+[ ^n *53
+K ,2
+E D2 $5
+D5 o5s
+D4 o5x
+D4 o5k
+D4 i6d
+D4 i63
+D4 $p
+D4 $@
+D4 $1 $0 $1
+D3 D3 ]
+D3 $8 $8 $8
+D3 $1 $0 $1
+D1 o4v
+D1 o4c
+D1 o2k
+D1 o1j
+D1 i3m
+D1 $n
+-0 y2
+-0 o2l
+-0 -5 -3
+-0 -4 -5
+-0 +6
+-0 $4 $4
++7 -5 -5
++5 -7 -7
++5 -2
++5 $d
++3 *12
++1 o2k
++0 o2x
+*62 *53
+*60 } D4
+*54 -5 +2
+*53 o0z
+*30 o2r
+*21 o0w
+*21 o0m
+*20 i3i
+'7 o11 -6
+$o $a $t
+$m *86
+$m $o $d $e
+$l $i $p
+$h $e $n
+$a $r $a
+$a $m $a
+$a $j $a
+$a $a $r $o $n
+$a $2
+$_ $1 $9
+$9 -8
+$8 $7 $7
+$6 $7 $2
+$6 $3 $9
+$5 ^b
+$4 $5 $4 $5
+$3 $5 $7 $9
+$2 $8 $0 $9
+$2 $6 $1 $2
+$2 $6 $0 $4
+$2 $1 $8 $9
+$1 $5 $0 $9
+$1 $3 $0 $4
+$1 $1 $3 $8
+$0 $9 $3
+$0 $9 $2
+oBo
+o6p c
+o4z $z
+o4y L6
+o3o .4
+o3o +4
+o3o $2 $0 $0 $3
+o2y $1 $2 $3
+o2k $o
+o2k $i
+o2j
+o1n ^t
+o1b $1 $2 $3
+o0w ,2
+o0v $1 $2
+o0t i4r
+o0n i2t
+o0n $2 $2
+o0T $1 $8
+o0R D4
+o0R $9 $9
+o0N $4
+o0N $1 $3
+o0M o1A
+o0L $1 $1
+o0J $1 $8
+o0H ]
+l sab
+l ] $f
+l $a $l $l $y
+k i1h
+k +0
+i8r
+i88 i80
+i85
+i80 i93
+i7w
+i7i o8a
+i7h T0
+i7c L8
+i71 i70
+i70 o83
+i6a i7d o8o
+i62 ]
+i61 $9 *67
+i5n i6o i7v
+i5m i6i
+i5k D2
+i5i o6a
+i5i i6m
+i5c i6h
+i5a i7d
+i59 ,6
+i4w o5o
+i4w D6
+i4v i5i
+i4s -5
+i4r -2
+i4k o5e
+i4i '8
+i4h K
+i4a i5n o6a
+i4a i5g o6a
+i42 i52 o64
+i42 i51 o64
+i41 i58 o60
+i40 i50 o68
+i40 i50 o67
+i3u o4k
+i3e o4t
+i3c i4h i5i
+i3a i5d
+i3D c
+i36 i42 o56
+i35 i50
+i35 i44 o55
+i34 i48 o55
+i34 i45 o54
+i32 o49
+i32 i44 ,5
+i2s i3e i4p
+i2r o3c
+i2r ,3
+i2n o3o
+i2f o3a
+i2a i3l
+i1l o2u
+i1e i2d
+i1b i1a
+i0t i1e
+i0i $4
+i0f
+i0G ]
+i05
+i0/
+c o5c
+c i43
+c '7 $5
+c $9 $5 $8
+c $9 $2 $1
+c $8 $9 $7
+c $8 $5 $3
+c $8
+c $7 $5 $7
+c $7 $5 $6
+c $7 $2 $8
+c $7 $2 $1
+c $6 $8 $6
+c $6 $6 $9
+c $6 $6 $3
+c $6 $1 $5
+c $6 $0 $4
+c $5 $6 $4
+c $5 $2 $9
+c $2 $7 $5
+c $2 $2 $2
+c $1 $2 $8
+c $1 $2 $3 $!
+^y ^r ^a ^u ^r ^b ^e ^f
+^y ^n ^o ^m ^r ^a ^h
+^y ^n ^o ^m
+^y ^n ^a ^f
+^y ^e ^h ^y ^e ^h
+^y ^d ^a ^r ^g
+^s ^o ^t ^i ^l ^r ^a ^c
+^s ^i ^n ^a ^l ^a
+^s ^h ^s
+^s ^f ^l ^o ^w
+^p ^u ^p
+^p ^e ^j
+^o ^t ^a ^c
+^o ^n ^a ^j
+^o ^l ^l ^e ^j
+^o ^g ^a ^d
+^o ^d ^n ^a ^m
+^n ^u ^b
+^n ^i ^h ^p ^l ^o ^d
+^n ^a ^s ^s ^i ^n
+^n ^a ^e ^m
+^m ^e ^h
+^m ^e ^c
+^m ^a ^e ^r ^c ^s
+^l ^u ^d ^b ^a
+^l ^l ^e ^c
+^l ^i ^h
+^l ^e ^g ^n ^e
+^k ^n ^i
+^k ^l ^a
+^k ^d ^i
+^k ^a ^n ^a
+^i ^t ^a ^t
+^i ^n ^n ^a
+^i ^l ^i ^h ^c
+^i ^l ^i ^f
+^i ^e ^r ^d ^n ^a
+^i ^H
+^h ^p ^e ^t ^s
+^g ^n ^i ^h ^t ^o ^n
+^g ^n ^a ^b
+^g ^n
+^e ^i ^u ^o ^l
+^e ^i ^n
+^e ^i ^d ^d ^a ^m
+^e ^g ^d ^u ^f
+^d ^u ^p ^s
+^d ^i ^m
+^d ^a ^b ^g ^i ^b
+^c ^a ^s
+^a ^r ^t ^e ^p
+^a ^r ^o ^d ^n ^a ^p
+^a ^n ^o ^d
+^a ^m ^u
+^a ^l ^e ^b
+^a ^b ^b ^a
+^T o1H o2E
+^S $0 $1
+^P *13
+^7 o14 r
+^7 ^7 o27
+^6 o13 r
+^6 o10 r
+^4 o19 r
+^4 ^3 ^2 ^1 D7
+^3 $8
+^0 o14 r
+] ^e
+] ^c
+Y2 c T4
+K .1
+E i4t
+E -4 $1
+D7 *67
+D7 *23
+D6 o6i
+D6 k
+D6 -2
+D5 o51
+D4 o5t
+D4 *42 *32
+D3 o5p
+D2 o3t
+D2 o3l
+D2 o3d
+D2 o2k ]
+D2 *53
+D2 $@
+D1 o4d
+D1 o2t o3b
+D1 D3 +4
+D1 D2 +2
+D1 D1 D3
+D1 $3 $6 $0
+D1 $2 $0 $0 $0
+-3 -3 -5
+-2 -5 -3 -4
+-2 -2 -5
+-1 -6
+-0 $3
++6 ^d
++4 +4 +0
++2 +2 -4
++1 }
++0 -2 -1
+*62 *05
+*31 ^m
+*30 -0
+*30 +3
+*21 Z1 }
+*21 *54
+*03 *05
+*02 o3m
+*02 ^d *86
+*02 ^b
+'4 d [
+$t Z2
+$p $a $o
+$n $i $x
+$m *26
+$h $u $t
+$e $a $t
+$e $a $g $l $e
+$d $o $r
+$b $a $t
+$a +7
+$_ $0 $7
+$N T0
+$8 $5 $7
+$6 $7 $8 $9
+$6 $5 $5
+$5 ^e
+$5 $6 $8
+$4 $3 $9
+$2 ^j
+$2 $3 $0 $3
+$2 $3 $0 $2
+$2 $#
+$1 $7 $8 $9
+$1 $5 $9 $3 $5 $7
+$1 $2 $3 $5
+$0 $k
+$0 $4 $5
+$0 $4 $1 $2
+$0 $2 $1 $4
+o8x
+o7r $s
+o41 i52 ss3 $4 $5
+o4'
+o3y $y
+o3o $d
+o3X E *21
+o2p $1 $2 $3
+o2k i4p
+o1k $1 $2 $3
+o0s i3a
+o0r o2y
+o0p i4a
+o0p i2u
+o0p $9 $9
+o0o i1z
+o0i $1 $2 $3
+o0e -1
+o0T $1 $4
+o0S -2
+o0R $2 $0
+o0J o1C
+o0J $2 $0
+o0G T2
+o0F $2 $2
+o0C o1A
+l ] $m
+k ^k
+i7z ,8
+i7a i8r
+i6m i7o
+i6k o7i
+i6k D3
+i6i i7c
+i6a i7n
+i60 i70 ,8
+i5s i6o
+i5m i6a i7r
+i5k i6i i7n
+i5i i6l i7l
+i5e o6y
+i5e i6l i7l
+i5c '7
+i5a o6r o7i
+i5a o6n
+i50 i61 i71
+i50 ,6
+i5# o61
+i4t ]
+i4o o5k
+i4l *02
+i4i o5g
+i47 o50
+i47 i50 o67
+i44 i51
+i3v o4e
+i3u i4n
+i3t i4h
+i3r o4u
+i3n i4o
+i3h ]
+i3g o4o
+i3g o4a
+i3g i4u
+i3b i4i
+i3H l
+i38 i49 o50
+i34 i44 o55
+i2w o3e
+i2t i3e
+i2s i3t i4e
+i2s i3o
+i2r o3a
+i2n o3e
+i2m o3o
+i2i i3s
+i2c D8
+i1l i2e
+i1d o2u
+i0o i0J
+i0g i1r i2e
+c o6e
+c i56
+c $8 $4 $7
+c $8 $1 $5
+c $7 $9 $1
+c $7 $0 $2
+c $6 $6 $0
+c $5 $9 $0
+c $5 $8 $5
+c $4 $4 $4 $4
+c $4 $2 $9
+c $4 $1 $6
+c $3 $0 $7
+c $2 $5 $3
+c $2 $0 $2 $0
+^y ^t ^s ^i ^r ^k
+^y ^t ^i ^v ^a ^r ^g
+^y ^n ^e ^k
+^y ^d ^e ^n ^n ^e ^k
+^s ^o ^t ^a ^r ^k
+^s ^o ^k ^o ^k
+^s ^n ^o ^m ^e ^d
+^s ^m ^a ^i ^l ^l ^i ^w
+^s ^e ^y ^e ^r
+^s ^a ^r ^i ^e ^m ^l ^a ^p
+^r ^u ^e ^l ^f
+^r ^e ^n ^g ^a ^w
+^r ^e ^f ^r ^u ^s
+^o ^t ^s ^u ^g ^u ^a
+^o ^p ^m ^a ^c
+^o ^n ^a ^i ^r ^d ^a
+^o ^m ^e ^r
+^n ^o ^n ^a ^m
+^n ^i ^c
+^n ^i ^a ^t ^n ^u ^o ^m
+^n ^a ^r
+^m o3e
+^m ^u ^h
+^l ^r ^a ^e
+^l ^l ^i ^m
+^k z2
+^k ^l ^o ^f
+^i ^v ^e
+^i ^r ^n ^e ^h
+^i ^r ^c
+^i ^d ^r ^o ^j
+^h ^r
+^h ^g ^i ^e ^l
+^h ^c ^r ^a ^m
+^g ^n ^o ^b
+^f ^f ^i ^l ^c
+^e ^r ^e ^h
+^e ^d ^i ^v ^a ^d
+^d ^r ^a ^w ^o ^h
+^d ^r ^a ^c
+^d ^i ^l ^o ^s
+^d ^d ^a
+^c o2u
+^c ^m ^j
+^a ^v ^l ^i ^s
+^a ^t ^a ^n
+^a ^n ^i ^g ^e ^r
+^a ^m ^e
+^a ^l ^a ^o ^k
+^W -1
+^S -1
+^G T1
+^8 o11 r
+^7 o10 r
+^5 o14 r
+^3 *54
+^1 o13 r
+^1 ^1 ^9 ^0
+^0 ^0 ^2 o30
+[ i2_
+[ E y3
+[ -4 u
+[ $i
+[ $2 $1 $2
+[ $2 $0 $0 $0
+D6 $1 $1
+D5 ^e
+D4 o5g
+D4 $0 $3
+D3 o55
+D3 $5 $5 $5
+D3 $4 $5 $6
+D2 y2 *24
+D2 o5k
+D2 o4w
+D2 o3c
+D2 i4n
+D1 o4p
+D1 o4h
+D1 i3s
+D1 $0 $0 $7
+.0 *15
+-7 E $!
+-4 -6
+-4 *2A *51
+-2 *31
+-1 ^l
+-0 o3d
+-0 $1 $8
++5 -3 -4
++3 o5b
++3 -2 +5
++1 -0 -0
++1 +1 -4
++0 -4 -4
++0 -3 -2
++0 -2 -5
++0 $2 $9
+*87 sti
+*75 $7 [
+*53 i32
+*40 o4z
+*12 $2
+'6 *03
+$r $a $m $o $n
+$o $7 $7 $7
+$g $a $m $e $s
+$d *14 R8
+$d $e $v $i $l
+$b $r $a $i $n
+$a $r
+$a $n $i
+$_ $2
+$A [
+$@ $2
+$9 +8
+$8 o1i
+$7 -5
+$6 -2
+$6 $9 $7
+$5 *12
+$5 $5 $6 $6
+$3 i6@
+$2 $9 $1 $2
+$2 $6 $0 $6
+$2 $3 $3 $2
+$1 $9 $3 $8
+$1 $9 $2 $0
+$1 $4 $0 $6
+$1 $2 $1 $6
+$1 $2 $1 $5
+$1 $1 $2 $3
+$0 $8 $1 $1
+$0 $7 $0 $3
+$0 $7 $!
+$0 $4 $0 $1
+$0 $3 $0 $1
+$0 $2 $2
+$0 $1 $7
+} ]
+u o5U
+t i3U
+o6N
+o60 *1A
+o5a $r
+o5L
+o3T D4
+o2y .3
+o2u $o
+o2e -3
+o2b L5
+o26
+o1o $a
+o1a o3y
+o1a $a
+o0s o2i
+o0p o3o
+o0o o2g
+o0o i1w
+o0n i2o
+o0n $1 $2
+o0f i2h
+o0Z $0 $1
+o0W D2
+o0W $4
+o0T $3
+o0T $0 $4
+o0P +3
+o0J -2
+o0J $9 $9
+o0H D6
+o0H $1 $1
+o0E $2 $1
+o0B T4
+l i7l i8o o9v oAe
+i8c
+i88 i64
+i7g c
+i7d o8a
+i72 i80 i90
+i71 i80 o91
+i6r -8
+i6i o7a
+i68 ,7
+i5h i6i
+i5c o6h
+i5a o6p
+i52 i60 ss0 $6
+i52 i60 i70 o81
+i50 i69 i70 o89
+i50 i60 o74
+i4u ]
+i4s -0
+i4o o5s
+i4n o5a
+i4j i5a i6n
+i4h i5u
+i4g o5i
+i4e o5b
+i4a o5j
+i4a *30
+i48 i52 o68
+i45 i51
+i41 i55 o60
+i41 i55
+i3u o4c
+i3t i4h o5a
+i3s i4a
+i3r D6
+i3o i4u
+i3o i4l
+i3n o2n
+i3h +2
+i3e o4b
+i3a o4f
+i37 i48 o59
+i36 i41 o56
+i33 i41 o53
+i32 i42 o54
+i31 o48
+i30 o45
+i2t o3a
+i2k o3i
+i2k i3e
+i2g o3i
+i2d i3i
+i2c o3i
+i2a o3m
+i1u i2s
+i1r o2o
+i1j D4
+i1h ]
+i1a i2l
+c p3 '8
+c i7#
+c $8 $8 $9
+c $8 $4 $2
+c $8 $2 $1
+c $8 $0 $4
+c $7 $9 $3
+c $7 $0 $8
+c $6 $9 $0
+c $6 $3 $9
+c $5 $1 $9
+c $4 $7 $9
+c $3 $9 $0
+c $3 $2 $8
+c $3 $1 $5
+c $2 $1
+c $1 $9 $6
+c $1 $9 $5 $4
+c $1 $5 $8
+c $1 $3 $6
+c $1 $2 $5
+^y ^t ^s ^i ^r ^h ^c
+^y ^s ^s ^i ^s
+^y ^n ^n ^o ^d
+^y ^c ^a ^g ^e ^l
+^x ^z ^s ^a ^w ^q
+^w ^s ^a
+^w ^j ^c
+^t ^s ^e ^n ^r ^e
+^t ^e ^i ^v
+^t ^e ^g ^d ^i ^m
+^s ^k ^j
+^s ^i ^v ^a ^m
+^r ^o ^t ^s ^a ^p
+^r ^j ^a
+^r ^i ^a ^j
+^r ^e ^v ^o ^r
+^r ^e ^t ^s ^e ^l
+^p ^u ^t ^u ^h ^s
+^o ^t ^e ^v ^o ^l
+^o ^n ^a ^f ^e ^t ^s
+^o ^l ^a ^k
+^o ^j ^i ^h
+^o ^i ^c ^u ^l
+^o ^c ^n ^i ^c
+^n ^i ^t ^n ^e ^l ^a ^v
+^n *31
+^l ^a ^t
+^l ^a ^r ^o ^c
+^l ^a ^f
+^k ^l ^e
+^k ^c ^i ^l ^s
+^i ^u ^r
+^i ^l ^i ^m
+^h ^t ^e ^n ^n ^e ^k
+^f ^i ^l ^e
+^e ^u ^q ^i ^r ^n ^e
+^e ^r ^a
+^e ^n ^i ^d ^a ^n
+^e ^l ^e ^l
+^e ^l ^c
+^e ^k ^o ^p
+^d ^n ^o ^b
+^a ^z ^i ^l
+^a ^r ^o ^d
+^a ^n ^a ^h
+^a ^l ^i ^e ^l
+^a ^i ^l ^i ^c ^e ^c
+^a ^g ^g ^i ^n
+^a ^d ^l ^e ^z
+^a ^b ^e ^s
+^Z -1
+^G -1
+^5 o16 r
+^5 $9
+^2 o10 r
+^2 ^0 ^2
+^1 o10 r
+^0 o16 r
+^0 o12 r
+^0 ^0 o27
+[ +1 *31
+[ $r u
+[ $2 $1 $3
+[ $1 $0 $1
+Z1 i8v
+T0 i4S
+T0 T5 T6
+E ] $A
+D5 *46
+D4 o51
+D3 y2
+D3 D7
+D2 D3 D4
+D2 $1 $3 $5
+D2 $0 $9 $8
+D1 o2q ]
+D1 Y2
+D1 D3 D3
+D1 D2 -4
+-0 -7
+-0 $1 $5
++4 -3 -3
++3 o40
++1 i0h
+*75 [
+*64 -1 [
+*54 K +3
+*54 *20
+*50 -4
+*45 D0
+*43 ] *20
+*42 Z1 D1
+*35 *50 +5
+*35 *31
+*31 i44
+*30 D4
+*25 +5
+*20 o5x
+*20 o0v
+*20 o0m
+*15 +3
+*13 o0j
+*12 o3c
+'6 s\P o1f
+'6 $3
+'5 $3 L5
+$m $2
+$e $m $a
+$e $l $i $t $e
+$c $h $a
+$b $a $g
+$a $x
+$7 $9 $6
+$7 $8 $2
+$7 $7 $8 $8
+$6 $6 $6 $6 $6 $6
+$4 $5 $6 $7
+$4 $4 $9
+$4 $3 $8
+$3 $1 $4 $1
+$3 $1 $0 $5
+$2 $6 $0 $3
+$2 $5 $0 $3
+$2 $3 $0 $6
+$2 $2 $4 $4
+$1 *03
+$1 $3 $0 $9
+$1 $2 $8 $9
+$1 $2 $0 $3
+$0 $8 $0 $7
+$0 $8 $0 $1
+$0 $5 $0 $1
+$0 $2 $7
+$0 $1 $0 $7
+$# $7
+{ -0
+{ $i Y2
+t ] Z2
+o8q
+o7u o8k
+o4g Z2
+o49 i59 i69 ,7
+o43 i53 i63 ,7
+o3l o0R
+o32 i40 i50 o66
+o2z $1 $2 $3
+o2i Z2
+o2e $e
+o2d $1 $2 $3 $4
+o1a $u
+o13 y2
+o0v $0 $1
+o0t ,3
+o0s i2i
+o0p .2
+o0n o4i
+o0d ,2
+o0T T3
+o0R D3
+o0K *34
+o0K $2 $0
+o0J $2 $7
+o0J $0 $5
+l ] $h
+l '5
+i9i
+i94 s5d
+i81 i92 iA3
+i7o o6g
+i6m i7i
+i69 i79 ,8
+i64 ,7
+i62 i70
+i5v i6i
+i5u i6r
+i5o o6l
+i5n o6a
+i5m o6a o7i
+i5a o6u
+i5K E
+i57 i79
+i51 i63 o72
+i4v o5i
+i4p i5i
+i4l i5u
+i4g o5h
+i4e i5y
+i43 i54 o65
+i43 i52 i61
+i42 i56 o60
+i41 o52 $3
+i41 i53 o65
+i41 i52 o64
+i3o i4r
+i3n o4o
+i3m o4o
+i3l o4u
+i3l ,4
+i3g o4h
+i3d o4i
+i3c i4o
+i3c ]
+i3c T0
+i3b o4u
+i36 i42 o51
+i32 o45
+i31 o44
+i31 i42 o58
+i30 ss0 $7
+i2v o3i
+i2u ]
+i2t o3u
+i2t D4
+i2s k
+i2r D5
+i2h o3a
+i2g D5
+i2b
+i22 $4
+i1w sle
+i1k D4
+i1h D4
+i1e i2t
+i1e i2n
+i1a i2n i3g
+c $8 $9 $2
+c $8 $6 $0
+c $8 $5 $7
+c $8 $2 $4
+c $7 $8 $3
+c $7 $7 $6
+c $7 $3 $7
+c $7 $2 $7
+c $6 $9 $1
+c $6 $4 $4
+c $6 $3 $3
+c $4 $3 $0
+c $3 $8 $7
+c $3 $8 $5
+c $2 $6 $8
+c $2 $3 $9
+c $1 $4 $0
+c $1 $3 $5
+c $1 $1 $0 $9
+c $0 $0 $!
+^y ^t ^y ^t
+^y ^n ^n ^o ^r
+^y ^a ^r ^x
+^x ^e ^r ^t
+^x $1 $2 $3
+^w ^a ^c
+^w ^a ^b
+^t ^i ^m ^s
+^t ^e ^g ^d ^i ^r ^b
+^s ^y ^r ^c
+^s ^w ^o ^c
+^s ^o ^m ^o ^s
+^s ^m ^a ^j
+^s ^k ^c ^i ^n
+^s ^e ^v ^l ^a
+^s ^e ^k ^a ^j
+^s ^a ^l ^a
+^r ^o ^o ^l ^f
+^r ^l ^a
+^r ^e ^p ^a ^e ^r
+^r ^e ^m ^e
+^r ^e ^b ^m ^i ^t
+^o ^l ^o ^r
+^o ^k ^r ^a ^d
+^n o1u
+^n ^o ^s ^n ^h ^o ^j
+^n ^o ^s ^i ^r ^r ^a ^h
+^n ^o ^n ^n ^e ^l
+^n ^e ^w
+^m ^a ^h ^c
+^l ^o ^r ^t ^n ^o ^c
+^l ^i ^n
+^k ^c ^u ^s
+^k ^a ^b
+^i i4i
+^i ^s ^e ^d
+^i ^n ^i ^m ^e ^g
+^i ^m ^i ^j
+^g ^n ^i ^n ^r ^o ^m
+^g ^a ^f
+^f ^a ^r
+^e o2e
+^e ^p ^a
+^e ^k ^u ^s ^a ^s
+^e ^i ^b ^b ^e ^d
+^e ^f ^a ^s
+^e ^d ^i ^c ^i ^u ^s
+^e ^b ^a ^b
+^d ^i ^r ^t ^s ^a
+^d ^d ^o ^t
+^c o1h i2e
+^a o2a
+^a ^n ^n ^a ^i ^r ^b
+^a ^i ^l
+^a ^c ^i ^l ^e ^g ^n ^a
+^S ,4
+^S $5
+^9 o12 r
+^5 $4
+^3 o16 r
+^2 ^0 T2
+] ] ] $1 $2 $3
+[ i4o
+Z1 i76
+K ,8
+E o4J
+D6 o6u
+D6 o61
+D6 *35
+D4 o5l
+D4 -0
+D3 o4j
+D3 o4d
+D3 ^z
+D3 -0
+D2 i4p -0
+D2 $h
+D2 $2 $0 $1 $2
+D2 $1 $0 $0
+D1 o3r
+D1 o1p D3
+D1 D2 o2j
+D1 $$
+-4 k
+-3 D2 u
+-2 D0 *54
+-2 -5 -5
+-1 -2
+-0 -3
+-0 *40
+-0 $1 $4
+-0 $0 $5
++6 -2 -2
++6 -0 -0
++5 +6 -4
++5 *31
++4 i1l D3
++4 -6 -6
++3 -4 -4
++1 ^c
++1 D3 D4
++1 -4
++0 ^1
++0 -4 -3
++0 -2 +5
++0 -1
++0 *32
++0 $d
+*74 k $8
+*43 o21
+*43 *21
+*43 *01 }
+*35 o2m
+*34 $1
+*30 *43
+*25 o3m D4
+*24 *15
+*21 D3 *42
+*21 $3 *02
+*04 D5 D3
+*04 +4
+*02 $d
+'7 i29
+'7 $t
+'6 $0
+$m $e $t
+$m $e $l $o $n
+$j $e $s $s $e
+$g $y $m
+$g $i
+$d $o $t
+$b Z2
+$a $n $o
+$a $n $d
+$_ $2 $5
+$G c -0
+$8 *04
+$8 $7 $8 $7
+$8 $4 $7
+$8 $3 $6
+$8 $3 $4
+$7 $7 $2
+$7 $3 $5
+$6 $7 $4
+$5 Z3
+$5 $9 $9
+$4 *04
+$4 $9 $9
+$3 $0 $0 $5
+$2 i7_
+$2 $9 $0 $8
+$2 $6 $0 $8
+$2 $4 $0 $3
+$2 $1 $0 $2
+$1 $9 $2 $6
+$1 $0 $0 $2
+$0 $6 $0
+$0 $2 $1 $7
+$0 $1 $0 $8
+$0 $1 $0
+$# $5
+} i4i
+{ $7
+r o0H sD'
+o5t $t
+o5M ]
+o3z t
+o3p $o
+o3o $1 $2 $3 $4 $5
+o3a .4
+o3L D4
+o2o $i
+o2j $1 $2 $3
+o2i .1
+o1o $e
+o0z o5a
+o0y i3a
+o0y +2
+o0t *54
+o0r $0 $3
+o0p o3a
+o0p i3i
+o0n o5o
+o0d $i
+o0W $2
+o0S *12
+o0N $8 $8
+o0K i51 i62 o73
+o0K ]
+o0K $0
+o0J z2 D2
+o0J $9 $8
+o0J $7 $8
+o0D $1 $9
+o0C ,3
+i95
+i8a K
+i6n o7i
+i6h i7a i8n
+i6T c
+i5t o6u
+i5s -6
+i5n o6t
+i5g ]
+i5c i6h o7a
+i5b o6o
+i53 i73
+i53 i63 i73
+i4l ,5
+i4g i5u
+i41 i50 o61
+i3s o4u
+i3s ,4
+i3p i4i
+i3p *03
+i3o o4l
+i3m i4o
+i3l i4e
+i3j o4u
+i3j o4e
+i3j ]
+i3h i4a
+i3d o4o
+i3c o4a
+i3a o4t
+i35 i45 o54
+i34 i42 o55
+i34 i41 o55
+i32 i43 o57
+i31 i45 o59
+i31 i42 o53
+i31 i41 o56
+i2n i3o
+i2n i3e
+i2e ]
+i2e ,3
+i2c ,3
+i2c *30
+i1r i2e
+i1e o2g
+i1a i2m
+i0s i1h i2a
+i0e i2c
+c oA0
+c o2P
+c ^_ $_
+c ^8 ^0
+c ^1 ^2 ^3
+c $9 $5 $9
+c $9 $3 $6
+c $8 $1 $4
+c $7 $6 $2
+c $6 $8 $0
+c $6 $4 $5
+c $6 $3 $5
+c $6 $0 $1
+c $5 $8 $0
+c $5 $4 $1
+c $5 $0 $0 $0
+c $4 $7 $1 $1
+c $4 $7 $1
+c $3 $8 $4
+c $3 $5 $0
+c $3 $4 $7
+c $3 $3 $5
+c $3 $3 $4
+c $2 $8 $7
+c $2 $8 $6
+c $2 $5 $4
+c $2 $5 $2
+c $1 $8 $9
+c $1 $6 $7
+c $1 $5 $3
+c $1 $1 $2
+c $1 $0 $3 $0
+^z ^e ^v ^a ^h ^c
+^z ^e ^r ^a ^v ^l ^a
+^z ^a ^h ^s
+^y ^t ^u ^d ^f ^o ^l ^l ^a ^c
+^y ^t ^i ^u ^r ^f
+^y ^t ^i ^c ^n ^a ^m
+^y ^c ^n ^i ^u ^q
+^t ^t ^a
+^t ^h ^g ^i ^l ^n ^o ^o ^m
+^s ^u ^m ^i ^t ^p ^o
+^s ^t ^a ^p
+^s ^n ^e
+^s ^a ^i ^h ^t ^t ^a ^m
+^r ^o ^t ^k ^i ^v
+^r ^e ^z ^o ^d
+^r ^e ^k ^i
+^r ^e ^b ^o ^o ^g
+^p ^x ^e
+^o ^n ^a ^i ^c ^u ^l
+^o ^h ^c ^u ^l
+^o ^d ^n ^a ^l ^r ^o
+^o ^d ^n ^a
+^o ^d ^a ^r ^o ^l ^o ^c
+^n ^w ^a ^p ^s
+^n ^o ^l ^e ^m
+^n ^n ^i ^u ^q
+^n ^i ^k ^s
+^n D3
+^m o3i
+^m ^e ^l ^a ^s
+^l ^e ^d ^a
+^k *14
+^i o3i
+^i ^n ^e ^b
+^i ^f ^i ^f
+^i ^d ^a ^m
+^h ^t ^i ^d ^u ^j
+^h ^s ^u ^r
+^h ^p ^l ^a ^r
+^h ^a ^i ^a ^s ^i
+^g ^a ^d
+^e ^t ^a ^v ^i ^r ^p
+^e ^n ^n ^a ^o ^j
+^e ^n ^e ^g
+^e ^k ^a ^t
+^e ^i ^l ^y ^k
+^e ^d ^u ^j
+^b ^a ^j
+^a ^z ^i ^l ^e
+^a ^r ^o ^b ^e ^d
+^a ^n ^i ^d
+^a ^d ^o ^y
+^P ^J
+^I T1
+^5 *41
+[ {
+[ *23
+[ $9 $9 $9
+Y2 o0P
+E *24 $1
+D9 +9
+D6 +2
+D4 +6
+D3 r ^z
+D3 o5k
+D3 o4r
+D3 K
+D2 o3s
+D2 $2 $1 $3
+D2 $1 $1 $2
+D2 $0 $0 $7
+D1 o4k
+D1 D3
+D1 D2 $r
+D0 Y1 -4
+-5 $w
+-3 -7
+-0 -3 -3
+-0 -0 -3
+-0 $2 $4
++7 o5l
++7 +5
++5 $6
++4 +7 +4
++3 o1m
++2 -3 -3
++1 D3 D3
++1 -2 +1
++0 $4 $5
+*62 snd
+*53 -0
+*53 +5
+*50 *02
+*45 o0g
+*31 $r
+*24 o4k
+*20 c ,3
+*20 ^e
+*12 { $g
+'7 Y2
+'6 *21 u
+$o $k $u
+$l $u $c $k
+$j {
+$h $a $i
+$d $3
+$_ $0 $5
+$I c
+$8 $5 $3
+$6 +8
+$6 $9 $4
+$6 $4 $1
+$6 $3 $5
+$5 $6 $6
+$5 $5 $3
+$2 ^x '6
+$2 $5 $0 $2
+$2 $4 $0 $1
+$2 $1 $4 $2
+$2 $0 $9 $9
+$1 +7
+$1 $6 $1 $6
+$1 $5 $1 $0
+$1 $3 $0 $5
+$1 $2 $9 $0
+$0 $9 $0 $1
+$0 $6 $1 $1
+$0 $1 $0 $4
+} i1o }
+} *43
+{ '8 ^b
+saQ c
+o3z $9 $9
+o2u i3y
+o1l $2 $0 $0 $4
+o1i $o
+o1e $r
+o0y o2y
+o0y ]
+o0x i1p
+o0v .5
+o0s o5i
+o0r $1 $2
+o0k $2 $0 $0 $1
+o0j $i
+o0g .1
+o0b i2y
+o0V D3
+o0R D5
+o0R $1 $7
+o0P D6
+o0P ,3
+o0L i3s
+o0K $3 $3
+o0K $0 $4
+o0J $9 $0
+o0J $2 $5
+o0C $9
+o0A ]
+l $1 $0
+i85 $5
+i81 i94
+i80 i95
+i7o '9
+i7k
+i7d c
+i6w i7e i8r
+i6u o7l
+i6r o7y
+i6k
+i6i o7l
+i5x ,6
+i5p o6h
+i5h o6i
+i5L l
+i52 i60 i71 o82
+i51 ,6 .3
+i50 ,6 o71
+i4s o5o
+i4h i5e
+i4e o5p
+i4e i5l i6i
+i4c i5h o6i
+i4c +5
+i41 i54 o67
+i41 i52 o68
+i40 i51 o62
+i3v o4a
+i3t ]
+i3t +2
+i3s i4i
+i3l *02
+i3g i4e
+i3g i4a
+i3g ]
+i3d i4o
+i3c o4i
+i3c $1
+i3a ]
+i37 i47 ,5
+i37 i41 ,5
+i31 i44 o56
+i30 i40 o51
+i2u o3g
+i2u i3r
+i2r i3a
+i2p o3i
+i2m i3a
+i2i D5
+i2f i3a
+i2c o3h i4i
+i2b ,3
+i1u i2l
+i1o i2s i3h
+i1m D4
+i1j K
+i1i o2l
+i1i i2n i3d
+i1e o2d
+i1b D3
+i0H i1e i2l i3l i4o
+c o52
+c i33
+c ^a ^D
+c ^3 $4
+c $] ^[
+c $9 $2 $3
+c $8 $6 $7
+c $8 $2 $6
+c $8 $0 $1
+c $7 $4 $2
+c $7 $3 $4
+c $6 $9 $7
+c $5 $9 $7
+c $5 $9 $6
+c $5 $3 $7
+c $4 $8 $3
+c $4 $2 $4
+c $3 $9 $7
+c $3 $6 $1
+c $3 $5 $2
+c $3 $2 $9
+c $2 $8 $5
+c $2 $4 $3
+c $2 $3 $0
+c $2 $2 $8
+c $1 $9 $5 $7
+c $1 $9 $0
+c $1 $4 $8
+c $1 $1 $0 $4
+c $0 $1 $7
+^z ^a ^s
+^y ^t ^a ^m
+^y ^o ^b ^y ^b ^a ^b
+^y ^l ^l ^e ^h ^s
+^y ^h ^t ^a ^n
+^y ^e ^t ^e ^p
+^y ^e ^l ^n ^i ^f
+^y ^b ^b ^o ^r
+^y ^a ^d ^n ^o ^m
+^s ^t ^m
+^s ^s ^e ^m
+^s ^p ^u
+^s ^k ^c ^u ^d
+^s ^e ^a
+^r ^e ^s ^a ^r ^f
+^r ^e ^b ^m ^e ^t ^p ^e ^s
+^r ^a ^e ^y
+^p ^o ^n
+^o ^t ^i ^m
+^o ^l ^a ^v
+^o ^i ^l ^e ^h
+^n ^a ^n
+^n ^a ^i ^l ^i ^l
+^m ^t ^k
+^m ^i ^r ^a ^k
+^m ^a ^y
+^l ^o ^o ^h ^c ^s
+^l ^o ^m
+^l ^e ^c
+^j ^a ^b
+^i ^l ^a ^d
+^i ^b ^m ^a ^b
+^h ^t ^o ^o ^m ^s
+^h ^c ^u ^m
+^g ^n ^i ^s
+^g ^n ^i ^o ^g
+^g ^n ^a ^f
+^e ^z ^t ^a ^k
+^e ^i ^p ^p ^i ^h
+^e ^c ^i ^u ^j
+^d o3a *13
+^d ^o ^o ^h
+^d ^o ^o ^f
+^d ^n ^a ^l ^s ^i
+^d ^n ^a ^l ^o ^r
+^c ^a ^z
+^c ^a ^l
+^c +1
+^a o2e
+^a ^r ^r ^a ^t ^i ^u ^g
+^a ^r ^a ^i ^k
+^a ^n ^a ^l
+^a ^l ^o ^c ^a ^c ^o ^c
+^M
+^7 *65
+^2 ^3 ^1 o34
+^1 o11 r
+^0 ^1 ^0 o32 r
+[ $4 K
+[ $1 $5 $9
+[ $1 $1 $2
+K o3a -0
+D8 o7t
+D6 o6x
+D6 $9
+D5 o6a
+D5 $h
+D3 o4z
+D3 i61 i72 o83
+D3 *56 k
+D2 $e
+D1 o3c
+D1 o2l
+D1 D2 o2h
+D1 D2 -2
+D1 $9 $0 $0
+D1 $7 $8 $9
+D1 $1 $0 $0
+C [ i2B
+-5 *14
+-4 o28
+-3 o0z
+-0 -5 -1
+-0 -5
+-0 -2 -0
+-0 $2 $8
++6 +4
++5 *34 p4
++5 $v
++3 $0 $1
++2 +4 +2
++1 {
++1 +2 +1
++0 *31
++0 $5 $5
++0 $0 $7
+*64 +3
+*61 T0
+*50 *31
+*43 $3
+*42 r
+*36 -0 +4
+*21 -3
+*15 *23
+*02 o3j
+$y Z2
+$r Z2
+$p $a $w
+$o $1 $0
+$n *24
+$l $e $i
+$a $d $a
+$_ $4
+$_ $0 $6
+$X Z1
+$E [ c
+$7 $8 $7 $8
+$7 $4 $8
+$7 $3 $4
+$6 -5
+$4 $6 $1
+$3 $0 $0 $9
+$2 $9 $0 $6
+$2 $8 $0 $5
+$2 $0 $0
+$1 -7
+$1 $A
+$1 $8 $1 $8
+$1 $7 $1 $7
+$1 $0 $9 $1
+$0 $9 $1 $6
+$0 $6 $1
+$0 $6 $0 $4
+$0 $1 $8
+$( } o6)
+$# $4
+u ^C ^D
+o3R D4
+o3D D4
+o1u +2
+o1u $e
+o1o ,3
+o0y o4i
+o0v o3i
+o0t o5o
+o0s o3u
+o0r i2a
+o0n $1 $0
+o0j $o
+o0W D4
+o0V D5
+o0V D4
+o0N o51
+o0N $7
+o0M .2
+o0K D3 ]
+o0K $1 $7
+o0I D4
+o0H $0 $7
+o0F .2
+o0F -4
+o0D i68
+o0D ]
+o0B ,2
+k ^A
+iAU t y2
+i91 iA2 oB3
+i80 o94
+i7t o8h
+i7o ,6
+i7e i8s
+i6r i7a
+i6l ]
+i6c i7a
+i62 i70 o81 o92
+i5x D3
+i5u i6n
+i5t +6
+i5s *34
+i5p i6i
+i5g o6e
+i5a i6r i7d
+i51 o63 o72
+i4z o5i
+i4w i5a i6r
+i4s i5o i6n
+i4r ]
+i4k o5u
+i4k o5a o6i
+i4k i5u
+i4j *04
+i4f o5u
+i4e ]
+i4c o5i
+i4a o5v o6a
+i43 i52 o63
+i41 i51 ,6
+i3w o4i
+i3u i4r
+i3r i4a
+i3g o2i
+i3e R4 L4
+i3e $2
+i3a o4j
+i3a o2y p5
+i3a i4v o5i
+i39 i40 o59
+i35 i48 ,5
+i35 i45 o56
+i34 i45 o56
+i33 i43 o54
+i31 i47 o53
+i31 i43 o57
+i2w ]
+i2s i3i
+i2r o3o
+i2r o3b
+i2m i3a i4s
+i2j ]
+i2e o3f
+i2H c
+i1t ]
+i1o i2r i3d
+i1e i2g
+i1d D3
+i1c D4
+i1a o2u
+i1a i2n i3t
+c o5M
+c ^0 ^0
+c $9 $2 $2
+c $9 $1 $5
+c $8 $9 $8
+c $8 $7 $3
+c $8 $4 $5
+c $8 $3 $9
+c $8 $0 $7
+c $7 $9 $0
+c $7 $8 $1
+c $7 $4 $3
+c $7 $3 $0
+c $7 $1 $9
+c $6 $8 $5
+c $6 $4 $6
+c $6 $2 $3
+c $5 $8 $7
+c $5 $5 $0
+c $5 $4 $9
+c $5 $4 $5
+c $5 $4 $3
+c $5 $4 $0
+c $4 $4 $2
+c $4 $2 $1
+c $4 $1 $3
+c $4 $$
+c $3 $2 $7
+c $2 $1 $1 $2
+c $1 $?
+c $1 $9 $4 $5
+c $1 $6 $8
+c $1 $6 $3
+c $1 $5 $6
+c $1 $4 $9
+c $1 $4 $2
+c $1 $3 $4
+c $1 $0 $4
+c $0 $9 $5
+c $0 $5 $9
+c $0 $5 $1
+c $0 $2 $5
+^z ^e ^t ^r ^o ^c
+^y ^f ^f ^u ^r ^c ^s
+^y ^a ^r ^d
+^x ^s ^w
+^u ^t ^u ^t
+^u ^f ^u ^f
+^u ^d ^a ^r
+^s ^r ^e ^t ^s ^a ^m
+^s ^i ^l ^l ^i ^w
+^r ^e ^m ^l ^e
+^o ^r ^e ^j
+^o ^l ^l ^a ^g
+^o ^h ^c ^i ^b
+^o ^g ^r ^i ^v
+^o ^c ^i ^r ^e ^d ^e ^f
+^n ^a ^m ^r ^e ^h
+^n ^a ^k ^a ^h
+^n ^a ^g
+^n D2
+^m ^i ^w ^s
+^m ^e ^m
+^m ^a ^t
+^m ^a ^e ^r ^c
+^l ^i ^a ^m ^e
+^l ^e ^x ^i ^p
+^k ^n ^a ^d
+^i o4a
+^i i2a
+^i ^s ^s ^e ^m
+^i ^m ^e ^s
+^i ^l ^l ^e
+^i ^h ^a ^n ^a
+^i ^h T2
+^g ^n ^a ^i ^l
+^g ^i ^m
+^e ^n ^a ^i ^d
+^e ^n ^a ^c
+^e ^l ^k ^c ^i ^p
+^e ^k ^a ^c
+^e ^e ^g
+^d o2r
+^d ^e ^l
+^c ^i ^t ^c ^r ^a
+^a o4i
+^a ^x
+^a ^n ^o ^l ^e ^c ^r ^a ^b
+^a ^n ^h ^s ^i ^r ^k
+^a ^m ^o ^l ^a ^p
+^a ^m ^m
+^a ^l ^s ^i
+^a ^l ^a ^k
+^a ^i ^f ^a ^m
+^a ^g ^o ^y
+^a ^f ^a ^t ^s ^u ^m
+^a ^b ^u ^c
+^S $1 $2
+^R +1
+^@ $1
+^4 ^3 ^3
+^1 ^0 ^2
+] *43 *40
+] $2
+[ $3 $3 $3
+K o1a
+K .2
+K $y
+E o3G
+D7 D9
+D6 o6z
+D5 *45
+D3 o5z
+D3 R3
+D2 o3k
+D2 i3v
+D2 $w
+D1 D2 o3j
+D1 +5
+D1 +3 ]
+D1 *54 +5
+D1 $4 $5 $6
+.0 o4t +0
+-4 -4 -5
+-3 {
+-2 -5
+-2 -3
+-1 [ -5
+-0 $0 $1
++7 Y2
++6 $5
++5 [ .3
++5 $4
++4 i03 C
++3 -4 +3
++3 *49 $m
++3 $1 $0
++1 +1 +5
++0 y1 *13
++0 -5 -5
++0 -1 +2
++0 $7 $7
++0 $4 $4
+*60 *42 ss-
+*54 o3l
+*50 ,2
+*40 *54
+*32 *25
+*25 *24 *10
+*21 +4 l
+*02 o3a
+'8 Y2
+$n $1 $0
+$l $o $k $i
+$l $a $y $e $r
+$k $i $n $g $s
+$g $a $s
+$f $l $a $s $h
+$e $g $o
+$e $c $o
+$b $r $i $a $n
+$b $o $o $k
+$a $y $a
+$_ $8
+$7 o84
+$7 +1
+$5 ^j
+$4 $8 $1
+$4 $6 $3
+$2 *30
+$2 $8 $0 $7
+$2 $7 $0 $8
+$2 $6 $2 $6
+$1 $9 $2 $7
+$1 $9 $0 $4
+$1 $2 $1 $9
+$1 $2 $0 $0
+$0 $7 $1 $2
+$0 $4 $0
+$0 $1 $9
+$) i7(
+$# $9
+{ $i
+sec y2 scp
+o9v oAe
+o7j ]
+o7Z c
+o7D
+o5B
+o50
+o3v $1 $2 $3
+o3O l
+o1j $1 $2 $3
+o0y o1g
+o0y i2r
+o0v o4a
+o0v $0 $2
+o0t y2
+o0t i4a
+o0q o1s
+o0p $a
+o0n o3o
+o0n $9 $9
+o0k $1 $2 $3 $4
+o0W D5
+o0R $7
+o0R $3
+o0R $1 $6
+o0P $1 $5
+o0N o61
+o0N
+o0M ,2
+o0L .2
+o0K *12
+o0D $1 $1
+k i1s
+k ^M
+i9a
+i7o sis
+i78 i50
+i6t i7e
+i6o o7l
+i6n i7e
+i6l ,7
+i6c i7o
+i6_ D2
+i6$
+i5q o6u
+i5l +6
+i5k o6u
+i5k o6e
+i5k Z1
+i5g o6i
+i5c *25
+i59 i60 i70
+i51 i64 o73
+i51 ,6 o72
+i4y ]
+i4v i5e
+i4v *42
+i4u o5l
+i4o o5b
+i4n i5g
+i4m i5o i6n
+i4h -0
+i4f i5i
+i4c i5i
+i4c *56
+i4a i5k o6i
+i45 i50
+i3q
+i3p i4o
+i3o o4t
+i3n o4a
+i3n
+i3i i4n i5h
+i3h o4o
+i3d .2
+i3c i4a
+i3M l
+i34 i45 ,5
+i34 i41 o53
+i32 i42 o55
+i31 i46 o58
+i2v ]
+i2u D5
+i2s o3e
+i2r i3d
+i2r ]
+i2o o3r
+i2n D5
+i2k i3u
+i2j i3a
+i2f i3f
+i2c o3e
+i2c i3k
+i2b ]
+i23 i34 o45
+i23 i32 o41
+i1v o2a
+i1o i2r
+i1o i2l i3d
+i1E E
+c oA2
+c o7e
+c o5.
+c *65 o65
+c '7 $4
+c $8 $6 $4
+c $8 $6 $2
+c $8 $5 $5
+c $7 $9 $8
+c $6 $5 $2
+c $6 $2 $7
+c $5 $9 $1
+c $5 $8 $2
+c $5 $6 $7
+c $4 $9 $7
+c $4 $3 $7
+c $4 $3 $6
+c $3 $8 $1
+c $2 $5 $7
+c $2 $5 $5
+c $2 $5 $1
+c $2 $4 $5
+c $2 $0 $7
+c $1 $6 $9
+c $1 $2 $3 $.
+c $0 $6 $9
+^z ^e ^u ^g ^i ^r ^d ^o ^r
+^y ^s ^o ^j
+^y ^r ^o ^k
+^y ^e ^l ^d ^u ^d
+^w ^a ^l ^c
+^t ^s ^e ^r
+^t ^o ^i ^l ^e
+^t ^n ^i ^u ^q
+^s ^i ^g ^e ^r
+^s ^a ^a
+^r ^o ^o ^n
+^r ^i ^a ^l ^c
+^r ^e ^k ^n ^i ^t
+^r ^a ^t ^s ^l ^l ^a
+^p ^c ^j
+^o ^x ^e ^s
+^o ^r ^o ^t
+^o ^r ^a ^t
+^o ^n ^e ^m
+^o ^m ^i ^r ^p
+^o ^l ^a ^z ^n ^o ^g
+^o ^h ^n ^i ^n ^u ^j
+^o ^c ^i ^r ^n ^e
+^n ^o ^t ^l ^o ^c
+^n ^o ^s ^d ^u ^h
+^n ^o ^s ^d ^e
+^n ^n ^a ^h ^o ^j
+^m o3u
+^m ^g ^m
+^m ^a ^h ^a ^r ^b ^a
+^l ^l ^e
+^l ^i ^a ^m ^t ^o ^h
+^k ^n ^i ^r ^d
+^k ^e ^e ^g
+^k ^c ^a ^r ^t
+^i i3a
+^i ^p ^a ^p
+^i ^j
+^i ^h ^t
+^i ^c ^r ^a ^m
+^i ^a ^s
+^h ^c ^e ^m
+^h *31
+^g ^r ^o ^e ^g
+^g ^o ^h
+^g ^n ^a ^l
+^f o2o
+^e ^m ^a ^d
+^e ^l ^i ^h ^c
+^e ^l ^a ^m
+^e ^h ^t T3
+^e $a
+^d ^o ^p
+^d ^n ^o ^m
+^d ^n ^e ^g ^e ^l
+^c ^y ^n
+^a i2a
+^a ^t ^n ^a ^f
+^a ^s ^a ^m
+^a ^l ^o ^c ^i ^n
+^a ^j o2y
+^a ^h ^c ^o ^m
+^M D2
+^G D4
+^7 o11 r
+^6 ^5 ^4 ^3 ^2 ^1 D8
+^5 *40
+^5 $2
+^0 ^9 ^3
+] .3 }
+[ $1 $2 $4
+T0 T7 T8
+L0 L1
+K o0G
+K i1a
+E y5
+E y3
+E o4B
+E o0z o2v
+D8 o7k
+D6 -7
+D6 +7
+D5 o6r
+D5 o5v
+D4 ^A
+D4 $g
+D3 ] ]
+D2 o3w
+D2 o3u
+D2 o3m
+D2 $2
+D1 o1j D2
+D1 D3 D4
+-4 $7
+-3 o1v
+-0 $0 $3
++6 +0
++6 $l
++3 ^b
++2 ^h
++2 +4
++1 o2g
++1 -2
++0 o2q
++0 -3 +0
++0 +4 -1
++0 +0 +3
++0 $1 $8
++0 $0 $8
+*86 '8
+*43 -2
+*40 i36
+*36 [ *05
+*32 o3x
+*30 -4
+*21 sfa i56
+*10 ^a
+'7 ^t sxt
+$s $u $b
+$o $g $o
+$o $1 $3
+$n $1 $2 $3
+$h *54
+$g $a $b
+$e $s $s
+$b *56
+$A u
+$9 +4
+$9 $3 $9 $3
+$8 s*h +2
+$7 $7 $4
+$6 ^s
+$5 +1
+$3 $4 $3 $4
+$3 $1 $0 $1
+$2 $9 $0 $4
+$2 $9 $0 $1
+$2 $8 $0 $2
+$2 $3 $2 $4
+$1 $9 $0 $1
+$1 $8 $0 $9
+$1 $7 $0 $8
+$1 $6 $1 $2
+$1 $6 $0 $8
+$1 $5 $0 $8
+$1 $1 $2 $6
+$0 -6
+$0 $9 $7
+$0 $8 $1
+$0 $7 $7
+$0 $7 $0 $6
+$0 $4 $1
+$0 $3 $9
+$# $0 $1
+} i0A
+y3 i3y
+siu t
+sS- $M $A $N
+r c r T0
+o7o $o
+o7n
+o7U c
+o5R
+o5M
+o52 -6
+o2o .3
+o2D D3
+o1a +2
+o0z $z
+o0y o3u
+o0y +7
+o0t i3a
+o0t i2i
+o0s o3o
+o0s i2a
+o0p ,1
+o0n $0 $4
+o0h $o
+o0T $2 $5
+o0K $9
+o0J $1 $6
+o0J $0 $3
+o0I D2
+o0G $1 $4
+o0E $2 $2
+o0D $0 $4
+o0B $1 $1
+o0A o1S
+l .1 i2b
+k i0C
+i92 ,A
+i8i i9t
+i8e i9r
+i84 i95
+i7r o8a
+i7d i7e
+i6t i7o
+i6s o7a
+i6s i7s
+i6o i7r
+i6o +7
+i6m .7
+i6h i7e
+i6a i7r i8d
+i5s ]
+i5o ,6
+i5k .4
+i5i i6d
+i5h i6a
+i5g o2m
+i5f o6i
+i5e o6l
+i5b i5b
+i51 i61 i72
+i51 i61 ,7
+i50 ,6 o77
+i4i i5m
+i4e i5t i6t
+i4e i5r i6s
+i4a i5l o6i
+i4a ]
+i46 i51 o69
+i45 i52
+i43 i53 o64
+i41 i52 o65
+i3u i4k
+i3e o4f
+i3e o4c
+i3e i4m
+i3B *03
+i39 i40 ,5
+i33 i42 o53
+i32 $0
+i2z o3i
+i2s i3s i4e
+i2n u
+i2m ]
+i2m ,3
+i2h D4
+i2e i3l
+i1w o2a
+i1u o2t
+i1r o3e
+i1q o2u
+i1m ,2
+i1i i2l
+i1a o2g
+i1a i2r
+i0S i1a
+i0K i1a
+i0A *31
+c o4K
+c o2L
+c i5g
+c i48
+c T2 i2_
+c 'A $1
+c $9 $3 $5
+c $8 $7 $5
+c $7 $9 $2
+c $7 $6 $9
+c $7 $5 $2
+c $7 $4 $4
+c $7 $0 $3
+c $6 $7 $9
+c $6 $0 $8
+c $5 $9 $5
+c $5 $9 $3
+c $5 $8 $9
+c $5 $5 $2
+c $4 $8 $7
+c $4 $6 $9
+c $4 $0 $6
+c $3 $8 $9
+c $3 $7 $5
+c $3 $4 $5
+c $1 ^9
+c $1 $9 $2
+c $1 $3 $!
+c $1 $2 $9
+c $1 $1 $9
+c $1 $1 $8
+c $1 $$
+c $0 $9 $3
+c $0 $3 $8
+^z ^n ^e ^k
+^y ^s ^g ^u ^b
+^y ^n ^i ^a ^r
+^y ^l ^l ^u ^s
+^y ^e ^r ^l ^e
+^y ^d ^o ^o ^m
+^y ^a ^l ^n ^i ^f
+^t ^r ^j
+^t ^a ^e ^h ^c
+^s ^y ^a ^j
+^s ^s ^o ^h
+^s ^o ^m ^e
+^s ^g ^o ^r ^f
+^s ^e ^v ^l ^o ^w
+^s ^a ^l ^a ^s
+^r ^o ^t ^s ^e ^n
+^r ^i ^m ^e
+^r ^i ^a ^h ^c
+^r ^e ^y ^a ^l ^p
+^r ^e ^p ^p ^o ^h ^c
+^r ^e ^m ^r ^a ^f
+^r ^e ^h ^c ^r ^a
+^r ^a ^c ^s ^a ^n
+^p ^m ^u ^p
+^o ^r ^t ^e ^i ^p
+^o ^r ^o
+^o ^o ^b ^m ^a ^b
+^o ^g ^i ^b
+^o ^d ^n ^i ^l
+^o ^c ^r ^a
+^o ^Y
+^n ^o ^t
+^n ^o ^s ^m ^a ^s
+^n ^l ^o ^c ^n ^i ^l
+^n ^i ^m ^a
+^n ^i ^e ^t ^s
+^n ^e ^s
+^n ^e ^r ^o ^l
+^n ^a ^i ^d
+^m i2g
+^m ^o ^r
+^m ^e ^r
+^m ^e ^h ^c
+^l o3o
+^l ^a ^m ^a ^j
+^l ^a ^e ^r ^e ^h ^t
+^k ^a ^k
+^j $1 $2
+^i ^u ^l
+^i ^r ^a ^h
+^i ^p ^i ^p
+^i ^m ^i ^k
+^i ^l ^l ^i ^l
+^i ^a ^b
+^h ^c ^t ^u ^d
+^h ^a ^i ^r ^a ^m
+^g ^a ^r ^d
+^e ^t ^n ^e ^c ^i ^v
+^e ^r ^o ^l
+^e ^i ^h ^c ^r ^a
+^d ^r ^o ^w ^s
+^b o2n
+^b ^m ^a
+^b ^j ^d
+^a ^y ^e ^r ^f
+^a ^n ^d
+^a ^l ^o ^i ^v
+^a ^i ^v ^i ^l
+^a ^i ^g ^r ^o ^e ^g
+^S $1 $0
+^O $1
+^4 ^8 ^9
+^3 ,3
+^1 i58
+^1 ^0 ^0 ^2 ]
+^0 ^3 T2
+^0 ^2 ^0 ^2
+] i59
+] ^# u
+] $4
+[ i2A u
+T0 $V
+K R3
+E ,6 -4
+D6 -6
+D5 ^x
+D4 o5s
+D4 i68
+D4 Y2
+D3 o4h
+D3 $1 $1 $1
+D2 $9 $0 $0
+D1 o2b ]
+D1 i2f
+D1 D2 +3
+D1 ,5
+-6 *20
+-4 $d
+-3 *24
+-2 +6
+-1 i0j
+-0 ,1
+-0 $2 $3
++9 o83
++8 -2 u
++4 o0t
++4 D3 i1l
++4 +6 +6
++4 $1 $2
++3 $1 $3
++2 -3 -5
++2 +6 +2
++1 [ -5
+*56 r
+*50
+*43 o1p
+*32 *13
+*30 .1
+*25 ^a
+*24 o2x
+*20 ^s
+*16 *05
+*14 o5k
+*10 *25
+*02 +5
+'8 *12
+$h *02
+$f $l $a $m $e
+$_ $6
+$_ $0 $0 $7
+$@ $1 $2 $3 $4
+$8 $6 $6
+$8 $5 $9
+$8 $5 $8 $5
+$8 $0 $0 $0
+$7 i67
+$7 $3 $8
+$6 o2r
+$5 o53
+$5 $9 $4
+$5 $9 $3
+$3 ^b
+$3 *32
+$2 ^e
+$2 $9 $0 $3
+$2 $8 $0 $4
+$2 $2 $3 $3
+$1 i2r
+$1 $9 $2 $8
+$1 $9 $0 $2
+$1 $6 $1 $0
+$1 $6 $0 $2
+$1 $4 $0 $4
+$1 $3 $0 $6
+$1 $2 $3 $1
+$1 $2 $3 $#
+$0 $8 $3
+$0 $7 $8
+$0 $7 $0 $2
+$0 $5 $4
+$0 $5 $2 $5
+$0 $3 $2 $5
+$0 $2 $2 $0
+$0 $1 $0 $3
+o8n $t
+o4_ $7
+o3i $y
+o2i +3
+o2e $a
+o1l $1 $2 $3
+o1e $z
+o1+
+o0z Z2
+o0y o2u
+o0y D5
+o0s $1 $2 $3
+o0p $1 $2
+o0n o4o
+o0n i2g
+o0T i3i
+o0R $1 $8
+o0R $0 $6
+o0M ,5
+o0M $1 $9
+o0K .3
+o0K $7 $8
+o0K $0 $7
+o0J o1M
+o0H T5
+o0G $1 $5
+o0D $2 $7
+k ] o0p
+i7x
+i7t o8e
+i7e i8t
+i7a ]
+i7N c
+i75
+i6n i7a
+i6g i7o
+i6a i7c i8k
+i5z ,6
+i5t ]
+i5s i6t
+i5p o6a
+i5o -4
+i5a i6m
+i5a i6k
+i5Y c
+i52 i60 ,7 o87
+i4t i5e i6r
+i4t ,5
+i4s ,5
+i4s *02
+i4r i5s
+i4o o5c
+i4k D2
+i4j o5i
+i4c ]
+i47 i58 i69
+i45 i52 o60
+i43 i52 o64
+i3z o4a
+i3v
+i3t o4i
+i3s o4a
+i3p o4o
+i3o u
+i3k i4o
+i3g o4i
+i3e ]
+i3a i4n
+i3a *04
+i39 i48 o57
+i32 i42 ,5
+i31 i51
+i31 i44 o57
+i31 i44 o55
+i31 i42 i53 i64
+i30 i41 o53
+i2t o3y
+i2r i3o
+i2p o3a
+i2o o3n
+i2n o3i
+i2n c
+i2h i3i
+i2e o3m
+i2b i3o
+i1u i2n
+i1t D3
+i1e i2r
+c i5c
+c ^8 ^8
+c ^4 ^0
+c T7 $!
+c '6 $1
+c $8 $8 $1
+c $8 $5 $1
+c $8 $3 $0
+c $7 $7 $0
+c $7 $6 $8
+c $7 $3 $9
+c $6 $8 $7
+c $6 $7 $1
+c $6 $0 $5
+c $5 $3 $9
+c $4 $6 $2
+c $4 $5 $3
+c $4 $4 $0
+c $4 $2 $3
+c $4 $1 $7
+c $3 $9 $6
+c $3 $8 $3
+c $3 $5 $9
+c $3 $4 $0
+c $2 $9 $2
+c $2 $8 $9
+c $2 $7 $7
+c $2 $6 $3
+c $2 $4 $9
+c $2 $3 $6
+c $1 $9 $5
+c $1 $8 $8
+c $1 $8 $5
+c $1 $3 $3
+c $1 $0 $2
+c $0 $3 $2
+c $0 $1 $0 $1
+^y o1y
+^y ^s ^i ^a ^m
+^y ^p ^s ^i ^r ^c
+^y ^n ^n ^a ^n
+^y ^k ^c ^a ^w
+^y ^h ^s ^o ^j
+^y ^e ^l ^r ^u ^h
+^y ^d ^i ^s ^s ^a ^c
+^y ^a ^r ^y ^a ^r
+^w ^o ^l ^l ^i ^p
+^u ^n ^a ^e ^k
+^t ^r ^e ^p ^x ^e
+^t ^i ^r ^a ^m
+^s ^s ^e ^n
+^s ^j ^t
+^s ^j ^j
+^s ^i ^m ^a ^s
+^s ^i ^h ^p ^m ^e ^m
+^s ^e ^m ^o ^g
+^r ^p ^s
+^r ^o ^t ^k ^o ^d
+^r ^e ^l ^y ^k
+^r ^e ^d ^n ^e ^b
+^p ^o ^h ^s
+^o ^y ^a
+^o ^s ^a
+^o ^k ^a ^p
+^n ^o ^i ^s ^u ^f
+^n ^i ^v ^l ^e ^k
+^n ^i ^l ^e
+^n ^i ^a ^p
+^n ^e ^r ^r ^a ^w
+^n ^a ^m ^d ^l ^o
+^m ^r ^a ^f
+^m ^o ^s
+^m ^e ^l
+^k ^n ^u ^j
+^k ^a ^l ^b
+^j o2a
+^i ^r ^h ^c
+^i ^m ^o ^d
+^h ^t ^a ^m
+^h ^c ^a
+^g o2o
+^g ^n ^i ^k ^i ^v
+^g ^m ^a
+^f ^f ^a
+^e ^s ^e
+^e ^p ^i ^p
+^e ^d ^a ^m
+^d ^r ^a ^r ^e ^g
+^d ^m ^a
+^d ^a ^u ^q
+^b ^b ^b
+^b ^a ^h
+^a o4e
+^a i3l
+^a ^n ^e ^l ^i ^m
+^a ^l ^i ^m ^a ^k
+^a ^l ^e ^c ^r ^a ^m
+^a ^i ^l ^e ^c
+^a ^i ^a ^m
+^a ^c ^r ^a ^b
+^S $1 $2 $3
+^D ^J
+^5 ^0 ^9 ^1
+^2 ^3 o21
+^2 ^0 ^0 ^1
+^1 ^3 $3 $1
+^1 ^1 ^0 ^1
+^0 o11 r
+[ i5u
+[ T0 o3K
+[ *04 y1
+[ $8 $9 $0
+T1 T2 T3 T4 T5 T6
+R4 Z2
+K o0F
+E i5r
+E i5m
+DA DA
+D6 $1 $2 $3
+D4 z1 }
+D4 o4o
+D4 +1
+D3 o4u
+D3 +2
+D3 $e $r
+D2 o3h
+D2 $3 $0 $0
+D1 o2h
+D1 D2 o2c
+D1 -2 ]
+D1 $@
+@e o7k
+.2 $1 $2 $3 $4
+-7 } }
+-2 ^e
+-0 K
+-0 -0 -5
+-0 $4
++7 -6 -6
++5 z1 D4
++5 -7 +5
++3 +3 +5
++2 +2 -3
++2 +0
++2 $6
++1 ^e
++0 -1 +0
+*A9 s05
+*82 E *41
+*63 l +6
+*54 { k
+*52 ,3
+*45 -4 $1
+*43 -0
+*42 t
+*42 *41
+*41 *34
+*36 D3 [
+*34 ] $m
+*30 ,2
+*25 Z1 [
+*23 *30 i03
+*21 i0m
+*21 *41 *23
+*05 +3
+*04 o41
+'8 o12
+$p $e $e
+$n $o $s $e
+$m $o $d
+$f $a $n $g
+$e $4
+$d $o $g $s
+$a $k $i
+$9 +3
+$9 $6 $9 $6
+$8 $3 $3
+$7 $4 $6
+$5 $s }
+$4 +2
+$2 -3
+$2 $6 $0 $5
+$2 $6 $0 $1
+$2 $5 $0 $6
+$1 $4 $0 $7
+$1 $1 $1 $3
+$0 $8 $0 $4
+$0 $8 $0 $2
+$0 $4 $2 $1
+$0 $3 $5
+$0 $0 $1
+$. $m
+} *32 ]
+u *3B $V
+p1 E
+o7J
+o6E
+o59
+o3o -4
+o3M D4
+o2v $1 $2 $3
+o2B D3
+o1r i2D c
+o1o o7o
+o0z i3a
+o0z $9 $9
+o0v i3a
+o0v $a
+o0o o1z
+o0n o2y
+o0k $e
+o0j $7 $7 $7
+o0a ] ^v
+o0S T4
+o0R $2 $2
+o0L T5
+o0K $1 $1
+o0I D5
+o0D $0 $3
+k i1e
+i81 i93
+i80 *97
+i7z o8a
+i7n o8e
+i6t o7a
+i6p ]
+i6o i7p
+i6i i7c i8k
+i6h i7a
+i5y i6o
+i5o i6t
+i5n ]
+i5m i6a ]
+i5h i6a i7n
+i5c o6i
+i55 i65 ,7
+i55 ]
+i51 i71
+i50 ,6 ,7
+i4o i5t
+i4o ,5
+i4k Z1
+i4i o5l
+i4i i5l
+i4f
+i4e $2
+i4a i5p
+i4a *52
+i49 i50 o69
+i40 i59 o68
+i3y o4a
+i3v o4i
+i3u i4t
+i3l k +3
+i3j o4o
+i3j i4a
+i3h D5
+i3g i4o
+i3e i4d
+i3_ *04
+i32 i45 ,5
+i31 o46
+i2t i3o
+i2r o3u
+i2n k
+i2c i3o
+i2a o3h
+i2a i3n
+i1o o2t
+i1a o2r
+d o0r
+c o5_
+c $_
+c $9 $3 $8
+c $8 $9 $3
+c $8 $0 $6
+c $7 $4 $5
+c $7 $0 $0
+c $6 $9 $3
+c $6 $5 $3
+c $6 $4 $8
+c $6 $4 $3
+c $6 $3 $4
+c $6 $2 $9
+c $5 $8 $6
+c $5 $6 $0
+c $5 $2 $7
+c $5 $2 $2
+c $4 $7 $8
+c $4 $7 $5
+c $4 $3 $1
+c $3 $6 $8
+c $3 $3 $2
+c $2 $2 $9
+c $1 $7 $1
+c $1 $6 $1
+c $1 $5 $0
+c $1 $2 $6
+c $1 $2 $3 $4
+c $1 $1 $5
+c $1 $1 $2 $2
+c $1 $0 $7
+c $0 $8 $6
+c $0 $3 $6
+^{ $}
+^y ^t ^e ^l
+^y ^e ^d ^i ^p ^s
+^y ^d ^r ^i ^b
+^y ^d ^a ^m
+^y ^c ^r ^a ^m
+^x ^i ^r ^t
+^u ^z ^u ^z
+^u ^o ^i ^e ^a
+^t ^n ^u ^t ^s
+^t ^a ^c ^t ^a ^f
+^s ^w ^a ^j
+^s ^w ^a
+^s ^s ^s
+^s ^o ^l ^r ^a ^k
+^s ^l ^o ^o ^c
+^s ^e ^y ^a ^h
+^s ^e ^i ^k ^o ^o ^c
+^r ^r ^a ^b
+^r ^i ^m ^a ^s
+^r ^e ^t ^r ^o ^p
+^r ^e ^t ^i ^p
+^r ^e ^m ^m ^u ^h
+^r ^e ^h ^t ^n ^a ^p
+^r ^J
+^p ^o ^b
+^p ^j ^c
+^p ^a ^o ^s
+^o ^t ^o ^s
+^o ^t ^i ^n ^a ^u ^j
+^o ^m ^i ^l
+^o ^d ^e ^p
+^n ^o ^b ^r ^a ^c
+^n ^i ^t ^s ^u ^g ^a
+^n ^e ^v
+^n ^a ^m ^n ^o ^r ^i
+^n *03
+^m ^o ^n ^e ^v
+^m ^j ^m
+^l ^o ^o ^f
+^l ^l ^e ^s ^s ^u ^r
+^l ^l ^a ^h ^s ^r ^a ^m
+^k ^c ^o ^l
+^i ^r ^k
+^i ^r ^d
+^g ^i ^d
+^e ^t ^a ^r ^i ^p
+^e ^p ^i ^l ^i ^f
+^e ^n ^i ^f
+^e ^m ^o ^r ^e ^j
+^e ^l ^u ^j
+^e ^l ^p ^o ^e ^p
+^e ^i ^r ^r ^a ^c
+^d ^y ^o ^l ^l
+^c ^e ^b
+^b ^m ^a ^l
+^b +1
+^a o3a
+^a ^t ^u ^p
+^a ^m ^o
+^a ^l ^i ^e ^h ^s
+^a ^k ^s ^a ^l ^a
+^a ^i ^p
+^a ^i
+^a ^d ^i ^a
+^a ^c ^o ^b
+^T ^J
+^S $8
+^S $7
+^L ^E
+^I D4
+^E o1m
+^9 ^8 ^7 ^6 ^5 ^4 ^3 ^2 ^1 DA
+^8 o19 r
+^8 K
+^7 ^9 ^9
+^6 ^5 ^4 ^3 ^2 ^1 T6
+^4 o12 r
+^3 ^3 o23
+^3 ^2 ^1 ^3 ^2 ^1
+^3 *63
+^3 *50
+^0 ^9 ^0
+] -5 Y2
+T0 T1 T4
+E i2s ,3
+D8 D9
+D6 o6p
+D5 o5h
+D5 *65
+D5 $r
+D4 o5r
+D4 $r
+D4 $k
+D3 $u
+D2 u '4
+D2 o4l
+D2 o3g
+D2 D2 ]
+D1 o2y
+D1 D3 $1 $2 $3
+D1 -1 D3
+D0 i5r
+.0 .3 r
+-2 ^c
+-0 u
+-0 o2p
+-0 +2
+-0 $2 $1
+-0 $1 $0
++9 $0
++7 D4 +2
++7 D1
++7 -0 -0
++6 t K
++5 o6k
++5 *35
++2 .1
++1 o0r
++1 D2 D2
++1 .0
++1 +6 +6
++0 y4
++0 k y1
++0 -6 +0
++0 +3 -5
++0 +0 +2
+*58 D5 s13
+*51 *14
+*46 D1
+*43 +2
+*41 k {
+*40 } $8
+*35 D2
+*23 ^m
+*23 .1
+*06 D3 sMf
+*03 ^a
+*02 ^j
+*01 *34 K
+$m $i $l $l $s
+$l $o $v $e $s
+$h {
+$h $o $l $e
+$e $1 $2 $3
+$d $o $d $o
+$c $h $u
+$b $l $a $s $t
+$_ $2 $4
+$Q c
+$@ $1 $3
+$9 z1
+$9 *15
+$8 $4 $4
+$6 *05
+$5 -1
+$2 $8 $0 $6
+$2 $7 $0 $5
+$2 $0 $1 $6
+$1 o3c
+$1 o2u
+$1 $9 $1 $4
+$1 $4 $1 $5
+$1 $3 $4 $9
+$1 $2 $1 $7
+$1 $1 $2 $8
+$1 $1 $2 $7
+$1 $0 $8 $9
+$0 $9 $5
+$0 $8 $0
+$0 $5 $2
+} ,2
+{ ^f
+{ ^9
+oA[ s2d sdX
+o7p c
+o7C
+o4z Y2
+o4K
+o1i $z
+o1e $1 $2 $3 $4 $5 $6
+o1a o6o
+o1a o4y
+o0z i1u
+o0z $1 $2 $3
+o0y o5a
+o0y *32
+o0t i3e
+o0r o2i
+o0p '9
+o0p $1 $2 $3
+o0n $5 $5
+o0m ^S
+o0P ]
+o0P *23
+o0K +2
+o0J $1 $7
+o0J $1 $5
+o0G $9
+k o0E
+k ^n
+i81 i91
+i77 i87 ,9
+i70 i80
+i6v o7a
+i6a i7r i8i
+i62 o71
+i62 i70 ,8 o96
+i5w o6i
+i5u i6l
+i5r i6o
+i5o $7
+i5n +3
+i5m i6a i7y
+i5k i6e
+i5i D1
+i5a i6n i7g
+i5E c +6
+i52 i60 ss0 $5
+i52 ,6 o78
+i4t i5y
+i4r u
+i4o o5v
+i4o i5p
+i4m i5a i6r
+i4m i5a ]
+i48 i50 o68
+i43 i53 ,6
+i42 i55 o64
+i41 i54 o65
+i41 i50 o62
+i40 o59 i60 o75
+i40 i50 o62
+i40 ,5 o61
+i3z i4a
+i3s o5e
+i3o *20
+i3m i4a i5r
+i3k o4u
+i3i i4k
+i3e o4d
+i3e i3c
+i3d i4u
+i3C l
+i39 i49 ,5
+i2w o3d
+i2s i3s
+i2s i3k
+i2s i3a
+i2p [
+i2n o0w
+i2n i3t
+i2e i3t
+i1o i2d
+i1i i2k i3e
+i1e i2h
+i0v i1e
+c ssv *52
+c o4.
+c o3m
+c i4e
+c $9 $3 $2
+c $9 $2 $4
+c $9 $0 $8
+c $8 $7 $0
+c $8 $3 $2
+c $8 $2 $2
+c $7 $8 $4
+c $7 $4 $0
+c $7 $0 $5
+c $6 $5 $7
+c $6 $4 $7
+c $5 $4 $7
+c $4 $9 $1
+c $4 $8 $2
+c $3 $9 $8
+c $3 $7 $7
+c $3 $5 $5
+c $3 $5 $3
+c $3 $4 $2
+c $3 $3 $9
+c $2 $8 $8
+c $2 $7 $2
+c $2 $4 $8
+c $2 $2 $7
+c $2 $0 $3 $0
+c $1 $@
+c $1 $9 $5 $6
+c $1 $9 $5 $5
+c $1 $9 $1
+c $1 $7 $9
+c $1 $6 $0
+c $1 $5 $1
+c $1 $2 $1
+c $1 $1 $0 $3
+c $0 $5 $7
+c $0 $3 $9
+c $0 $1 $9
+c $0 $1 $0
+^y ^t ^t ^u ^n
+^y ^p ^p ^i ^h ^c
+^y ^n ^e ^d
+^y ^e ^n ^t ^i ^h ^w
+^y ^b ^o ^k
+^w ^a ^r ^t ^s
+^t ^o ^o ^h ^s
+^t ^n ^e ^m ^e ^l ^c
+^t ^n ^a ^y ^r ^b
+^s ^y ^e ^k
+^s ^u ^t ^n ^e ^v ^u ^j
+^s ^l ^l ^i ^m
+^s ^e ^v ^y
+^s ^e ^l ^e ^g ^n ^a
+^r ^u ^a ^s ^o ^n ^i ^d
+^r ^s ^a
+^r ^k ^s
+^r ^e ^t ^s
+^r ^e ^t ^i ^p ^u ^j
+^r ^a ^g ^u ^o ^c
+^p ^s ^m
+^p ^o ^o ^h
+^o ^s ^o ^s
+^o ^r ^a ^m ^a ^c
+^o ^m ^a ^r
+^o ^i ^k
+^o ^d ^i ^d
+^o ^c ^o ^m
+^n ^r ^o ^j ^b
+^n ^i ^v ^l ^e ^m
+^n ^i ^p ^s
+^m o1y i2c
+^l ^l ^e ^h ^c ^t ^i ^m
+^l ^i ^a ^m ^g
+^l ^e ^n
+^k ^i ^v
+^k ^a ^r ^u ^b
+^i ^t ^t ^a ^m
+^i ^e ^f
+^g ^n ^a ^t
+^e o3r
+^e ^y ^a ^f
+^e ^n ^i ^n
+^e ^i ^z ^z ^i ^l
+^e ^g ^a ^g
+^e ^g ^a
+^d ^r ^o ^w
+^d ^e ^w
+^d ^a ^e ^r ^d
+^b ^o ^m
+^b ^A
+^a ^r ^y ^k
+^a ^r ^e ^t ^n ^a ^p
+^a ^m ^m ^a ^g
+^a ^l ^i ^a ^l
+^a ^i ^a ^g
+^a ^d ^a ^n
+^a ^d ^a ^j
+^T $4 p4
+^S $4
+^Q +1
+^9 o15 r
+^7 r Z2
+^7 ^7 T2
+^5 o10 r
+^4 o11 r
+^4 o10 r
+^0 ^0 ^2 o33
+] i73
+] i40 $1
+K o5o
+K o4u
+K o0D
+K i4y
+E ,5 $2
+D6 o42
+D5 o6k
+D5 o6d
+D5 R4
+D3 t Z1
+D2 o3q
+D2 i3j
+D2 $2 $0 $0 $0
+D2 $1 $3 $2
+D1 o2s
+D1 i3p
+D1 i3d
+D1 D2 -3
+D1 $9 $9 $9
+-2 ^k
+-0 ^u
+-0 $e
++7 -1
++6 i7u
++5 ^6
++5 +7 +5
++4 -2
++3 +6 +3
++2 o4s
++2 ^r
++0 o3w
++0 ^g
++0 +5 -3
++0 +5 +3
+*31 $2
+*30 $5
+*25 -7 *23
+*20 o2n
+*20 -0
+*03 o3x
+*02 o3e
+*02 i3k
+'8 o34
+$e +0
+$e $a $r
+$e $1 $0
+$c $u $b $e
+$c $r $o $s $s
+$c $a $n $d $y
+$b $i $n
+$b $a $n
+$a $l $l $e $n
+$A $b
+$7 +2
+$7 $3 $3
+$6 $3 $4
+$5 $6 $8 $3
+$5 $4 $5 $4
+$5 $4 $4
+$5 $3 $3
+$3 $0 $0 $7
+$2 i37
+$2 +3
+$1 $9 $3 $5
+$1 $9 $2 $9
+$1 $8 $1 $1
+$1 $7 $0 $7
+$1 $5 $0 $6
+$1 $2 $4 $5
+$1 $2 $2 $6
+$1 $1 $2 $2 $3 $3
+$1 $0 $2 $0 $3 $0
+$0 ^8
+$0 $9 $6
+$0 $9 $2 $1
+$0 $9 $1 $7
+$0 $7 $2
+$0 $5 $5
+$0 $5 $2 $0
+$0 $4 $1 $1
+$$ $1
+$# $8
+} ^L
+o8v
+o5Z u
+o5L ]
+o2p $o
+o1u $a
+o1o $o
+o1i *61
+o1i $y
+o1i $r
+o0z i3e
+o0z $a
+o0y o5y
+o0y $3
+o0v o1y
+o0t K Z1
+o0q o3q
+o0n o5i
+o0a $2 $0 $0 $2
+o0V $4
+o0V $0 $8
+o0T T4
+o0S D6
+o0O $1 $2 $3
+o0M $1 $2 $3 $4
+o0K $2 $5
+o0K $1 $4
+o0K $0 $6
+o0H $0 $3
+l ] $n
+i8i o9a
+i82 i93 iA4
+i7r o8i
+i7n o8a
+i79 i89 i98
+i72
+i6i i7a o8n
+i6f s1s
+i6e i7r i8o
+i6b i7o
+i6a *63
+i65 o70
+i64 o70
+i5o o6v
+i5a i6t o7o
+i51 i73
+i4t +2
+i4t *04
+i4s +5
+i4q o5u
+i4p *40
+i4o i5k
+i4o $o
+i4a i5n ]
+i4a i5m o6i
+i4a i5a
+i41 i52 i63 i74
+i40 i51 o60
+i3z o4o
+i3u o4b
+i3t i4u
+i3p ,4
+i3o o4d
+i3f i4a
+i3f i3e
+i3f i3a
+i3e i1e
+i3a o4h
+i3a k
+i35 i43 o51
+i32 i44 o56
+i31 i45 o56
+i30 i41 o50
+i2s i3u
+i2p *43
+i2l i3o
+i2l i3l i4i
+i2k o3a ]
+i2e o3g
+i2a o3k
+i2a $1
+i1v
+i1p D3
+i1g D3
+i1e o2i
+i0u ^z
+c o4W
+c o2p
+c $Z
+c $9 $3 $3
+c $9 $1 $4
+c $9 $0 $6
+c $8 $8 $0
+c $8 $6 $8
+c $8 $2 $7
+c $7 $6 $7
+c $7 $1 $5
+c $6 $9 $8
+c $6 $9 $5
+c $6 $6 $2
+c $6 $3 $1
+c $5 $7 $8
+c $5 $3 $4
+c $4 $6 $4
+c $4 $5 $4
+c $3 $9 $5
+c $3 $6 $4
+c $3 $4 $8
+c $2 $2 $1 $0
+c $1 $6 $4
+c $1 $5 $4
+c $1 $1 $3
+c $1 $1 $0 $8
+c $1 $0 $6
+c $0 $7 $8
+c $0 $4 $9
+c $0 $2 $4
+^z ^x ^c ^v ^b ^n ^m
+^y ^r ^e
+^y ^m ^m ^a ^c
+^y ^k ^a ^e ^n ^s
+^y ^h ^s ^a
+^y ^e ^n ^o ^o ^r
+^x ^a ^m ^d ^a ^m
+^s ^t ^r ^a ^e ^h
+^s ^r ^e ^l ^l ^i ^k
+^s ^h ^j
+^s ^S
+^r ^u ^o ^n
+^r ^o ^d ^a ^v ^l ^a ^s
+^r ^e ^p ^r ^a ^h
+^r ^d ^m
+^p ^e ^k
+^o ^r ^r ^e ^p ^i ^m
+^o ^r ^a ^h
+^o ^l ^p
+^o ^l ^l ^e ^b
+^o ^d ^r ^a ^r ^e ^g
+^o ^c ^a ^l ^f
+^o ^a ^d
+^n ^u ^h ^c
+^n ^r ^o ^c ^i ^n ^u
+^n ^o ^t ^s ^u ^o ^h
+^n ^o ^t ^s ^a ^g
+^n ^o ^s ^r ^e ^m ^e
+^n ^o ^l
+^n ^i ^t
+^n ^i ^k ^p ^m ^u ^p
+^n ^a ^n ^r ^e ^h
+^n ^a ^m ^d ^a ^b
+^m ^u ^l ^a ^c
+^m ^o ^c ^l ^o ^v
+^m ^e ^l ^c
+^m ^a ^e ^t ^s
+^m ^M
+^l ^i ^m ^a ^c
+^l ^i ^d
+^l ^a ^t ^r ^o ^m ^m ^i
+^k ^e ^t
+^j ^D
+^i ^x ^e ^l ^a
+^i ^t ^a ^k
+^i ^i ^a ^w ^a ^k
+^i *02
+^f ^a ^d
+^e ^v ^a ^w
+^e ^m ^e ^v ^o ^l
+^e ^m ^e ^m
+^e ^m ^a
+^e ^k ^a ^c ^p ^u ^c
+^e ^d ^n ^o ^l ^b
+^e ^c ^r ^o ^f
+^d ^d ^i ^k
+^c }
+^c ^m ^c
+^c ^c ^a
+^b o2i
+^a o1y
+^a ^v ^a ^l
+^a ^r ^y ^a ^m
+^a ^l $a
+^a ^k ^i ^v
+^a ^j ^a
+^a ^h ^s ^a ^d
+^S .3
+^I D3
+^9 $0
+^3 ^0 ^9 ^1
+^2 o52
+[ i4y
+[ $2 $3 $4
+K o2y
+D6 o6s
+D4 s14
+D3 o51
+D3 o3o
+D2 i4s
+D2 $0 $0 $0
+D1 i3f
+D1 c $4
+D1 D2 o3r
+D1 $1 $9 $0 $7
+D1 $1 $0 $1 $0
+-6 i06
+-5 *50 K
+-3 i0s
+-2 $0 $1
+-0 o49
+-0 +7 *94
++8 $0
++7 Y1 $9
++4 -3 +4
++4 +6 +4
++3 -6 -6
++3 -5 -5
++3 -2
++3 +0
++3 $4
++2 +7
++1 ^b
++1 +0
++0 -5 +2
++0 -4 +0
++0 +5
++0 *05
++0 $3 $2
+*73 *84
+*56 *30
+*53 -5
+*52 o3k
+*45 *03
+*40 i0b
+*34 o0z
+*32 $1
+*30 -2
+*20 D5
+*14 ^f
+*01 ^0
+$y $2 $0 $0 $4
+$t $a $x
+$l $a $y
+$g $o $o
+$f $i $n
+$d -5
+$d $a $i $s $y
+$_ $x
+$_ $2 $0
+$@ $1 $1
+$8 $5 $2 $0
+$8 $5
+$7 z1
+$7 $3 $9
+$4 $7 $4 $7
+$4 $2 $0 $0
+$2 $9 $0 $7
+$2 $4 $0 $4
+$2 $4 $0 $2
+$2 $1 $2 $2
+$2 $1 $0 $0
+$1 o6l
+$1 $9 $2 $5
+$1 $9 $0 $6
+$1 $8 $9 $2
+$1 $6 $0 $5
+$1 $3 $3 $1
+$1 $2 $8 $8
+$1 $0 $9 $0
+$0 +5
+$0 $6 $5
+$0 $4 $9
+$0 $3 $2
+$0 $3 $1 $4
+$0 $2 $6
+$0 $1 $2 $0
+$# r
+$# +7
+} i3i
+u sI!
+o9t
+o9o K
+o8o
+o7o ]
+o66
+o4s ]
+o4_ i51 i62 o73
+o2y $a
+o2T D3
+o1u $z
+o0y o3o
+o0y $2
+o0v o3e
+o0r i3e
+o0q o4q
+o0p i3e
+o0T ]
+o0R -2
+o0Q $1
+o0N $3
+o0N $2 $2
+o0K $0 $3
+o0I D3
+o0G .2
+o0D ,5
+k ^s
+i8o
+i80 i90
+i7a
+i72 i80 i90 oA1
+i6s i7i
+i6s i7a
+i60 o71
+i5v o6i
+i5o o7i
+i5o ]
+i5k ]
+i5j o6o o7h
+i5i i6a i7n
+i5a i7a
+i5a +6
+i5_ u
+i59 L4 L5
+i55 i65 i75
+i53 $9
+i52 o60
+i52 $9
+i51 i70
+i51 i62 ,7
+i4p o5u
+i4o o5g
+i4n o5i
+i4k i5i i6n
+i4i o5o
+i4h i5i
+i4f o5o
+i4c o6a
+i4c o5u
+i4c i5h o6u
+i48 i50 ,6
+i42 o51
+i42 i51 o63
+i3s i4h
+i3r i4o
+i3p i4e
+i3o o4m o5a
+i3m i4y
+i3e o4z
+i3b i4u
+i3a o4w
+i32 i44 o55
+i31 i45 o53
+i2z i3a
+i2t i3i
+i2t i3a
+i2s o4a
+i2s i3h
+i2s ]
+i2p +4
+i2j o3i
+i2j
+i2g i3u
+i2g i3i
+i2f o3u
+i2a ]
+i1u i2r
+i1t
+i1i i2n i3g
+i1e i2n i3t
+i1e D5
+i1c ]
+i1a i2n
+i13 ^2 *73
+i0L i1i
+c o4F
+c i5K
+c i5B
+c $9 $3 $1
+c $8 $2 $3
+c $7 $7 $3
+c $7 $7 $1
+c $7 $6 $6
+c $7 $2 $2
+c $6 $8 $3
+c $6 $7 $2
+c $6 $6 $5
+c $6 $5 $8
+c $5 $3 $8
+c $5 $2 $8
+c $5 $0 $6
+c $4 $9 $0
+c $4 $8 $4
+c $4 $5 $8
+c $3 $9 $4
+c $3 $8 $8
+c $2 $9 $7
+c $2 $8 $0
+c $2 $7 $9
+c $2 $1 $3
+c $1 $9 $3
+c $1 $3 $9
+c $1 $3
+c $0 $9 $1
+c $0 $6 $5
+c $0 $2 $3
+c $0 $2 $2
+c $0 $0 $2
+^z ^e ^n ^e ^m ^i ^j
+^y ^v ^e
+^y ^t ^n ^e ^w ^t
+^y ^r ^d ^a
+^y ^m ^m ^a ^h
+^y ^l ^l ^o
+^y ^l ^l ^i ^h ^c
+^y ^g ^g ^u ^b
+^y ^f ^f ^a ^t
+^y ^e ^w ^e ^d
+^y ^e ^l ^k ^a ^o
+^y ^e ^k ^i ^p ^s
+^y ^a ^t ^y ^a ^t
+^s ^o ^p ^m ^a ^c
+^s ^i ^n ^o ^d ^a
+^s ^h ^k
+^s ^h ^h
+^s ^c ^b
+^s ^a ^m ^i ^d
+^o ^t ^a ^t
+^o ^r ^t ^e ^p
+^o ^i ^v ^l ^i ^s
+^o ^g ^n ^e ^t
+^n ^u ^g ^t ^o ^h ^s
+^n ^o ^s ^n ^e ^b
+^n ^o ^r ^b ^e ^l
+^m ^u ^r
+^m ^n ^b ^v ^c ^x ^z
+^m ^i ^a
+^m ^a ^e ^r ^c ^e ^c ^i
+^l ^u ^b ^n ^a ^t ^s ^i
+^l ^e ^u ^n ^a ^m ^e
+^l ^a ^j
+^k ^o ^o ^r ^b
+^i }
+^i ^x
+^i ^o ^k
+^i ^h ^p
+^i ^d ^u ^a ^l ^c
+^h ^c ^a ^m
+^h ^c ^a ^b
+^h ^a ^n ^o ^j
+^g ^n ^i ^l
+^e o4o
+^e ^r ^c
+^e ^p ^a ^r ^g
+^e ^l ^e ^h ^c ^i ^m
+^e ^i ^n ^n ^o ^r
+^e ^i ^d ^o ^j
+^e ^f ^i ^l ^y ^m
+^d ^n ^i ^l
+^d ^e ^j
+^d ^e ^f
+^c ^i ^n ^i ^m ^o ^d
+^a o5o
+^a o4o
+^a ^z ^i
+^a ^y ^n ^a ^t
+^a ^u ^l
+^a ^n ^o ^k
+^a ^m ^u ^p
+^a ^d ^a ^m
+^O o1b
+^M D4
+^M -1
+^I D5
+^I -1
+^8 o12 r
+^8 ^9 o27 r
+^1 i65
+^1 ^2 ^3 ]
+^0 ^0 ^2 o31
+[ -2 ^s
+[ $5 $5 $5
+[ $1 $9 $9 $8
+[ $1 $3 $2
+Z5 Y5
+T0 o4O
+E $t $h
+D9 DA
+D4 ] ]
+D4 $e $n
+D3 o5x
+D3 o5v
+D3 i51 +4
+D3 Z2 -A
+D3 $n
+D3 $0 $0 $0
+D2 o4m
+D2 o3z
+D2 $4 $5 $6
+D2 $3 $2 $1
+D2 $2 $0 $2
+D1 i3l
+D1 i2q
+D1 $6 $7 $8
+-3 -6
+-2 ^p
+-2 $a
+-0 o51
+-0 o3c
+-0 o2w
++9 'A
++8 +8 +8 +8
++3 ^p
++3 -5 +3
++3 +6
++3 +4 +4
++2 o0M
++2 $0 $9
++1 ^j ]
++1 ,3
++0 -6
++0 $3 $3
+*53 o5x
+*53 +4
+*52 .4
+*50 o3l
+*32 r
+*31 $1
+*30 D0
+*16 -0 l
+*15 *41 *43
+*02 o4z
+*01 i11
+'8 +6
+'7 +6
+$s $q $u $i $d
+$p $o $k $e
+$m $e $o $w
+$j $2
+$i *60 D2
+$g $r $a $y
+$e [ u
+$e $7
+$c $a $r $s
+$b $u $n
+$b $3
+$b $1 $2
+$a y2
+$a $s $e
+$a $k $o
+$a $g $o
+$9 *04
+$8 *23
+$7 $4 $7 $4
+$6 D6
+$6 +4 @k
+$5 $2 $5 $2
+$3 i3s
+$2 $7 $0 $4
+$1 $7 $0 $2
+$1 $2 $9 $2
+$1 $0 $7 $8
+$0 $9 $1
+$0 $7 $1 $3
+$0 $7 $0 $1
+$0 $6 $7
+$0 $6 $6
+$0 $6 $0 $1
+$0 $5 $!
+$0 $3 $3 $0
+$0 $2 $0 $1
+$0 $1 $6
+sax c
+o53
+o3i -4
+o3i +4
+o2x $1 $2
+o2r $o
+o1e $o
+o0y i3i
+o0t o3y
+o0t $a
+o0r i3a
+o0p o3i
+o0n i2a
+o0n *65
+o0n $a
+o0a $2 $0 $0 $4
+o0V $7
+o0T $1 $6
+o0R T5
+o0R $1 $5
+o0M $1 $0 $1
+o0J $2 $9
+o0G ]
+o0D o1A
+o0D .2
+k o0n *31
+i8c sie
+i83
+i81 $1
+i7i o8n
+i79 ,8
+i78 -A
+i6s i7e
+i6l o7e
+i6d i7o
+i6A
+i5y i6o i7u
+i5s i6h
+i5r i6i
+i5o i6n i7g
+i5l ]
+i5a o6n $a
+i59 i79
+i58 i68 i78
+i52 i72
+i52 i60 ss0 $4
+i50 i71
+i4v ]
+i4r D6
+i4o o0f
+i4o i5u
+i4c i5h o6a
+i4c -5
+i4Y E
+i4@ o51
+i45 i55 i65
+i44 i53 o62
+i43 i51
+i42 o50
+i42 i52 o60
+i40 i50 o69
+i40 -7
+i3z ]
+i3w i4a
+i3t i4e i5r
+i3s o4o
+i3n i4a
+i3l -0
+i3i o4m
+i3g i4i
+i3d i4e i5n
+i3d ,2
+i3a R2 L2
+i3a +2
+i3S l r
+i32 i49 ,5
+i32 ,5
+i31 i45 ,5
+i31 i44 o53
+i2x
+i2s o3o
+i2r o4a
+i2r o3y
+i2m i3i
+i2l D4
+i2i o3j
+i2h o3i
+i2g *30 s0(
+i2e i5e
+i2c i3h i4e
+i2a +6
+i1w D3
+i1q
+i1o i2s i3t
+i1o i2r i3t
+i1i D4
+i04 sea {
+d '8 c
+c o5H
+c o4N
+c i6b
+c ^3 ^3
+c '8 $2
+c $8 $8 $2
+c $8 $5 $8
+c $8 $5 $4
+c $8 $4 $3
+c $8 $2 $5
+c $8 $1 $3
+c $7 $9 $7
+c $7 $2 $4
+c $6 $9 $4
+c $6 $2 $1
+c $6 $1 $4
+c $5 $6 $9
+c $5 $3 $2
+c $3 $5 $8
+c $3 $3 $6
+c $3 $1 $2
+c $2 $8 $1
+c $2 $7 $1
+c $2 $6 $9
+c $2 $6 $6
+c $2 $0 $6
+c $1 $9 $5 $8
+c $0 $9 $7
+c $0 $8 $9
+c $0 $7 $0 $9
+c $0 $6 $7
+c $0 $5 $8
+c $0 $4 $7
+c $0 $4 $2
+c $0 $2 $7
+^z ^e ^e ^d
+^y ^t ^n ^a ^s
+^y ^r ^a ^d
+^y ^d ^w ^o ^r
+^y ^d ^u ^o ^l ^c
+^t ^k ^a
+^t ^e ^l ^l ^a ^b
+^t ^c ^e ^p ^s ^e ^r
+^s ^t ^n ^a ^i ^g
+^s ^s ^e
+^s ^r ^s
+^s ^o ^n ^a ^m
+^s ^n ^i ^v ^e ^k
+^s ^j ^k
+^r ^m ^e
+^r ^e ^z ^a
+^r ^e ^t ^t ^o
+^r ^e ^p ^s ^a ^k
+^r ^e ^d ^n ^a ^s
+^r ^e ^d ^i ^a ^r
+^r ^a ^p ^s ^a ^g
+^p ^i ^r ^c
+^p ^i ^j
+^o ^v ^e ^u ^n
+^o ^t ^i ^f
+^o ^t ^i
+^o ^n ^a ^i ^r ^a ^m
+^o ^d ^n ^a ^l
+^n ^u ^r ^a
+^n ^o ^t ^y ^e ^p
+^n ^o ^r ^a
+^n ^e ^d ^y ^a
+^m ^u ^g
+^m ^o ^o ^z
+^m ^o ^o ^r ^h ^s ^u ^m
+^l ^o ^o ^p
+^l ^e ^g ^i ^n
+^k ^c ^o ^r ^b
+^k ^c ^i ^h ^c
+^j o4g
+^i ^s ^i ^s
+^i ^l ^l ^i ^w
+^i ^f ^o ^s
+^i ^f ^a
+^i ^F
+^h ^u ^d
+^h ^a ^b
+^g ^p ^r
+^g ^e ^r
+^f ^e ^s ^o ^j
+^e ^v ^o ^l ^e ^w
+^e ^n ^o ^l
+^e ^m ^i ^d
+^e ^g ^a ^r
+^e ^d ^o ^m
+^d ^l ^o ^r ^a ^h
+^d ^a ^c
+^c o1u
+^b ^u ^b
+^b ^a ^s
+^a i2d
+^a ^y ^a ^k
+^a ^t ^i ^v
+^a ^l ^a ^c
+^a ^k ^i ^k
+^a ^k ^a ^m
+^a ^i ^g
+^a ^h ^s ^i ^m
+^a ^h ^s ^a ^m
+^a ^d ^n ^a ^m
+^a $i
+^_ ^e ^h ^t
+^C ^J
+^A D3
+^9 z2 D5
+^5 $1
+^3 ^9 ^9
+^2 ^3 o21 r
+^2 *40
+^1 sS2 i23
+[ $3 $2 $1
+E $E s7-
+D8 o8r
+D8 $0
+D6 o6j
+D6 o6h
+D6 -4
+D6 '9
+D5 o5n
+D4 o5n
+D3 o5t
+D3 o52
+D2 o5t
+D2 *46
+D2 $v
+D2 $7 $7 $7
+D2 $5 $6 $7
+D2 $1 $1 $1
+D1 o4j
+D1 D2 o3p
+D1 -3 D4
+D1 $5 $0 $0
+D1 $2 $0 $1 $2
+@s u
+-9 'A
+-6 r
+-4 *43 .2
+-4 *14
+-3 t
+-3 -4 -4
+-2 $1 $0
+-1 ^c +B
+-0 o52
+-0 $2 $2
+-0 $0
++9 $7
++7 -3
++5 o3p
++4 o3g
++3 +4 +5
++3 $1 $6
++0 -6 -6
++0 -6 -4
++0 +5 +5
++0 +3 +3
++0 +2 +2
++0 $1 $9
+*45 *53
+*43 t -5
+*42 $0
+*37 *46
+*35 ^c
+*31 o3p
+*31 o0r
+*30 o48 *17
+*30 $9
+*24 o4b
+*02 ,1
+'6 $5
+$y $a $p
+$s $h $y
+$n *15 *12
+$l Z2
+$i $s $a $a $c
+$h i6t *67
+$g $a
+$g $2
+$f $a $n
+$e $r $e
+$d $i $n $o
+$a $t $e
+$S $2
+$9 $1 $9 $1
+$8 -5
+$8 $4
+$7 o5_
+$6 -8
+$5 $6 $5 $6
+$3 +5
+$3 +2
+$3 *13
+$3 $4 $5 $6
+$3 $2 $1 $0
+$3 $0 $0 $1
+$2 [ c
+$2 $1 $1 $3
+$2 $0 $5 $0
+$1 $2 $8 $7
+$0 $9 $2 $8
+$0 $8 $0 $6
+$0 $7 $5
+$0 $5 $8
+$0 $5 $3
+$0 $2 $2 $8
+$0 $2 $1 $5
+{ k
+{ +4 y1
+{ *73 *64
+std
+s4w E
+o6J
+o4z $a
+o4o
+o4M
+o3y $e
+o2o i0C
+o2i -3
+o1/
+o0y i1g
+o0x .1
+o0v i3i
+o0p ,5
+o0o o2i
+o0n .2
+o0j -2
+o0i ^P
+o0Z T6
+o0Y D1
+o0X $1
+o0N D5
+o0N $8 $9
+o0N $0 $5
+o0K $1 $5
+o0A i1A
+o0A $A
+l $e $d
+k o3_
+iA# E
+i91 iA0
+i8S E
+i7a i8t
+i7a i8s
+i6y E
+i6u i7n
+i6t ]
+i6o ]
+i6n o7a
+i6l i7o
+i6b i7e i8r
+i6a -7
+i68 o70
+i5d ]
+i58 ,6 ,7
+i54 i63 i72 o81
+i52 i60 ,7 ,8
+i51 i60 i70 ,8
+i50 i62 i70
+i4z ,5
+i4y o5a
+i4o ]
+i4m ]
+i4h i5e i6r
+i4a o5w
+i42 ,5
+i41 i59 i67 o73
+i41 i55 o69
+i41 i53 ,6
+i4/ -1
+i3y i4o
+i3w ]
+i3v i4a
+i3t i4o i5n
+i3s i4o
+i3o o4p
+i3n D5
+i3m D2 o50
+i3m +0
+i3h i4o
+i3d i3a
+i3a i4g o5a
+i35 i45 ,5
+i35 i42 o50
+i33 i73
+i32 i40 i51 o60
+i31 i71
+i31 i40 ,5
+i2w
+i2o o3p
+i2n ]
+i2k i3a
+i2e o5e
+i2c ]
+i2a o3g
+i2a i3r
+i22 i30 i40 o52
+i1u i2m
+i1u i2c
+i1s D4
+i1s *13
+i1i i5i
+i1i i2d
+i1f i1e
+i1e o2u
+i1e i2b
+i1a i2r i3a
+i1a i2k i3e
+i0c
+c i59
+c i32
+c ^e ^D
+c $8 $8 $4
+c $8 $4 $6
+c $8 $4 $1
+c $8 $3 $8
+c $8 $3 $7
+c $7 $4 $8
+c $7 $3 $3
+c $6 $8 $4
+c $6 $6 $4
+c $6 $6 $1
+c $6 $5 $9
+c $6 $5 $6
+c $6 $4 $1
+c $6 $3 $7
+c $6 $1 $3
+c $5 $8 $8
+c $4 $9 $4
+c $4 $7 $2
+c $4 $6 $3
+c $4 $5 $0
+c $3 $9 $3
+c $3 $8 $2
+c $3 $7 $0
+c $3 $6 $6
+c $3 $0 $6
+c $2 $9 $6
+c $2 $6 $4
+c $2 $6 $2
+c $2 $6 $0
+c $2 $3 $7
+c $2 $3 $4 $5
+c $2 $2 $4
+c $1 $7 $6
+c $1 $6 $2
+c $1 $3 $8
+c $1 $2 $4
+c $1 $1 $4
+c $1 $1 $1 $1
+c $1 $1 $0 $5
+c $1 $0 $3
+c $0 $8 $3
+c $0 $3 $1
+c $0 $2 $1
+^z ^t ^a ^c
+^y ^t ^e ^e ^w ^t
+^y ^f ^f ^u ^p
+^y ^b ^b ^u ^b
+^s ^y ^o ^b ^w ^o ^c
+^s ^s ^o ^r ^c ^o ^t ^o ^m
+^s ^p ^a ^c
+^s ^m ^m
+^s ^k ^o ^o ^r ^b
+^s ^i ^x ^a ^m
+^s ^i ^h ^t ^a ^m
+^s ^g ^g ^e
+^s ^e ^l ^u ^c ^r ^e ^h
+^s ^d ^o ^o ^w
+^s ^J
+^r ^e ^g ^g ^i ^d
+^p ^e ^n ^y ^e ^z
+^o ^l ^u ^c
+^o ^k ^r
+^o ^i ^v
+^n ^w ^o ^r ^c
+^n ^r ^o ^h
+^n ^r ^e ^b
+^n ^i ^m ^r ^a
+^n ^e ^d ^l ^o ^h
+^n ^a ^u ^y
+^m ^r ^o ^w
+^m ^i ^z
+^l ^e ^v ^a ^p
+^l ^e ^d ^e
+^l ^e ^b ^a ^m
+^k ^n ^a ^l ^b
+^k ^c ^i ^r ^b
+^i ^u ^h
+^i ^s ^a ^k
+^i ^d ^u ^r
+^h ^s ^a ^d
+^g ^a ^r
+^e o4i
+^e o2i
+^e o1z
+^e ^y ^a
+^e ^r ^g ^i ^t
+^e ^n ^o ^g
+^e ^n ^a
+^e ^l ^l ^e ^b ^a ^s ^i
+^e ^i ^s ^o ^j
+^e ^g ^n ^a
+^e ^e ^n ^e ^r
+^e ^d ^y ^l ^c
+^e ^d ^a ^c
+^e ^c ^r ^a ^m
+^d ^s ^a ^w
+^d ^n ^a ^l ^g ^n ^e
+^d ^i ^r ^d ^a ^m
+^d ^e ^m ^a ^h ^o ^m
+^c $s
+^b ^u ^k ^a ^j
+^b ^e ^l ^a ^k
+^a ^y ]
+^a ^v ^e ^u ^n
+^a ^t ^i
+^a ^n ^n ^a ^w
+^a ^n ^a ^o ^j
+^a ^n ^a ^l ^a
+^a ^l ^l ^i ^m
+^a ^h ^a ^m
+^a ^d ^i ^r ^o ^l ^f
+^W +1
+^S $3
+^P +1
+^I $1
+^E D4
+^8 o58
+^5 ^6 o24 r
+^2 ^9 ^0
+^2 ^3 o23
+^2 .3
+^1 ^2 ^2 ^1
+] $a *64
+[ $1 $2 $0
+K ^b
+E $P
+D5 o6l
+D5 o6i
+D4 -7
+D4 $1 $1 $1
+D3 o5l
+D3 o4e
+D3 $2 $3 $4
+D2 i4a
+D2 ^B
+D2 ] ]
+D2 $y
+D1 D4 D4
+D1 *21
+D1 $2 $3 $4
+D1 $2 $3 $3
+D1 $0 $2 $0 $3
+C y1 i48
+.0 .4
+-7 '8
+-2 -4
+-1 Z1
+-1 .2
+-0 t .3
+-0 ^h
+-0 +3
+-0 $n
++7 +8 K
++7 *56 [
++4 *52
++3 +5
++3 $1 $5
++2 +5 +5
++1 o3q
++0 i4s
++0 +5 -4
+*74 +4
+*42 D3
+*24 +0
+*20 o5s
+*14 ^1
+*14 *31 *12
+*03 o40
+*02 -4 E
+*02 *57 sdl
+$y $2 $0 $0 $3
+$v Z2
+$o $1 $4
+$l *57
+$k *57
+$i $2
+$i $1 $2
+$h $i $p
+$h $e $y
+$e -6
+$e $n $e
+$a $p $e
+$a $p $a
+$_ $7 $8
+$K
+$@ $5
+$8 -7
+$8 $8 $9 $9
+$8 $6
+$7 $0 $0 $0
+$6 i39
+$5 +5
+$3 $1 $3 $1
+$3 $0 $0 $4
+$2 o6e
+$2 $5 $0 $7
+$2 $4 $2 $5
+$2 $1 $3 $4
+$1 o04
+$1 $8 $0 $8
+$1 $7 $1 $2
+$1 $7 $0 $6
+$1 $6 $0 $9
+$1 $5 $0 $3
+$1 $3 $0 $3
+$1 $3 $0 $2
+$1 $1 $1 $4
+$1 $0 $9 $4
+$1 $0 $9 $3
+$1 $0 $9 $2
+$0 D5
+$0 -2
+$0 $9 $3 $0
+$0 $9 $2 $3
+$0 $8 $8
+$0 $7 $0
+$0 $5 $3 $1
+$0 $3 $2 $0
+$0 $3 $1 $7
+$0 $0 $0 $7
+{ q
+o72
+o6S
+o6H
+o5o i5y
+o5H
+o4y $y
+o4a i52 i60 i70 o84
+o3e $z
+o2o $1 $2 $3
+o2k $1 $2 $3 $4
+o1x u
+o1t $1 $2 $3
+o1h $1 $2 $3
+o0y o2z
+o0v o4o
+o0t i2o
+o0s $r
+o0s $2 $0 $0 $4
+o0p o5a
+o0o i2g
+o0e $1 $2 $3
+o0a $2 $0 $0 $3
+o0V D1
+o0S T2
+o0R D6
+o0K -2
+o0J .2
+k i2z
+k ^o
+k ^j
+i9s
+i80 i94
+i7i o8o
+i6p -7
+i6h i7o
+i69
+i65 ,7
+i5s o6h o7a
+i5s -7
+i5o i6u
+i5o i6s
+i5m o6i
+i5m ]
+i5j o6u
+i5h o6o
+i5e i7e
+i5e i71
+i57 i77
+i51 i60 i71
+i51 ,6 ,7
+i50 i60 i75
+i50 ]
+i4e -0
+i4K E
+i45 i51 o60
+i44 i55 i66
+i42 i52 o63 ,7
+i41 i50 ,6
+i3y i4a
+i3w i4e
+i3v i4i
+i3u o4t
+i3t D5
+i3p i4a
+i3o o4v
+i3o ]
+i3m +2
+i3l $2
+i3k i4e
+i3i o4a
+i3a i4m
+i34 i45 o50
+i34 i43 o52
+i33 i44 o55
+i33 i43 ,5
+i31 t i32
+i30 i70
+i2z i3e
+i2w o3i
+i2v i3i
+i2u o4i
+i2p i3o
+i2o ,3
+i2n [
+i2m i3m
+i2i o3r
+i2h i3a
+i2e i3s
+i2e *03
+i2d o1l
+i1s o2i
+i1r .3
+i1o i2n
+i1i o2r
+i1d i1a
+i1c D3
+i1a i2s
+i1a i2p
+i1a i2n i3k
+c r T0
+c o42
+c o3w
+c o39
+c i5o
+c i1h
+c ^#
+c $8 $7 $6
+c $8 $6 $9
+c $7 $8 $5
+c $7 $6 $4
+c $7 $4 $6
+c $6 $3 $8
+c $6 $2 $2
+c $5 $7 $5
+c $4 $5 $7
+c $4 $0 $1
+c $3 $7 $8
+c $3 $7 $3
+c $3 $7 $2
+c $3 $6 $2
+c $3 $4 $1
+c $3 $3 $8
+c $2 $8 $2
+c $1 $9 $9
+c $1 $9 $5 $9
+c $1 $8 $1
+c $1 $7 $8
+c $1 $5 $5
+c $1 $4 $1
+c $1 $1 $6
+c $1 $0 $5
+c $1 $0 $1 $2
+c $1 $#
+c $0 $8 $0 $8
+c $0 $5 $2
+c $0 $4 $3
+c $0 $3 $1 $1
+c $0 $1 $6
+c $0 $0 $%
+^z ^z ^a ^t
+^z ^e ^d ^n ^e ^m
+^y ^t ^t ^o ^d
+^y ^r ^r ^e ^i ^h ^t
+^y ^n ^n ^o ^h ^j
+^y ^h ^c ^i ^r
+^y ^e ^k ^u ^l
+^y ^a ^w ^b ^u ^s
+^y ^a ^h ^s ^k ^a
+^v ^o ^r ^p
+^u ^n ^u ^n
+^t ^o ^i ^r ^t ^a ^p
+^t ^e ^r ^r ^e ^f
+^t ^a ^c ^d ^l ^i ^w
+^s ^u ^s ^a ^g ^e ^p
+^s ^t ^t ^a ^m
+^s ^n ^a ^y ^r
+^s ^k ^l
+^s ^b ^b
+^r ^r ^a
+^r ^e ^t ^s ^b ^o ^l
+^r ^e ^l ^o ^o ^c
+^r ^e ^l ^l ^o ^r
+^p ^e ^s ^o ^j
+^o ^v ^a ^t
+^o ^r ^i ^a ^j
+^o ^r ^e ^i ^p
+^o ^n ^i ^v
+^o ^l ^o ^h ^c
+^o ^l ^e ^g
+^o ^e ^m
+^o ^a ^m ^l
+^n ^o ^z ^a ^r ^o ^c
+^n ^o ^s ^i ^d ^e
+^n ^i ^w ^r ^e
+^n ^e ^t ^s ^r ^i ^k
+^n ^a ^n ^o ^c
+^n ^a ^l ^s ^a
+^n ^a ^l ^o ^n
+^n ^a ^d ^g ^o ^b
+^m ^y ^g
+^m ^o ^d ^g ^n ^i ^k
+^m ^m ^a
+^m ^l ^j
+^m ^e ^n
+^m ^a ^n
+^m ^a ^d ^n ^u ^g
+^l ^l ^i ^d
+^k ^s ^a ^m
+^j $1 $0
+^i ^u ^q ^i ^h ^c
+^i ^n ^e ^d
+^i ^l ^r ^a ^h ^c
+^i ^h ^c ^i ^h ^c
+^i -1
+^i ,2
+^h o1k *12
+^g z1 ]
+^e }
+^e o3e
+^e ^s ^o ^o ^g
+^e ^r ^a ^c
+^e ^n ^i ^r ^e ^h ^t ^a ^c
+^e ^i ^l ^l ^i ^w
+^e ^i ^l ^i ^m ^e
+^e ^d ^a ^w
+^d ^r ^a ^z ^i ^l
+^b ^o ^o ^n
+^a o3i
+^a ^w ^a ^k
+^a ^v ^i
+^a ^u ^g ^a
+^a ^t ^o ^y ^o ^t
+^a ^r ^o ^n
+^a ^r ^a ^i ^c
+^a ^n ^i ^t ^n ^e ^l ^a ^v
+^a ^n ^i ^l ^a ^t ^a ^c
+^a ^l ^l ^i ^n ^a ^v
+^a ^l ^l ^i ^m ^a ^c
+^a ^i ^r ^a ^d
+^a ^i ^c ^r ^a ^m
+^a ^c ^a ^m
+^U +1
+^P ]
+^M $1
+^B z1
+^7 ^3 ^3
+^5 ^5 o25
+^5 ^3 ^3
+^3 i42
+^2 o12 r
+^1 ^3 T2
+] +4 $1
+R4 o5)
+K o6i
+E p4 '9
+E *87 $1
+D7 *54 o5l
+D6 o7a
+D6 [ Z1
+D5 -6
+D3 o5y
+D3 $2 $0 $0
+D2 o5z
+D2 i3f
+D2 $A
+D1 o2u
+-5 -7 -5
+-4 ] -1
+-0 o5a
+-0 i3t
+-0 $0 $2
++7 o83
++6 sg[ o39
++6 o2s
++6 o0p
++6 +6 +6 +6
++6 *63
++3 -6
++2 +3 +2
++2 $2 $1
++2 $2
++2 $0 $2
++0 o3s
++0 o2v
++0 i37
++0 -5
++0 +7
+*75 D4
+*65 *34
+*64 $0
+*62 -0
+*62 *04
+*52 o4a
+*52 o3r
+*40 $6
+*26 *37 ]
+*23 $k
+*20 *14 c
+*16 *05 *30
+*14 } i38
+*14 o0z
+*13 Z1 [
+*12 }
+*03 -5
+'8 *32
+'7 T3
+'6 ^l D1
+'5 ^b
+'5 $e -5
+'5 $c
+$l $e $v $i
+$g $7
+$f $a $i $l
+$e *53
+$b $e $l $l $e
+$a $5
+$_ $3 $3
+$V r
+$T T4 *B6
+$H .7
+$8 $3 $9
+$6 $7 $7
+$6 $7 $3
+$3 $2 $3 $2
+$2 o3k
+$2 $7 $0 $3
+$2 $7 $0 $1
+$2 $0 $1 $2
+$1 $8 $0 $2
+$1 $7 $1 $1
+$1 $6 $1 $1
+$1 $2 $9 $3
+$1 $2 $2 $9
+$1 $1 $2 $0
+$1 $0 $9 $6
+$0 $9 $2 $9
+$0 $8 $4
+$0 $7 $6
+$0 $6 $8
+$0 $6 $3
+$0 $6 $0 $2
+$0 $5 $6
+$. $9 $9
+} *15
+{ ^7
+{ $2
+o7z ]
+o7u +8
+o6O
+o5Z
+o4p Z2
+o4a i51 i62 i73 o84
+o4N
+o4J
+o3?
+o2z y2
+o1s $1 $2 $3
+o0y o1t
+o0y i2l
+o0y i1h
+o0y i1e
+o0y $5
+o0v $1 $2 $3
+o0s ,1
+o0r o3o
+o0p o5o
+o0m $2 $0 $0 $2
+o0d $1 $2 $3 $4
+o0T $1 $7
+o0N $6 $9
+o0N $6
+o0N $2 $4
+o0K
+o0J +5 *85
+o0J $2 $8
+l ] $d
+l $3
+k ^G
+i93
+i7i i8c
+i7i ]
+i7c c oB)
+i6z
+i6s i7o
+i6s '8 c
+i6o i7v
+i6V l
+i69 ,7 ,8
+i65 ]
+i60 Z1
+i5p i6o
+i5o i6l
+i5k c ]
+i5j o6o
+i5i o6m
+i5i +7
+i5e i5c
+i5e +0
+i5e $s
+i52 i60 ss0 $3
+i50 i61 i72
+i50 T4
+i4z .3
+i4t i5a i6n
+i4t +6
+i4s i5o
+i4r i5u
+i4p o5o
+i4o o5m
+i4m o5a o6u
+i4m i5a o6u
+i4l i5y
+i4i o5c
+i4c i5e
+i4a o5b o6a
+i44 i50 ,6
+i41 i54 o63
+i3u $u
+i3t i4y
+i3s o5o
+i3q o4u
+i3o i4s
+i3n i4i
+i3h D1
+i3g
+i3e *53
+i3c i4i
+i3c i3a
+i3b +5
+i3a i4r
+i3a i4l i5i
+i3a i0A
+i3B E
+i35 i46 o57
+i35 i46 o51
+i32 i45 o50
+i31 i40 o51
+i2t [
+i2r o3p
+i2o o4a
+i2n i3d i4a
+i2n +3
+i2m o3y
+i2l i3i i4n
+i2i o4u
+i2i i3t
+i2e i3p
+i2e i3n
+i2a ,3
+i1v ]
+i1v D3
+i1u i2g
+i1l E
+i1i i2c
+i1e o3t
+i1e D4
+i1c ,2
+i1b i2c
+i1a i2s i3h
+i1a i2d i3e
+c o4S
+c i7!
+c i47
+c *21
+c $8 $8 $5
+c $8 $6 $3
+c $8 $6 $1
+c $8 $5 $2 $0
+c $8 $1 $7
+c $7 $3 $6
+c $6 $4 $0
+c $5 $7 $6
+c $5 $4 $2
+c $5 $2 $3
+c $4 $9 $8
+c $4 $9 $5
+c $4 $7 $4
+c $4 $7 $3
+c $3 $8 $6
+c $3 $8 $0
+c $3 $5 $6
+c $2 $4 $4
+c $2 $2 $1 $1
+c $1 $2 $0 $9
+c $1 $0 $2 $0
+c $1 $0 $0 $7
+c $0 $8 $2
+c $0 $6 $0 $9
+c $0 $3 $3
+^z ^n ^a ^h
+^z ^e ^d ^n ^a ^n ^r ^e ^f
+^y ^t ^s ^a ^e ^b
+^y ^t ^n ^u ^o ^b
+^y ^t ^e ^f ^a ^s
+^y ^r ^o ^t ^s
+^y ^o ^l ^e
+^y ^n ^o ^b
+^y ^m ^m ^a ^j
+^y ^k ^n ^o ^m
+^y ^d ^l ^o ^g
+^u ^i ^o ^p
+^t ^r ^a ^w ^e ^t ^s
+^t ^n ^e ^d ^u ^t ^s
+^t ^e ^n ^r ^o ^h
+^t ^c ^m
+^s ^t ^a ^h ^w
+^s ^s ^c
+^s ^r ^e ^k ^c ^a ^p
+^s ^r ^a ^b
+^s ^o ^c ^a ^t
+^s ^k ^d
+^r ^u ^l ^b
+^r ^o ^t ^p ^a ^r
+^r ^h ^s
+^r ^e ^v ^r ^e ^s
+^r ^e ^v ^i ^r ^d
+^r ^e ^l ^y ^k ^s
+^r ^a ^h ^c ^i ^r
+^r ^a ^b ^m ^a
+^p ^r ^a
+^p ^o ^i
+^p ^i ^l ^u ^t
+^o ^z ^n ^e ^k
+^o ^r ^e ^n ^e
+^o ^m ^r ^e ^l ^l ^i ^u ^g
+^o ^g ^n ^a ^h ^c
+^o ^b ^m ^o ^c
+^o ^b ^b ^a ^h
+^n ^r ^e ^t ^s ^e ^w
+^n ^o ^g
+^n ^o ^d ^n ^a ^l
+^n ^i ^a ^m ^o ^r
+^n ^a ^s ^s ^a ^h
+^n ^a ^l ^c ^e ^d
+^m ^j ^d
+^m ^a ^l ^s
+^m ^a ^i ^r ^a ^m
+^m ^a ^g
+^l ^r ^i ^g ^y ^b ^a ^b
+^l ^o ^a
+^l ^i ^b ^o ^m
+^l ^e ^m ^a ^r ^a ^c
+^k ^o ^k
+^i ^n ^n ^e ^j
+^i ^n ^a ^j
+^i ^m ^e ^r
+^i ^b ^o ^b
+^i ^b ^f
+^h ^s ^i ^w
+^h ^e ^j
+^g o2k
+^g ^l ^a
+^e o4a
+^e ^r ^o ^g
+^e ^r ^a ^m
+^e ^l ^g ^n ^i ^s
+^e ^i ^x ^i ^p
+^d ^y ^s
+^c ^i ^r
+^a o3z
+^a o2u
+^a i5s
+^a ^y ^n ^a
+^a ^r ^c
+^a ^n ^i ^l ^u ^a ^p
+^a ^n ^e ^h ^t ^a
+^a ^l ^l ^a
+^a ^l ^e ^u ^n ^a ^m
+^a ^l ^b ^a ^l ^b
+^S ,3
+^L D2
+^7 ^7 o27 r
+^6 o15 r
+^4 ^2 o26
+^0 ^2 $0 $4
+^( o5)
+[ o0W
+[ $3 $6 $0
+[ $3 $0 $0
+[ $2 $2 $2
+[ $1 $2 $5
+[ $1 $2 $2
+[ $0 $0 $0
+L8 Z1 i4o
+D5 o49
+D5 $p
+D4 o6a
+D4 o5a
+D4 $i
+D2 o4r
+D2 o3r
+D2 ]
+D2 $u
+D2 $3 $3 $3
+D1 -2 D3
+D1 +1 D3
+D1 $8 $8 $8
+D1 $1 $0 $0 $0
+-6 *24 D0
+-4 o2t
+-4 o05
+-4 -7 -4
+-4 +6
+-4 $a
+-3 o4l
+-3 -6 -6
+-0 y3
+-0 o2z
+-0 D5
++6 $h
++5 z1
++4 [
++4 -7
++4 -5 -5
++4 $3
++1 +2
++0 -5 +0
++0 $s
++0 $2 $8
+*53 o47
+*52 o5v
+*46 +4
+*43 -6
+*40 z1
+*34 o5j
+*31 i43
+*30 ^h
+*10 o4z
+*10 o42
+*02 o51
+*02 o2w
+'B DA $3
+'9 *85
+'7 +0 +4
+'6 { $n
+'5 u
+$o $1 $2
+$h Z2
+$c $h $i $c
+$c $h $a $s $e
+$b $r $a $v $o
+$b $o
+$a $m $i
+$a $b $b $y
+$L L8
+$8 *13
+$8 $4 $9
+$7 o67
+$5 L8 +3
+$4 $@
+$3 i66
+$2 $8 $0 $1
+$1 *41
+$1 $8 $8 $8
+$1 $7 $1 $0
+$1 $1 $0 $0
+$1 $0 $8 $8
+$0 ^c
+$0 ^2
+$0 $9 $1 $3
+$0 $7 $3
+$0 $7 $2 $9
+$0 $6 $4
+$0 $4 $2
+$0 $3 $1 $6
+$0 $3 $1 $3
+$0 $1 $2 $5
+$0 $0 $0 $1
+$. $. $. $.
+$# $1 $2
+o6T
+o3f $o
+o3c $o
+o2M D3
+o1z $1 $2 $3
+o1k
+o1d $1 $2 $3
+o1L D2
+o0y $2 $4
+o0s i4i
+o0r i2i
+o0p ]
+o0o ]
+o0n i2w
+o0T $3 $3
+o0N $9 $9
+o0K $2 $6
+o0K $1 $9
+o0J $3 $1
+o0J $0 $0
+o0D ,2
+l ]
+k ^y
+i8m i9a iAn
+i7r o8o
+i70 i81 i92
+i6M E
+i6A u
+i62 o70
+i5v i6e
+i5v ]
+i5u *51
+i5o i6o
+i5o +6
+i5l ,6
+i5k -6
+i5j -4
+i5e +7
+i5d i6e i7r
+i5c ]
+i52 o60 ss0 $8
+i52 i62 i72
+i52 i60 i70 o86
+i4z i5a
+i4z ,5 ,6
+i4x -5
+i4u o5b
+i4n -0
+i4e -5
+i4b ]
+i3p
+i3o i4t
+i3o ,4
+i3n Z1
+i3j o4i
+i3j c
+i3i o4t
+i3i i4e
+i3h o4u
+i3h i4u o5a
+i3f o4a
+i3e i7e
+i3a i7a
+i3a i4m i5a
+i3a i4a
+i3Y l
+i31 i47 o55
+i30 i40 ,5
+i2t i3u
+i2t i3t
+i2r Z1
+i2k i3o
+i2d D4
+i2a i3d
+i1w o2e
+i1u i2k
+i1o D5
+i1i i2s
+i1g D4
+i1e i1d
+i1c i1e
+i0R i1a
+c o32
+c i5u
+c i40
+c ^3 ^0
+c ] ]
+c '8 $5
+c $8 $1 $9
+c $7 $9 $5
+c $7 $6 $3
+c $6 $7 $5
+c $6 $6 $8
+c $5 $9 $2
+c $5 $7 $0
+c $5 $5 $8
+c $5 $5 $4
+c $4 $4 $5
+c $4 $3 $3
+c $3 $9 $2
+c $2 $0 $5
+c $1 $9 $8
+c $1 $9 $5 $0
+c $1 $2 $1 $1
+c $1 $2 $1 $0
+c $1 $1 $0 $7
+c $1 $1 $0 $2
+c $1 $0 $2 $5
+c $1 $0 $2 $4
+c $0 $5 $0 $9
+c $0 $4 $6
+c $0 $3 $7
+c $0 $2 $1 $0
+^z ^i ^t ^r ^o
+^y ^t ^t ^a ^n
+^y ^r ^o ^l
+^y ^r ^a ^l
+^y ^o ^n ^i ^p
+^y ^n ^a ^n
+^y ^m ^m ^u ^d
+^y ^l ^e ^m
+^y ^k ^u ^l
+^y ^g ^n ^a
+^y ^e ^g ^o ^b
+^y ^e ^c ^i
+^y ^b ^u ^r c
+^x ^i ^w ^t
+^t ^e ^i ^r ^r ^a ^h
+^t ^a ^c ^b ^o ^b
+^s ^u ^m ^a ^e ^s
+^s ^s ^e ^b
+^s ^i ^n ^a ^m
+^s ^f ^a
+^r ^e ^p ^p ^i ^k ^s
+^r ^e ^d ^n ^i ^c
+^r ^e ^b ^m ^e
+^p ^o ^p ^i ^l ^l ^o ^l
+^o ^t ^s ^o ^g ^a
+^o ^t ^n ^i ^p
+^o ^t ^i ^p ^e ^p
+^o ^t ^a ^n
+^o ^r ^d ^n ^a
+^o ^p ^p ^i ^l ^i ^f
+^o ^m ^j
+^o ^m ^a ^m
+^o ^h ^l ^a ^r ^a ^c
+^o ^g ^n ^i ^r ^g
+^o ^c ^o ^p
+^o ^c ^n ^a ^l ^b
+^o ^a ^f ^m ^l
+^n ^r ^a
+^n ^o ^l ^a ^v ^a
+^n ^i ^m ^z ^a ^j
+^n ^i ^l ^k ^n ^a ^r ^f
+^n ^e ^t ^s ^i ^r ^k
+^n ^a ^i ^t
+^m ^t ^a
+^l ^e ^v ^r ^a ^m
+^l ^e ^s
+^l ^e ^k ^i ^m
+^k ^e ^e ^r ^g
+^i ^x ^a ^t
+^i ^v ^a ^r
+^i ^u ^a ^m
+^i ^r ^a ^l
+^i ^n ^a ^n
+^i ^l ^e ^c
+^h ^t ^l ^a ^e ^t ^s
+^h ^c ^a ^e ^p
+^g ^r ^e ^s
+^g ^r ^a
+^g ^n ^i ^d
+^g ^a ^b
+^e o3u
+^e i2t
+^e ^y ^k ^s
+^e ^v ^r ^e ^m
+^e ^t ^a ^m
+^e ^r ^e ^w
+^e ^n ^a ^d
+^e ^m ^e
+^e ^l ^l ^i ^m ^a ^c
+^e ^k ^i ^k
+^e ^c ^e
+^d o2w
+^d ^t ^u ^n ^a ^m
+^d ^n ^i ^k
+^d ^a ^j
+^c o2a
+^a i2o
+^a ^t ^a ^k
+^a ^s ^e ^c ^n ^i ^r ^p
+^a ^r ^b ^i ^l
+^a ^r ^a ^l ^k
+^a ^n ^e ^l ^a
+^a ^l ^o ^r ^a ^p
+^a ^h ^c ^s ^a ^s
+^a ^e ^t
+^a ^d ^z ^a ^m
+^a ^b ^n
+^a ^b ^m ^a ^s
+^Y ]
+^S z1
+^S ]
+^M ^A ^I
+^M D3
+^J ^C
+^7 ^6 ^5 ^4 ^3 ^2 ^1 o78
+^4 ^3 ^2 ^1 D5
+^4 ^0 ^0 ^1
+^1 ^1 i61 ,7
+[ p2 ^j
+[ $9 $0 $0
+Y1 ,4
+K i4o
+K i0J
+E ss8
+E $4 *23
+D7 o7y
+D7 o7e
+D7 ,6
+D6 $m
+D4 $d
+D2 o4j
+D2 i4u
+D2 $9 $9 $9
+D1 z2
+D1 o3z
+D1 o1j D3
+D1 i2x
+D1 i2b
+D1 D2 D4
+D1 -4
+D0 .1 k
+-8 '9 Z1
+-4 o5k
+-4 T7 i0d
+-4 -6 -6
+-3 $2 $1
+-2 ^w
+-0 $0 $0
++B
++7 o54
++7 -4 -4
++5 $r
++4 i25
++4 +4 -5
++3 $0 $3
++2 +2 -5
++2 $9 $9
++2 $1 $0
++0 o51
++0 *23 *31
+*75 +6
+*72 '6
+*64 .3 *31
+*62 +6
+*60 o6l
+*54 o2g
+*32 *34
+*31 o1v
+*26 o33
+*24 -2
+*21 o0A *32
+*20 slm ^9
+*12 ,3
+*01 ^7
+'8 [
+$l $1 $2
+$k +8
+$i +3
+$i $1 $2 $3
+$g *54
+$f Z2
+$e $l $l
+$d $1 $2
+$a $b $i
+$_ $2 $8
+$A $1
+$9 sae
+$8 $8 $9 $0
+$7 $7 $7 $7 $7 $7 $7
+$6 o38
+$6 i27
+$3 o4g
+$3 $0 $0 $8
+$2 $3 $0 $0
+$2 $1 $1 $1
+$2 $0 $0 $0 $0
+$1 $9 $3 $0
+$1 $9 $2 $2
+$1 $9 $1 $5
+$1 $8 $0 $5
+$0 ^7
+$0 *35
+$0 $9 $2 $7
+$0 $7 $1 $6
+$0 $7 $1
+$0 $5 $7
+$0 $4 $8
+$0 $4 $7
+$0 $4 $2 $6
+$0 $3 $3
+$0 $3 $2 $1
+$0 $0 $!
+} q
+u $4 $L $I $F $E
+o7O
+o71 +8
+o2o $o
+o1i -2
+o0z i2y
+o0s o2y
+o0r $1 $2 $3
+o0o o1w
+o0o i2a
+o0i ^V
+o0b $1 $2 $3 $4
+o0a $1 $2 $3 $4
+o0Z D1
+o0X
+o0W D6
+o0P .2
+o0N D1
+o0N ,3
+o0K +5
+o0K $9 $8
+o0K $7 $6
+o0K $7 $5
+o0J $7 $7
+o0J $2 $6
+o0I $2 $3
+o0D .3
+l $i $a $n $a
+iA1
+i7b i8o
+i6o ,7
+i69 o78
+i60 i70 i83
+i5y
+i5r i6o i7s
+i55 $s
+i52 i60 ,7 o81
+i50 i60 i73
+i4o -3
+i4n o6r
+i4m
+i4i o5a
+i4i *25
+i4b i5e i6r
+i4a i5r i6d
+i47 i57 ,6
+i3s i4u
+i3i $1
+i3h o4i
+i3e o4p
+i3e i4p
+i3e i4e
+i3a i4n ]
+i3a i4k o5a
+i32 ,4 ,5
+i31 i41 ,5
+i30 i40 o58
+i2w o3a
+i2n i3s
+i2i o3z
+i2h o3u
+i2h i3o
+i2d +0
+i26 r
+i1u i2t
+i1r -5
+i1o i2s
+i1a i2t
+i11 i32 i53 i74
+c oB4
+c o7o
+c i45
+c i3o
+c $U o8s
+c $9 $9 $9 $9
+c $9 $3 $7
+c $9 $3 $4
+c $9 $0 $0 $0
+c $8 $4 $9
+c $7 $8 $2
+c $7 $8 $0
+c $7 $7 $7 $7
+c $7 $5 $1
+c $7 $1 $6
+c $6 $8 $1
+c $6 $4 $2
+c $6 $0 $7
+c $5 $9 $8
+c $5 $8 $3
+c $5 $4 $3 $2 $1
+c $4 $9 $6
+c $4 $4 $8
+c $4 $1 $8
+c $3 $7 $1
+c $3 $4 $3
+c $2 $6 $5
+c $2 $6 $1
+c $1 $7 $4
+c $1 $2 $3 $4 $5 $6
+c $1 $0 $1 $3
+c $1 $0 $0 $9
+c $1 $0 $0 $3
+c $1 $0 $0 $2
+c $0 $6 $0 $8
+c $0 $4 $0 $6
+c $0 $3 $0
+^z ^l ^l ^a ^b ^n ^o ^g ^a ^r ^d
+^z ^a ^o ^b
+^y ^n ^n ^u ^h
+^y ^n ^n ^i ^g
+^y ^n ^e ^b
+^y ^e ^c ^a ^k
+^y ^A
+^u ^y ^u ^y
+^u ^h ^u ^h
+^t ^u ^t
+^t ^k ^s
+^s ^r ^e ^k ^c ^i ^n ^s
+^s ^r ^e ^d ^i ^a ^r
+^s ^g ^a
+^s ^e ^h ^c ^a ^e ^p
+^s ^a ^m ^x
+^s ^a ^g ^r ^a ^v
+^r ^l ^e
+^r ^e ^k ^c ^a ^r ^c
+^r ^e ^i ^v ^i ^l ^o
+^r ^a ^r
+^r ^a ^l ^y ^k ^s
+^p ^l ^m
+^p ^i ^h ^s
+^p ^a ^a
+^o ^z ^r ^a ^m
+^o ^t ^e ^r ^p
+^o ^r ^r ^o ^h ^c ^a ^c
+^o ^f ^l ^o ^d ^o ^r
+^n ^o ^t ^s ^n ^i ^w
+^n ^o ^t ^l ^e
+^n ^o ^s ^r ^e ^f ^f ^e ^j
+^n ^o ^r ^t
+^n ^i ^l ^b ^o ^g
+^n ^a ^t ^i ^p ^a ^c
+^n ^a ^i ^v ^i ^v
+^n ^a ^i ^l
+^m ^o ^k
+^m ^l ^i
+^m ^l ^a ^p
+^m ^a ^l ^s ^i
+^l ^l ^o ^r
+^l ^e ^w ^e ^j
+^l ^a ^c ^i ^g ^a ^m
+^k ^o ^l
+^k ^i ^k
+^k ^c ^u ^l
+^k ^c ^o ^h ^s
+^k ^b ^h
+^j ^n ^a
+^i ^v ^a ^m
+^i ^t ^a ^n
+^i ^r ^o
+^i ^n ^o ^j
+^i ^l ^l ^i ^m
+^i ^l ^l ^i ^h ^c
+^i ^k ^u ^s
+^i ^h ^p ^o ^s
+^i ^g ^o ^y
+^i ^c ^n ^a ^r ^f
+^i ^a ^p
+^h ^s ^i
+^g ^u ^h
+^g ^n ^u ^j
+^e ^v ^a ^r ^b
+^e ^n ^o ^l ^a
+^e ^l ^y ^t ^s
+^e ^e ^r ^b
+^d z2
+^d ^y ^o ^l ^f
+^c ^r ^e ^m
+^b ^o ^j
+^a ^s ^i ^l ^a
+^a ^r ^p
+^a ^r ^a ^m ^a ^t
+^a ^r ^a ^b
+^a ^p ^a
+^a ^l ^e ^m
+^a ^i ^j
+^a ^c ^e ^b ^e ^r
+^_ ^_ $_ $_
+^M D6
+^E ^V ^O ^L ^I
+^C D4
+^5 o55
+^3 ^2 ^1 i73 i82 o91
+^3 .3
+^0 ^0 ^1 T3
+[ $2 $0 $0
+K +6 o7y
+D7 o7i
+D6 o6v
+D6 $g
+D3 o5u
+D2 o4e
+D2 -5
+D1 o2k ]
+D1 -2
+D1 '6 -3
+-3 -5 -4
+-3 -5
+-3 $m
+-2 o40
+-2 -4 -4
+-0 -0 -6
+-0 '7
+-0 $1 $2
+-0 $1
++8 +6
++7 *64
++6 u +6
++6 -3 +6
++6 *02
++6 $0
++5 o4p
++5 $1 $2 $3
++4 o5t
++4 +7 +7
++3 -7 +3
++3 +4
++3 $7 -6
++2 z1
++2 t
++2 -5
++2 -3
++0 o2d
++0 ^9
++0 $2 $0
+*94 '8
+*72 D7
+*57 o7a
+*57 -0
+*56 -4
+*53 o5v
+*53 +0
+*45 $6
+*32 $9
+*32 $6
+*24 o31
+*21 o5l
+*13 o2b
+*12 ]
+*10 Y2 +7
+*07 D6
+*06 D2
+*05 o4u
+*05 -3
+*05 -1
+*04 o0t
+*03 o1t
+*02 o1o
+'A $2
+'5 i2.
+$o $2 $1
+$m $a $p
+$l $a $g
+$j $e $l $l $y
+$i +6
+$h $o $o $d
+$e $t $h $a $n
+$d o0p
+$c $r $a $f $t
+$b $y
+$a $c $h
+$a $1 $1
+$H
+$9 o76
+$9 *14
+$6 $0 $0 $0
+$5 *32
+$3 $6 $3 $6
+$2 +7
+$2 $7 $0 $2
+$2 $1 $2 $7
+$2 $1 $0 $1
+$2 $0 $2 $5
+$1 k E
+$1 $9 $2 $1
+$1 $9 $1 $6
+$1 $8 $3 $0
+$1 $8 $0 $6
+$1 $7 $0 $9
+$1 $5 $0 $7
+$1 $5 $0 $5
+$1 $4 $5 $3
+$1 $3 $7 $9
+$1 $2 $2 $2
+$1 $1 $8 $8
+$1 $1 $1 $8
+$1 $0 $8 $7
+$1 $0 $6 $9
+$0 $9 $1 $9
+$0 $7 $4
+$0 $6 $1 $8
+$0 $4 $2 $3
+$0 $3 $1 $5
+$0 $2 $2 $3
+$0 $1 $4 $7
+$. $r $u
+} *36
+o6Z
+o4z o5a $a
+o3i .4
+o35 i44 i53 i62 o71
+o2w $1 $2 $3
+o2K D3
+o1f $1 $2 $3
+o1e -2
+o0y $1 $0
+o0y $0 $1
+o0r i2y
+o0n i3h
+o0n $0 $3
+o0j -9
+o0W ,3
+o0V D2
+o0O .1
+o0N $2 $5
+o0N $2 $1
+o0K $3 $0
+o0K $0 $0 $7
+o0J o3J
+o0J $0 $4
+o0H ,2
+o0G -3
+o0F ,5
+o0D *35
+l Z3 Y2 $4 x54 '6
+k i2y
+i7o o8r
+i7b E
+i73 o82
+i6r i7o
+i6D
+i5z ] ]
+i5y ]
+i5t i6e i7r
+i5p o6o
+i5o i6m
+i5n $5
+i5l o7y
+i5i i6g
+i5i i6a o7n
+i5h o6u
+i5g i6e
+i54 i63 i72
+i52 ,6 ,7
+i50 i60 i78
+i4y o5u
+i4t i5o i6n
+i4s i5s
+i4s
+i4q i5u o6i
+i4b i5o o6y
+i4a i5k
+i42 ,6
+i3v i4e
+i3s i4o i5n
+i3r i4i
+i3o o4m
+i3o o4c
+i3l K
+i3k *53
+i3i o4l
+i3i o4g
+i3i i4l
+i3i i4c
+i3i D6
+i3f o4u
+i3f i4i
+i3e i4n i5d
+i3e i4c
+i3b i4o i5y
+i33 i44 o50
+i33 i42 o51
+i32 i44 o50
+i31 i43 o52
+i30 i40 o59
+i2o ]
+i2n D4
+i2j o3e
+i2i *03
+i2d i3e i4r
+i2b D4
+i1w ]
+i1n D3
+i1l i2o
+i1j ]
+i1f i1a
+i1e o2a
+i1a o3l
+i1a i2r i3t
+i1_ ]
+i0p i1l i2a
+c o3r
+c i5_
+c i4o
+c i4a
+c $H
+c $8 $9 $4
+c $8 $8 $3
+c $8 $3 $6
+c $7 $6 $1
+c $7 $3 $5
+c $6 $4 $9
+c $5 $5 $3
+c $5 $4 $4
+c $5 $3 $6
+c $3 $6 $7
+c $3 $2 $2
+c $2 $9 $4
+c $2 $7 $3
+c $1 $9 $5 $3
+c $1 $3 $1
+c $1 $1 $0 $6
+c $1 $0 $6 $6
+c $1 $0 $0 $8
+c $0 $8 $0
+c $0 $4 $8
+c $0 $4 $1
+c $0 $1 $8
+^z ^i ^a ^f
+^y ^z ^e ^e ^r ^b
+^y ^v ^e ^l
+^y ^e ^k ^o ^p
+^x ^i ^m ^e ^r
+^w ^a ^w
+^u ^h ^c ^u ^h ^c
+^t ^t ^i ^k
+^t ^n ^u ^o ^c ^c ^a
+^t ^i ^j
+^t ^e ^l ^i ^o ^t
+^s ^r ^e ^w ^o ^l ^f
+^s ^o ^n ^o ^r ^k
+^s ^e ^s ^o ^i ^d
+^r ^e ^t ^s ^a ^e
+^r ^e ^p ^s ^e ^j
+^r ^e ^i ^d ^l ^o ^s
+^r ^e ^d ^w ^o ^p
+^r ^a ^l ^l ^o ^d
+^q ^a ^h ^s
+^p ^o ^t ^p ^a ^l
+^p ^o ^p ^i ^l ^o ^l
+^o }
+^o ^o ^n
+^o ^l ^o ^p ^a
+^o ^j ^n ^a ^u ^j
+^o ^g ^n ^e ^m ^a ^l ^f
+^n ^r ^o ^c ^p ^o ^p
+^n ^o ^m ^l ^a ^s
+^n ^i ^f ^f ^i ^r ^g
+^n ^e ^y ^u ^g ^n
+^n ^e ^e ^l ^i ^e
+^n ^e ^d ^o ^o ^w
+^n ^e ^d ^a ^c
+^n ^a ^i ^t ^s ^a ^b
+^n ^a ^i ^r ^o ^d
+^n ^a ^d ^n ^e ^r ^b
+^m ^c ^j
+^m ^a ^r ^b
+^m ^J
+^l ^i ^d ^a
+^l ^e ^a ^m ^s ^i
+^l .1
+^l *20
+^k ^a ^l
+^i ^u ^g ^i ^u ^g
+^i ^t ^a ^p
+^i ^a ^h ^t
+^i ^D
+^i $1 $2 $3
+^h ^c ^t ^a ^p
+^g ^n ^i ^j
+^g *30
+^f ^r ^u ^m ^s
+^f ^f ^b
+^e ^s ^a ^b
+^e ^n ^i ^t ^s ^i ^r ^h ^c
+^e ^n ^i ^l ^e ^c
+^e ^l ^e ^i ^n ^a ^d
+^e ^l ^b ^o ^n
+^e ^i ^l ^l ^i ^b
+^e ^i ^d ^d ^e ^r ^f
+^e ^h ^t ^m ^i
+^d ^a ^o ^r
+^c ^j ^a
+^b o2o
+^b o2a
+^a ^u ^h
+^a ^t ^a
+^a ^n ^a ^v ^i
+^a ^m ^r ^i
+^a ^l ^a ^s
+^a ^j ^a ^j
+^a ^e ^d
+^a ^c ^a
+^J ^M
+^C ^M
+^@ ^3 ^2 ^1
+^5 ^5 o25 r
+^3 ^0 ^2 ^0 ^1 o50
+^0 ^9 ^0 o35
+] i7u
+] i6_
+] *10 i0c
+[ $8 $8 $8
+E o1o +6
+D7 o7a
+D6 o6r
+D2 o3n
+D2 i4e
+D2 i3t
+D2 -6
+D1 o2r
+D1 +2 ]
+D1 $u
+D1 $3 $2 $1
+D1 $1 $3 $5
+D1 $0 $8 $0 $2
+.0 -5
+-7 o14
+-5 -7
+-5 *53
+-4 -6 -4
+-3 i34
+-3 -6 -3
+-0 *03
++7 -3 -3
++7 $0
++6 l *32
++6 $t
++5 o3z
++4 ^j
++4 -6
++4 $2
++3 $0 $2
++2 +3
++2 $1 $3
+*45 o39
+*42 ] ^g
+*32 -2
+*26 D6
+*24 -0
+*24 +2
+*15 *10
+*14 $7
+*12 Y1 k
+*05 ] -5
+*04 *31 Z2
+*03 o3s
+*02 o1a
+*02 *05 [
+'8 -2
+'8 +0
+'5 z2
+'5 ^9
+$n i5e
+$g $1 $2
+$e Z2
+$e $n $a
+$d $i $n
+$c $l $o $u $d
+$b $e $d
+$a $s $k
+$a $l $a
+$8 *75
+$8 $0 $8 $0
+$3 $2 $5 $6
+$2 $8 $9 $0
+$2 $1 $2 $5
+$1 *52
+$1 $9 $3 $1
+$1 $8 $0 $3
+$1 $7 $7 $6
+$1 $6 $1 $8
+$1 $6 $0 $4
+$1 $1 $3 $0
+$0 $8 $5
+$0 $6 $2 $6
+$0 $5 $9
+$0 $5 $1
+$0 $5 $0
+$0 $3 $7
+$0 $3 $2 $6
+$0 $3 $1
+$0 $2 $1 $3
+$. $1 $5
+{ { c
+{ $6
+o7E
+o4L ]
+o42 i52 i62 ,7
+o3M
+o2L D3
+o1e +2
+o1a $o
+o1M D2
+o1A ]
+o0y o4y
+o0t Z2
+o0t $e
+o0s $1 $2 $3 $4
+o0n i4r
+o0n i3a
+o0l $1 $2 $3 $4
+o0W $1 $3
+o0V $2
+o0V
+o0T o51
+o0P $1 $1
+o0N ]
+o0M o1C
+o0K -5
+o0K $5 $5
+o0K $3 $4
+o0K $1 $8
+o0J -3
+o0J *13
+o0E -3
+o0C $1 $1
+o0A o1D
+o0A *75
+l ] $q
+k ^K
+k ^D
+i8o *86 *0B
+i8n o9e $s
+i7a i8l
+i6s u
+i65 .5
+i60 ,7
+i5a i6d o7o
+i5a +7
+i53 i64 i75
+i52 i60 i70 i81
+i52 Y1
+i51 i62 i72
+i51 i61 o72
+i51 i61 i71 ,8
+i50 ,6 o78
+i50 ,6 o73
+i4y $1
+i4n *65
+i4m i5a i6s
+i4l i5l
+i4i o5r
+i4i i5t o6o
+i4a o5i
+i47 i50 ,6
+i3m t
+i3m i4e i5n
+i3l i4o
+i3l i4i i5n
+i3h i4a i5n
+i3b ,4
+i3a i4r o5a
+i3a i4p
+i31 i45 o50
+i30 i41 o52
+i2n i3g
+i2n K
+i2l ]
+i2k ]
+i2g ]
+i2d -1
+i1o i2l i3a
+i1l o3u
+i1i i2z
+i1i i2k
+i1h o2a
+i1e o3n
+i0P i1a
+c o1P
+c i2u
+c i1a
+c ^0 ^1 ^0 ^1
+c D3 $7
+c '8 $3
+c $@ $2
+c $8 $4 $4
+c $7 $9 $6
+c $7 $4 $9
+c $6 $9 $9
+c $6 $9 $2
+c $6 $7 $4
+c $6 $5 $5
+c $5 $7 $4
+c $5 $6 $5
+c $5 $3 $3
+c $4 $3 $4
+c $2 $8 $3
+c $2 $3 $2 $3
+c $2 $0 $1 $5
+c $2 $#
+c $1 $7 $3
+c $1 $7 $2
+c $1 $3 $2
+c $1 $1 $2 $0
+c $1 $0 $2 $7
+c $1 $0 $0 $5
+c $0 $9 $2
+c $0 $9 $1 $1
+c $0 $8 $8
+c $0 $4 $0 $7
+c $0 $2 $6
+c $0 $1 $0 $5
+^y ^k ^r ^o ^p
+^y ^e ^l ^l ^o ^v
+^y ^e ^l ^i ^k
+^y ^b ^b ^u ^t
+^w ^a ^t
+^t t
+^t ^n ^e ^d ^i ^s ^e ^r
+^s ^y ^e ^k ^n ^o ^m
+^s ^y ^d ^d ^a ^d
+^s ^s ^o ^j
+^s ^n ^o ^s ^p ^m ^i ^s
+^s ^j ^e
+^s ^c ^i ^t ^l ^e ^c
+^s ^b ^a ^g
+^s ^a ^m ^u ^p
+^s ^a ^m ^a ^m
+^r ^e ^k ^c ^o ^l
+^r ^a ^w ^d ^e
+^p ^r ^m
+^p ^e ^m
+^p ^J
+^o ^t ^i ^k
+^o ^r ^i ^k
+^o ^o ^h ^c
+^o ^n ^i ^r
+^o ^m ^e ^k
+^o ^g ^e ^u ^f
+^o ^d ^o ^r
+^o ^d ^e ^m
+^o ^c ^s ^e ^c ^n ^a ^r ^f
+^n ^r ^u ^t ^a ^s
+^n ^o ^x ^a ^j
+^n ^o ^s ^r ^a ^c
+^n ^o ^p
+^n ^i ^y
+^n ^i ^o ^j
+^m ^u ^s
+^m ^s ^a
+^m ^r ^j
+^l ^l ^i ^g
+^l ^k ^j ^h ^g ^f ^d ^s ^a
+^l ^i ^n ^a
+^k ^r ^a ^l ^c
+^k ^n ^a
+^k ^l ^a ^w
+^i ^r ^u ^a ^l
+^i ^o ^b
+^i ^n ^n ^a ^i ^g
+^i ^k ^u ^l
+^i ^k ^a ^s
+^i ^c ^i ^c
+^h o2i
+^h ^s ^a ^m
+^g ^n ^e ^m
+^g ^g ^a ^w ^s
+^f ^f ^u ^m
+^e i2e
+^e ^v ^a ^r
+^e ^i ^v ^e ^t ^s
+^e ^h ^c ^n ^i ^p
+^e ^c ^n ^i ^v
+^d ^l ^o ^n ^r ^a
+^d ^l ^i ^h ^c
+^c ^f ^k
+^c *12
+^b ^m ^j
+^b ^l ^m
+^b ^j ^a
+^a o2y
+^a ^r ^u ^a
+^a ^p ^u ^h ^c
+^a ^n ^n ^a ^h ^o ^j
+^a ^n ^i ^l ^e ^m
+^a ^l o6a
+^a ^l ^u ^l
+^a ^l ^a ^n
+^a ^l ^a ^l ^a ^l
+^a ^d ^o ^k
+^M ^I
+^K ^J
+^E D3
+^A $1
+^8 *43 *A5
+^3 ^2 ^1 o4e
+^2 ^1 o24
+^1 ^8 ^0
+^1 $@
+^0 ^7 o20 r
+TB
+D5 ^o
+D3 o5i
+D3 ^y ^t
+D3 +6
+D2 o4h
+D2 o3p
+D1 y2
+D1 o2i
+D1 ]
+D1 -1 ]
+D1 $e
+D1 $5 $0 $0 $0
+D1 $3 $1 $2
+.0 *04
+-B
+-6 i7d
+-6 -6 -6
+-6 $7
+-5 -6 -5
+-4 +7
+-2 $3
+-1 t
+-1 *31
++8 -7
++6 $a
++5 -3
++3 .2
++2 -6
++2 ,4 *35
++1 ^z
++1 $0
++0 o1r
++0 -2
++0 $9 $9
++0 $0
+*75 D6
+*60 D0
+*53 +6
+*49 sax sWk
+*45 u
+*43 o2h
+*42 +6
+*41 o5t
+*23 -2 *25
+*23 *21
+*12 o3z
+*02 o2z
+'7 o5.
+'6 $4
+$n $1 $1
+$k *67
+$g Z2
+$g K +6
+$e o7m
+$e -2 *34
+$c L6
+$c $l $a $w
+$c $a $k $e $s
+$b $l $a $z $e
+$a Y2
+$a $i $l
+$a $1 $2 $3
+$G
+$9 o2i
+$9 -4
+$9 *12
+$8 o23
+$6 $5 $6 $5
+$6 $4 $6 $4
+$2 $4 $3 $0
+$1 i7s
+$1 $4 $0 $5
+$0 @9
+$0 $8 $2 $3
+$0 $5 $2 $6
+$0 $4 $6
+$0 $4 $2 $7
+$0 $3 $1 $8
+$0 $2 $8
+$0 $1 $2 $9
+$) '6 *23
+} ^M
+u Z3
+r C r
+o5S
+o4S D5
+o4R
+o4M ]
+o3Z
+o3K
+o2R D3
+o2F D3
+o1u $y
+o1r $1 $2 $3
+o0z $0 $0
+o0p i3o
+o0o +1
+o0j .2
+o0j $2 $0 $0 $1
+o0d $2 $0 $0 $1
+o0c $2 $0 $0 $5
+o0T -5
+o0S *45
+o0K o4K
+o0C i1C
+o0C ]
+o0B ,5
+k ^J
+i90 iA0
+i8o o7d
+i80 i91
+i7s o8e
+i7i o8c
+i75 i85 ,9
+i6s i7t i8a
+i6k i7o
+i6k ]
+i6h i7i
+i69 ,7
+i61 o70
+i60 ]
+i5i i6s i71
+i5h ]
+i59 i69 i79
+i58
+i53 $8
+i51 i62 i71 o82
+i4t -2
+i4p i5e i6r
+i4l i5a i6n
+i4k $5
+i4i $i
+i4g i5i
+i4c i5h i6e
+i4a o5u
+i4a o5r $a
+i4a o5h
+i45 i56 i67
+i42 i50 i61 o70
+i40 i50 ,6
+i3y ]
+i3r ]
+i3p o4i
+i3j i4i
+i3f o4i
+i3e $1
+i3c i4a i5t
+i3S l $5
+i36 i47 o58
+i32 i43 ,5
+i31 i42 o59
+i30 i40 o53
+i2u i3s
+i2s i3s i4i
+i2s i3e
+i2p ]
+i2p D4
+i2o o3l
+i2n i3a
+i2d ]
+i1n o2a
+i1m D3
+i1j D3
+i1e i2m
+i1a i2c i3h
+i1a ]
+i1a D5
+i0j *02
+c i5S
+c '6 $7
+c $8 $6 $6
+c $8 $5 $9
+c $7 $5 $8
+c $7 $5 $5
+c $6 $7 $3
+c $5 $7 $1
+c $5 $5 $7
+c $5 $4 $8
+c $5 $2 $4
+c $4 $7 $6
+c $4 $6 $6
+c $4 $3 $8
+c $4 $3 $5
+c $2 $5 $8 $0
+c $1 $9 $7
+c $1 $9 $0 $7
+c $0 $7 $9
+c $0 $4 $0
+c $0 $3 $0 $7
+^z ^z ^i ^l
+^y ^u ^i ^o ^p
+^y ^r ^y ^r
+^y ^r ^r ^a ^g
+^y ^o ^n
+^y ^o ^b ^y ^e ^k ^n ^o ^m
+^y ^o ^b ^e ^m ^a ^g
+^y ^l ^i ^m
+^y ^h ^s ^i ^u ^q ^s
+^y ^g ^g ^a ^m
+^y ^f ^f ^a ^d
+^x ^X $x $X
+^v ^s ^p
+^t ^r ^a ^t
+^s ^y ^r ^e ^c
+^s ^y ^a ^r
+^s ^r ^e ^w ^o ^p
+^s ^l ^l ^e ^w
+^s ^e ^m ^a ^l ^f
+^s ^e ^i ^b ^m ^o ^z
+^s ^a ^j ^n ^i ^n
+^r ^e ^t ^s ^o ^o ^r
+^r ^e ^n ^r ^u ^t
+^r ^e ^n ^i ^m
+^r ^e ^m ^a ^e ^r ^d
+^r ^e ^d ^y ^r
+^o ^v ^a ^d
+^o ^s ^l ^e ^c
+^o ^o ^p ^o ^o ^p
+^o ^o ^d ^o ^o ^d
+^o ^k ^a ^r ^d
+^o ^i ^l ^o ^o ^c
+^o ^f ^l ^o ^d ^a
+^n ^o ^s ^i ^d ^d ^a
+^n ^o ^f
+^n ^i ^r
+^n ^i ^f ^l ^e ^d
+^n ^i ^a ^h ^c
+^n ^e ^i ^r ^d ^a
+^n ^e ^h ^s
+^n ^e ^c
+^n ^a ^w ^s
+^n ^a ^n ^d ^a
+^n ^a ^i ^k
+^m ^u ^n
+^m ^j ^a
+^l ^e ^n ^a ^h ^c
+^l ^e ^h ^c
+^l ^a ^n ^i ^g ^i ^r ^o
+^k ^c ^i ^l
+^i ^r ^u ^a ^m
+^i ^n ^o ^s
+^h ^a ^l ^l ^a
+^h ^a ^c
+^g ^i ^b ^e ^h ^t
+^f ^f ^u ^b
+^e o4e
+^e i4e
+^e i0F
+^e ^u ^r
+^e ^t ^a ^r ^a ^k
+^e ^r ^i ^p ^m ^e
+^e ^n ^i ^o ^t ^n ^a
+^e ^m ^i ^x ^a ^m
+^e ^i ^r ^e ^l ^a ^v
+^e ^i ^n ^n ^i ^w
+^e ^i ^l ^l ^o ^h
+^e $4
+^d ^r ^a ^n ^r ^e ^b
+^d ^n ^i
+^d ^l ^a ^n ^o ^r
+^d ^i ^u ^q ^s
+^c ^m ^a
+^c ^c ^m
+^c ^a ^c
+^c ^a ^b
+^a o3e
+^a ^r ^i ^e ^v ^i ^l ^o
+^a ^m ^r ^o ^n
+^a ^l ^o ^i ^b ^a ^f
+^a ^l ^l ^e ^r ^t ^s ^e
+^a ^k o3e
+^a ^h ^s ^i ^a
+^a ^h ^c ^i ^m
+^a ^g ^a ^m
+^a ^d ^e
+^a ^c ^o ^c
+^a ^a ^m
+^O -1
+^N k c
+^E D5
+^A -1
+^8 ^8 o28
+^1 ^2 ^3 ^3 ^2 ^1
+^0 ^2 $0 $2
+] Y3
+[ -2
+R5 t
+L7 $r
+K ,6
+K $x
+E i1a i2g
+E Z2 s8(
+D3 o5e
+D3 o5a
+D2 i3d
+D2 +5
+D2 $1 $2 $1 $2
+D1 o3n
+D1 i3j
+D1 $1 $1 $2
+D1 $0 $9 $8
+-6 -6 -7
+-4 }
+-4 Z1 -6
+-4 *40
+-3 $1 $0
+-2 -3 -4
+-2 $4
+-1 D4
+-0 $0 $4
++9 D7
++8 $8
++6 -4 -4
++6 -4 +6
++4 t
++4 $u
++2 ^8
++2 -4
++1 i0i
++0 +0 +1
++0 *32 }
++0 *12
++0 $2 $3
+*86 +6
+*50 $0 Z1
+*46 *23
+*40 o3n
+*32 i05
+*32 *42
+*30 o0B
+*25 +2
+*12 } i01
+*05 r
+'8 T7
+'8 -6
+$p $y
+$o *03
+$o $1 $1
+$l $i $r $a
+$i -0
+$h $u $a
+$g $u $r $l
+$e $a $t $e $r
+$d $i $a
+$b $a $c $o $n
+$a $m $o
+$@ $y $a $h $o $o $. $c $o $m
+$@ $3
+$@ $$
+$9 $2 $9 $2
+$9 $1 $8 $2
+$8 $3
+$7 o61
+$7 o3u
+$7 $6 $6
+$4 $0 $4 $0
+$3 o77
+$2 $8 $2 $8
+$2 $6 $0 $2
+$2 $0 $1 $9
+$1 $7 $0 $5
+$1 $6 $0 $6
+$1 $5 $0 $2
+$1 $4 $0 $9
+$1 $4 $0 $3
+$1 $3 $0 $1
+$1 $2 $2 $7
+$1 $1 $8 $1
+$1 $1 $1 $7
+$1 $0 $9 $8
+$0 $@
+$0 $7 $2 $3
+$0 $5 $2 $1
+$0 $5 $1 $9
+$0 $3 $6
+$0 $3 $4
+$0 $1 $2 $7
+$0 $1 $2 $1
+$0 $1 $1 $2
+$0 $0 $6
+$0 $%
+{ $1
+o9A
+o6o $o
+o5D
+o3e .4
+o2/
+o1u $1 $2 $3 $4 $5
+o1i +2
+o1R D2
+o0z i3o
+o0t i4o
+o0r o8s o3a
+o0n i3e
+o0m $2 $0 $0 $4
+o0j ,2
+o0i .1
+o0T Y1
+o0R $0 $2
+o0O D2
+o0N K D1
+o0N D6
+o0N $0 $7
+o0K $2 $8
+o0K $2 $7
+o0K $1 $6
+o0J -4
+o0J $3 $3
+o0J $1 $9
+o0I +2
+o0D $1 $2 $3 $4
+o0A o1L
+l $. $b
+k o0k
+i96
+i92
+i80 i91 iA2
+i7g i8a
+i6y -0
+i6o *54
+i6j E
+i6W s5i c
+i63 R5
+i60 i71 i81
+i60 i70 i88
+i5t
+i5s o6a
+i5l o6y
+i5j i6a i7n
+i5i s;_ u
+i5a o6y
+i58 $2
+i52 i60 i70 o82
+i50 i60 i71
+i4w i5e
+i4n *31
+i4m i5i i6n
+i4m ,5
+i4l o5y
+i4l
+i45 i55 ,6
+i41 i53 o62
+i41 i52 o60
+i3y i4u
+i3t -5
+i3s *30
+i3o i4o
+i3o i4k
+i3i o4j
+i3i $i
+i3h i4i
+i3h -0
+i3g i4e i5r
+i3b i3e
+i32 i40 o51
+i31 i41 o52
+i30 i47 ,5
+i2z o3u
+i2w i3a
+i2s i3h i4a
+i2r o4u
+i2r o4i
+i2g
+i2a i3s
+i2a -4
+i2a -1
+i1s o2a
+i1o i2p
+i1n o2i
+i1h o2u
+i1c i1a
+i1a i2m i3p
+i1a i2m i3i
+c T4 R3
+c $7 $7 $4
+c $7 $7 $2
+c $5 $6 $8
+c $5 $3 $5
+c $4 $9 $3
+c $4 $7 $0
+c $4 $5 $9
+c $4 $4 $9
+c $2 $9 $9
+c $2 $7 $4
+c $2 $6 $7
+c $2 $2 $1 $2
+c $2 $0 $1
+c $2 $*
+c $1 $9 $5 $2
+c $1 $6 $6
+c $1 $4 $6
+c $1 $1 $0
+c $1 $0 $3 $1
+c $1 $0 $1 $4
+c $0 $9 $8 $7
+c $0 $9 $6
+c $0 $8 $4
+c $0 $8 $1
+c $0 $5 $0 $5
+c $0 $3 $0 $4
+^z ^o ^n ^u ^m
+^y ^p ^p ^a ^r ^c ^s
+^y ^e ^l ^e ^e ^k
+^t ^s ^e ^u ^g
+^t ^k ^o
+^t ^a ^y ^a ^h
+^s ^t ^a ^e ^b
+^s ^s ^e ^h
+^s ^e ^s ^o ^r
+^s ^e ^k ^a ^n ^s
+^s ^e ^d ^r ^u ^o ^l
+^r ^t ^a
+^r ^o ^r ^r ^e
+^r ^e ^t ^e ^j
+^r ^e ^l ^l ^e ^k
+^r ^e ^g ^n ^i ^s
+^p ^o ^s
+^o ^z ^n ^e ^r
+^o ^s ^e
+^o ^n ^e ^k
+^o ^l ^y ^m
+^o ^l ^e ^f
+^o ^i ^g ^r ^o ^i ^g
+^o ^b ^i ^b
+^o ^b ^a ^b
+^n ^o ^y ^l
+^n ^o ^n ^n ^a ^c
+^n ^o ^i ^n ^o
+^n ^i ^k ^a ^n ^a
+^n ^e ^s ^n ^e ^j
+^n ^e ^d ^a ^k
+^n ^a ^m ^j
+^n ^a ^m ^e ^e ^r ^f
+^n ^a ^i ^r ^a
+^m ^a ^r ^g
+^l ^y ^r ^a ^d
+^l ^m ^j
+^l ^l ^a ^m
+^l ^e ^a ^h ^p ^a ^r
+^k ^l ^i ^s
+^k ^c ^i ^r ^r ^e ^d
+^j ^a ^t
+^i ^v ^a ^x
+^i ^n ^i ^n
+^i ^l ^a ^t ^a ^n
+^i ^h ^i ^h
+^h ^s ^a ^r ^t
+^h ^e ^m
+^g ^n ^i ^w
+^g ^n ^a ^d
+^e o2u
+^e ^u ^q ^i ^n ^o ^m
+^e ^t ^s ^e
+^e ^r ^u ^t ^a ^n
+^e ^r ^e ^t
+^e ^o ^h ^s
+^e ^n ^n ^a ^e ^l
+^e ^l ^k
+^e ^g ^a ^m
+^e ^c ^a ^l ^l ^a ^w
+^e ,6
+^d ^u ^t ^s
+^d ^n ^a ^r ^b
+^d ^e ^r ^f ^l ^a
+^d ^E
+^b ^c ^j
+^a ^t ^l ^a
+^a ^r ^o ^m
+^a ^r ^o ^c
+^a ^n ^i ^t ^s ^i ^r ^h ^c
+^a ^n ^e ^n
+^a ^n ^a ^i ^l ^i ^l
+^a ^m ^o ^t
+^a ^d ^r ^e ^i ^m
+^a ^b ^a ^s
+^a $o
+^[ o5]
+^M .1
+^J i1c
+^F D3
+^8 $5
+^8 $3
+^7 ^0 ^9 ^1
+^6 ^9 ^9
+^5 ^4 ^3 ^2 ^1 D7
+^4 ^9 ^9
+^. D2
+[ i1t ^s
+[ *10 y2
+[ $4 $5 $6
+R3 t
+L6 i6x
+K D7
+E o7d
+E +1
+E *A6 $T
+D6 snl
+D6 $e
+D4 o5e
+D4 $u
+D3 o4i
+D3 +1
+D3 $o
+D3 $2 $0 $0 $7
+D2 o4u
+D2 $e $r
+D2 $4 $4 $4
+D1 q
+D1 o2m ]
+D1 $3 $0 $0
+D1 $0 $2 $0 $2
+-9 -9 -9
+-6 -8
+-5 *50
+-3 o4s
+-3 o4k
+-2 -6
+-1 $1
+-0 o3p
+-0 *64
+-0 $9 $9
+-0 $8
+-0 $1 $3
++8 Y2
++7 *75
++7 $4
++5 *46
++2 Z1 .3
++0 $0 $9
+*64 *34
+*54 +0
+*45 o2t
+*45 -2
+*43 y1 *13
+*41 z1
+*41 c ]
+*35 ^g
+*34 o42
+*21 ^6 *61
+*20 c
+*20 ]
+*14 -2
+*12 $4
+*05 o2f
+*02 o0M
+*02 i1r
+*01 Y2 -4
+'6 $1 $2 $3
+$g $1 $3
+$f $r $o $s $t
+$f $i $g $h $t
+$e $1 $2
+$a $d $o
+$a $1 $3
+$_ $2 $6
+$7 o3a
+$6 $6 $9 $9
+$5 $@
+$3 D7
+$2 o4r
+$2 +4 Y1
+$2 *52
+$2 $8 $8 $2
+$1 i61
+$1 $8 $2 $1
+$1 $7 $0 $4
+$1 $1 $1 $9
+$0 $9 $4
+$0 $9 $1 $8
+$0 $8 $9 $0
+$0 $8 $1 $3
+$0 $6 $2
+$0 $4 $3 $0
+$0 $4 $2 $2
+$0 $2 $2 $6
+$0 $2 $1 $9
+$- @h +5
+{ ^j
+s2! c ,3
+o9w
+o5X
+o4L
+o3B ]
+o2i
+o2N D3
+o1T D3
+o0y o5i
+o0y i53
+o0y i1t
+o0y $y
+o0y $1 $2
+o0y $0 $8
+o0s $i
+o0p *45
+o0l $2 $0 $0 $2
+o0d $2 $0 $0 $2
+o0c $1 $2 $3 $4
+o0Z Z1
+o0V $5
+o0S o1A
+o0R *31
+o0N $0 $6
+o0J $4 $5
+o0I ]
+o0C $1 $2 $3 $4
+o0A ,5
+o0A ,2
+l ^i
+l ] $k
+k sad
+i8i
+i80
+i6H *80 u
+i5t o6v
+i5t i6o i7n
+i5o o2n
+i5i i6t o7o
+i5i i6l
+i5e i5e
+i5a i6r i7i
+i5a i5a
+i51 i60 i70
+i50 i77
+i50 i60 i72
+i50 ,6 o79
+i50 ,6 o72
+i4u +2
+i4l *74
+i4i o5m
+i4e $1 $2 $3
+i4d i5e i6r
+i4_ Z1
+i4_ +5
+i42 i52 ,6
+i3u o4g
+i3s +0
+i3o o4g
+i3o i4m
+i3n i4y
+i3m D5
+i3i o4p
+i3i o4b
+i3i ]
+i3e D6
+i3a i5e
+i3a i4k
+i3a i1a
+i37 i40 ,5
+i34 i74
+i33 i46 o50
+i32 i43 o54
+i31 i44 o50
+i30 i49 o58
+i2z ]
+i2v i3a
+i2u o4a
+i2r o5l
+i2n i3d i4o
+i2i ]
+i2h o3o
+i2b i3e i4r
+i2a i3h
+i1u i2p
+i1r ^a
+i1o sSY D6
+i1i o3u
+i1i D5
+i1h $2
+i1e o3k
+i1e ]
+i1a i2t i3t
+c sa@ se3
+c o5X
+c i6a
+c '6 $6
+c $8 $3 $5
+c $7 $8 $8
+c $7 $7 $9
+c $7 $7 $8
+c $6 $9 $6 $9
+c $6 $8 $2
+c $5
+c $4 $9 $9
+c $4 $3 $9
+c $3 $9 $1
+c $3 $7 $4
+c $3 $4 $4
+c $2 $3 $1 $0
+c $2 $1 $1 $0
+c $1 $2 $0
+c $0 ^3
+c $0 $8 $7
+c $0 $7 $1 $1
+c $0 $6 $3
+c $0 $5 $3
+c $0 $3 $5
+c $0 $3 $4
+c $0 $2 $0 $9
+^y ^t ^o ^o ^s
+^y ^n ^n ^o ^b
+^y ^n ^e ^j
+^y ^e ^h ^s
+^y ^b ^r ^u ^f
+^x ^e ^t ^r ^o ^v
+^x ^a ^z
+^t ^t ^e ^n ^n ^e ^b
+^t ^t ^e ^l ^r ^a ^c ^s
+^t ^o ^o ^f ^g ^i ^b
+^t ^e ^l ^g ^i ^p
+^s ^s ^i ^r ^k
+^s ^s ^i ^r ^c
+^s ^r ^o ^t ^a ^g
+^s ^o ^l ^r ^a ^c ^n ^a ^u ^j
+^s ^o ^i ^r
+^s ^l ^e ^i ^n ^a ^d
+^s ^j ^s
+^s ^i ^u ^l ^e ^s ^o ^j
+^s ^e ^l ^t ^t ^i ^k ^s
+^s ^e ^l ^k ^c ^i ^p
+^s ^a ^t ^s ^o ^k
+^s ^a ^l ^o ^k ^i ^n
+^p ^o ^l ^p
+^o ^n ^r ^e ^f ^n ^i
+^o ^m ^i ^x ^a ^m
+^o ^m ^i ^s ^s ^a ^m
+^o ^i ^s ^s ^e ^l ^a
+^o ^h ^c ^a ^c
+^n ^y ^b ^o ^r
+^n ^o ^t ^w ^e ^n
+^n ^o ^t ^s ^e ^r ^p
+^n ^o ^r ^b
+^n ^o ^i ^p ^r ^o ^c ^s
+^n ^i ^a
+^n ^e ^g ^o ^m ^i
+^n ^e ^e ^t
+^n ^a ^l ^p
+^m ^a ^l ^a ^s
+^l ^u ^a ^s
+^l ^l ^l
+^l ^i ^z ^a ^r ^b
+^k ^o ^o ^c
+^k ^o ^b
+^k ^j ^d
+^j ^A
+^j $0 $1
+^i ^r ^i ^m
+^i ^o ^p
+^i ^m ^a ^d
+^i ^l ^u ^a ^p
+^i ^a ^r ^u ^m ^a ^s
+^h ^t ^a ^n
+^e ^v ^a ^l ^c
+^e ^n ^e ^g ^u ^e
+^e ^n ^a ^l
+^e ^m ^s ^e
+^e ^l ^f ^f ^a ^w
+^e ^l ^a ^c
+^e ^i ^t ^u ^c
+^e ^i ^s ^s ^u ^a
+^e ^i ^c ^u ^l
+^e ^T
+^d o3i
+^d ^r ^a ^z ^i ^w
+^d ^e ^s ^s ^e ^l ^b
+^d ^a ^n
+^c o2i
+^c ^s ^e
+^c ^o ^l
+^c ^i ^s
+^b ^a ^m
+^a ^s ^u ^m
+^a ^s ^a ^s
+^a ^r ^s ^e
+^a ^r ^p ^u ^s
+^a ^r ^d ^n ^e ^k
+^a ^l ^i
+^a ^l ^e ^b ^a ^s ^i
+^a ^k ^a ^t
+^a ^j ^e ^d
+^a ^i ^x ^e ^l ^a
+^a ^i ^t ^a ^k
+^a ^i ^k
+^a ^i ^h ^t ^n ^y ^c
+^a ^h ^t ^a ^g ^a
+^a ^h ^s ^a ^t
+^a ^h ^s ^a
+^a ^b ^m
+^R $2
+^M +7
+^L -1
+^9 ^9 o29 r
+^8 ^9 ^9
+^3 ^2 ^1 o3k
+^1 ^1 ^1 ^1
+^0 ^0 o21 r
+[ -1
+[ $5 $6 $7
+T9
+T0 T1 T2 T3 T5
+E T4 ,7
+D7 t
+D7 o7x
+D7 $e
+D6 o2d
+D5 o2p
+D5 i4g
+D5 $l
+D5 $e
+D4 o0p ]
+D3 $y
+D3 $g
+D3 $e
+D2 $2 $0 $2 $0
+D1 o2z ]
+D1 o2a
+D1 *10 Z2
+D1 $6 $7 $8 $9
+D1 $1 $0 $1
+-7 o1@
+-5 $3
+-3 -4 -3
++7 o6x
++7 -5
++6 i3.
++6 *43
++5 .3
++5 -6 -6
++4 +7
++3 +4 +3
++2 D4 *43
++2 -7
++0 +0 +6
+*65 *35
+*65
+*61 D1
+*57 o7s
+*56 D0
+*56 *64
+*54 +7
+*40 o0B
+*36 '6
+*35 i63
+*34 K }
+*31 ^i
+*31 $5
+*24 u [
+*06 '6
+*04 o0k
+'8 *45
+'7 $1 $2 $3
+'6 $1
+$r $i $c $h
+$n $0 $1
+$l $a $m $a
+$i $l $k
+$g $u $y $s
+$d $1 $2 $3
+$c $u $t $e
+$b $o $w
+$b $e $a $n $s
+$b $e $a
+$b $1 $2 $3
+$_ $2 $9
+$_ $0 $3
+$P c +6
+$D c
+$A +7
+$@ $8
+$9 *01
+$9 $9 $0 $0
+$9 $8 $9 $8
+$6 o61 $5
+$4 ^r
+$4 $2 $0 $1
+$4 $0 $2 $0
+$2 o2s
+$2 $6 $0 $7
+$2 $5 $8 $9
+$2 $4 $6 $9
+$2 $3 $5 $8
+$2 $1 $2 $0
+$1 $8 $8 $1
+$1 $8 $0 $1
+$1 $6 $0 $3
+$1 $5 $0 $4
+$1 $3 $9 $7
+$1 $2 $3 $6 $5 $4
+$1 $2 $3 $6
+$1 $2 $3 $2 $1
+$1 $2 $#
+$1 $1 $1 $5
+$1 $0 $4 $0
+$1 $0 $0 $0 $0
+$0 i7_
+$0 *30 svi
+$0 $9 $9 $0
+$0 $9 $2 $5
+$0 $9 $2 $0
+$0 $8 $7
+$0 $8 $2 $0
+$0 $8 $1 $6
+$0 $7 $2 $5
+$0 $4 $4
+$0 $4 $1 $8
+$0 $4 $1 $3
+$0 $3 $3 $1
+$0 $3 $2 $4
+$# $1 $2 $3
+y2 y4
+o9r
+o3y $o
+o3B
+o2e $o
+o2a $o
+o1u $o
+o1o $z
+o0y o3y
+o0y i2u
+o0s $2 $0 $0 $2
+o0n $1 $2 $3
+o0m $2 $0 $0 $3
+o0f $1 $2 $3 $4
+o0c $2 $0 $0 $2
+o0W $2 $2
+o0V $7 $7
+o0S ,5
+o0R ]
+o0P *53
+o0O
+o0N +1
+o0K $2 $9
+o0J $7 $9
+o0J
+o0E .3
+o0E ,5
+o0D +8
+o0A $1 $1
+l ] $A
+i8u
+i80 $4
+i7p
+i76 D5
+i73 K
+i6t i7i
+i6k i7i
+i6i i7m
+i6b o7o
+i6B
+i5z
+i5t o6a
+i5s o6y
+i5s o6o
+i5s $8
+i54 ,6 ,7
+i52 i60 i70 o87
+i52 i60 i70 o85
+i52 i60 ,7 o85
+i51 i62 i71
+i4z *64
+i4s k
+i4n ,5
+i4c i5h i6i
+i41 i52 ,6
+i3u ]
+i3q ]
+i3p i4e i5r
+i3o i4b
+i3l i4a i5n
+i3l D5
+i3i i4z
+i3e o5e
+i3a o4i
+i2y i3a
+i2y ]
+i2r i3s
+i2o i3p
+i2n i3i
+i2a o4a
+i21 o32 $3 $4
+i1s o2h
+i1s o2e
+i1o o2w
+i1o i2m
+i1o i2g
+i1i ]
+i1e o3s
+i1a i5a
+i1a i2r i3c
+i1a i2l i3l
+i1a i2c i3k
+i0z i1i
+i0t +2
+i0A o60
+c o4w
+c o2K
+c $8 $9 $5
+c $7 $9 $4
+c $6 $7 $6
+c $5 $7 $7
+c $5 $6 $6
+c $4 $8 $1
+c $4 $5 $5
+c $4 $0 $0 $0
+c $2 $9 $8
+c $2 $8 $4
+c $2 $1 $2 $1
+c $2 $0 $2 $1
+c $1 $9 $4
+c $1 $2 $0 $6
+c $0 $9 $1 $0
+c $0 $8 $0 $3
+c $0 $7 $4
+c $0 $5 $0 $6
+c $0 $2 $8
+c $0 $2 $0 $2
+c $0 $2 $!
+^y ^t ^t ^o ^p ^s
+^x t
+^t ^e ^g ^g ^u ^n
+^s ^u ^y
+^s ^r ^b
+^s ^i ^r ^i ^s ^o
+^s ^e ^v ^a ^r ^b
+^s ^a ^w ^q
+^s ^a ^r ^a
+^r ^e ^k ^c ^u ^s
+^r ^e ^g ^d ^o ^d
+^o ^t ^i ^t ^a ^g
+^o ^r ^e ^m
+^o ^l ^a ^v ^a ^c
+^o ^k ^o ^m
+^o ^j ^a
+^o ^i ^r ^a ^s ^o ^r
+^o ^g ^i ^d ^o ^c
+^o ^e ^k
+^o ^d ^l ^a ^w
+^o ^d ^a ^n ^r ^o ^t
+^o ^b ^m ^a ^s
+^o ^a ^j
+^o ^a ^e ^l
+^n } i1o
+^n ^r ^u ^t
+^n ^r ^a ^b
+^n ^o ^t ^y ^a ^l ^c
+^n ^o ^i ^d
+^n ^i ^a ^r ^t
+^n ^e ^l ^a ^j
+^n ^e ^f
+^n ^e ^d ^a
+^n ^a ^z
+^m ^l ^o ^c ^l ^a ^m
+^m ^e ^b
+^m ^a ^l ^g
+^l ^l ^e ^h ^s
+^l ^j ^m
+^l ^e ^u ^n ^a ^m ^m ^e
+^l ^e ^g
+^l ^a ^e ^h ^c ^i ^m
+^k ^S
+^j z1 u
+^i ^z ^t ^i ^m
+^i ^v ^i ^l
+^i ^t ^a ^f
+^i ^r ^a ^c
+^i ^m ^u ^l
+^i ^m ^e ^o ^n
+^i ^i ^a ^w ^a ^h
+^h z2
+^g ^n ^i ^n ^n ^u ^r
+^e i0S
+^e ^t ^i ^n ^i ^f ^n ^i
+^e ^t ^a ^d
+^e ^n ^i ^h ^s
+^e ^m ^s ^s ^i ^k
+^e ^m ^a ^l
+^e ^l ^o ^s
+^e ^l ^b
+^e ^i ^n ^n ^i ^m
+^e ^i ^m ^a
+^e ^i ^g ^o ^o ^b
+^e ^c ^n ^a ^r ^f
+^d ^u ^o ^r ^p
+^d ^r ^e ^n
+^d ^n ^o ^m ^y ^a ^r
+^d ^a ^l ^g
+^c ^i ^r ^d ^e ^c
+^c ^b ^b
+^a ^y ^t ^i ^d ^a
+^a ^y ^t ^a ^k
+^a ^n ^i ^n ^e ^m
+^a ^n ^e ^l ^e ^s
+^a ^k ^l ^i ^m
+^a ^i ^r ^o ^t ^i ^v
+^a ^i ^r ^a
+^a ^c ^a ^v
+^_ ^y ^b ^a ^b
+^Q D2
+^N i1e
+^L ^O ^L
+^L D4
+^G D3
+^F D5
+^B i1b
+^9 ^9 ^9 ^9
+^9 ^0 ^9 ^0
+^8 ^8 o28 r
+^3 i60
+^1 o0a ^N
+^0 ^2 ^0 ^1 ^0 o53
+] i7l
+] *75
+[ i1h
+K u Z1
+K srb
+K .6
+D5 Y2
+D4 o6k
+D4 o4A
+D4 -3
+D3 o5n
+D3 -5
+D2 $f
+D2 $0 $0 $0 $0
+D1 o3e
+D1 i4a
+D1 i2z
+D1 i2p
+D1 i2n
+D1 i2j
+D1 $3 $4 $5
+D0 }
+@n ^m
+.0 ,3
+.0 +2
+-5 -7 -7
+-5 -6 -7
+-5 $1 $2
+-3 o57
+-3 -4
+-3 +6
+-2 r
+-2 @1 o4h
+-2 $2 $3
+-0 i52
+-0 -4
+-0 -0 -7
++6 i4.
++6 +6 -5
++5 ,3
++5 +6 +7
++4 -6 +4
++4 -3
++4 +0
++3 o0t
++2 *75
++1 ^n
++0 o3z
++0 o2t
++0 $1 $7
+*65 D3
+*65 +3
+*60 c
+*53 o5z
+*51 slC
+*50 c K
+*50 $5
+*36 +5 -0
+*30 Z1 o59
+*25 o1a
+*23 o1d
+*20 o3i
+*20 i4c
+*18 D8
+*13 i70
+*13 +3
+*02 -4
+*02 $i
+'B +A
+'6 +3
+'6 $6
+$m $e $s
+$g $u $m
+$e $t $h
+$d $o $o
+$S $1
+$R T5
+$D
+$8 o3e
+$8 *62
+$7 *64
+$4 $4 $5 $5
+$2 $7 $0 $6
+$2 $0 $2 $2
+$1 o3m
+$1 $9 $3 $4
+$1 $6 $0 $1
+$1 $5 $0 $0
+$1 $2 $@
+$0 z1
+$0 ^b
+$0 [
+$0 $9 $2 $4
+$0 $9 $1 $4
+$0 $8 $2 $7
+$0 $8 $2 $4
+$0 $7 $9
+$0 $6 $2 $8
+$0 $6 $2 $1
+$0 $5 $1 $4
+$0 $5 $1 $3
+$0 $4 $1 $6
+{ -5
+r Z3
+o5J
+o4l
+o4F
+o4?
+o3T
+o1y $1 $2 $3
+o1n $1 $2 $3
+o1a -2
+o1P
+o1N D2
+o1F D3
+o1E Y2 [
+o0z i2i
+o0y ,1
+o0y $1 $5
+o0w sei
+o0t $i
+o0c $2 $0 $0 $4
+o0Z $1 $2 $3
+o0Z $1 $2
+o0Y D5
+o0Y D2
+o0W $0 $8
+o0S *45 *34
+o0S $1 $1
+o0J $9
+o0J $6 $6
+o0J $5 $5
+o0J $3 $2
+o0J $1 $1
+o0G $1 $1
+o0D i1D
+o0A $1 $2 $3 $4
+l $1
+i91 iA0 oB1
+i7c i8h
+i79 i89 ,9
+i70 i82 i90
+i6s $7
+i6a i7m
+i6G -8
+i67 ,7 ,8
+i62 ,7
+i5z o6a
+i5t o6y
+i5t i6y
+i5t ,6
+i5r i6b
+i5k $2
+i5i +6
+i5d i7d
+i5a i72
+i59 ,6 ,7
+i52 o60 i72 o80
+i52 i60 i71 o84
+i50 i60 i70 ,8
+i4y o5n
+i4w i5o
+i4w ]
+i4w ,5
+i4t $3
+i4o i5o
+i4o i5l o6o
+i4e o6e
+i4b ,5
+i49 i59 i69
+i43 i54 i65
+i42 i50 i61 ,7
+i3s o5a
+i3m i4i i5n
+i3j i4o
+i3e o0M
+i3S c ,4
+i33 i40 ,5
+i31 i43 o55
+i2z o3o
+i2x o3i
+i2t i3e i4r
+i2r i3r i4a
+i2o o3m
+i2o i3n
+i2n o0F
+i2m i3o
+i2m D4
+i2k i3i
+i2j i3o
+i2i o5a
+i2d -0
+i1u o2z
+i1s ]
+i1o i2v
+i1o i2s i3e
+i1o i2c
+i1m ]
+i1i i2m
+i1i i2h
+i1a i3a
+i1a *20
+i0s .3
+i0M i1a i2y
+c i36
+c ^m ^a ^I
+c 'B $1
+c $M
+c $8 $9 $9
+c $8 $2 $9
+c $7 $3 $8
+c $6 $7 $7
+c $5 $6 $7 $8
+c $4 $6 $5
+c $4 $4 $6
+c $4 $0 $7
+c $2 $9 $3
+c $2 $7 $6
+c $1 $9 $0 $5
+c $1 $7 $7
+c $1 $0 $1 $9
+c $0 $9 $0 $8
+c $0 $8 $1 $0
+c $0 $6 $!
+c $0 $3 $0 $3
+c $0 $2 $0 $8
+^z ^a ^z ^a
+^y ^z ^z ^i ^f
+^y ^z ^t ^i ^m
+^y ^m ^y ^m
+^y ^m ^a ^e ^r ^c
+^y ^l ^o ^p ^o ^n ^o ^m
+^y ^c ^n ^a ^r ^f
+^y ^b ^b ^o ^d
+^x ^z ^a ^q
+^u ^s ^u ^s
+^u ^p ^u ^p
+^t ^w ^e ^n
+^t ^o ^o ^h
+^t ^e ^l ^l ^i ^k ^s
+^t ^a ^c ^k ^c ^a ^l ^b
+^s ^s ^u ^p
+^s ^r ^e ^y ^l ^f
+^s ^p ^u ^p
+^s ^p ^l
+^s ^o ^i ^r ^a ^m
+^s ^o ^g ^i ^m ^a
+^s ^n ^a ^t ^i ^t
+^s ^l ^p
+^s ^i ^r ^o ^m
+^s ^e ^l ^a ^r ^o ^m
+^r ^e ^f ^l ^o ^g
+^r ^e ^b ^m ^o ^b
+^r ^a ^n ^n ^u ^g
+^o ^r ^i ^m ^a ^r
+^o ^o ^m ^o ^o ^m
+^o ^l ^i ^n
+^o ^g ^i ^r
+^n ^y ^c
+^n ^w ^o ^n ^k ^n ^u
+^n ^e ^o ^r ^e ^j
+^n ^a ^w ^e
+^n ^a ^m ^d ^a ^e ^d
+^n ^a ^i ^d ^a ^n ^a ^c
+^m ^u ^y
+^m ^r ^m
+^m ^a ^z
+^l ^o ^c ^i ^n
+^l ^m ^a
+^l ^i ^a ^n ^s
+^l ^i ^a ^m ^s ^i
+^l ^e ^d ^i ^f
+^k ^c ^a ^t ^t ^a
+^j ^a ^k
+^j +1
+^i ^n ^o
+^i ^m ^o ^t
+^i ^m ^a ^j
+^i ^h ^c ^a ^t ^i
+^i ^g ^g ^a ^m
+^i ^d ^h ^e ^m
+^h ^s ^a ^h
+^h ^o ^m
+^h ^c ^t ^a ^c
+^g ^n ^a ^h
+^g ^n ^a ^g
+^f ^f ^u ^p
+^e ^t ^i ^l
+^e ^s ^r ^u ^n
+^e ^r ^t ^s ^e ^m
+^e ^r ^e ^b
+^e ^r ^b ^m ^o ^h
+^e ^l ^o ^m
+^e ^c ^i ^l ^o ^p
+^e ^G
+^d ^o ^o ^w ^y ^l ^l ^o ^h
+^c ^o ^s
+^b ^s ^a
+^b ^o ^c
+^b ^i ^g
+^a i4a r
+^a i3r
+^a i2i
+^a ^z ^a
+^a ^r ^i ^e ^k
+^a ^p ^p ^a ^p
+^a ^o ^j
+^a ^n ^o ^j
+^a ^n ^i ^g ^a ^v
+^a ^n ^e
+^a ^n ^a ^u ^j
+^a ^n ^a ^i ^c ^u ^l
+^a ^m ^u ^k
+^a ^m ^s ^a ^l ^p
+^a ^l ^l ^i ^r ^o ^g
+^a ^k ^i
+^a ^h ^n ^i ^t ^a ^g
+^a ^d ^n ^a ^n
+^O +1
+^K
+^8 ^7 ^6 ^5 ^4 ^3 ^2 ^1 o89
+^2 ^1 o23 r
+^1 ^2 ^3 D5
+] i7r
+[ $1 $0 $0 $0
+K Y1 .5
+E sco s3A
+DB
+D7 o7c
+D5 +6
+D4 $o $n
+D4 $h
+D3 $r $o
+D2 o5i
+D2 o3e
+D2 *34
+D2 $8 $8 $8
+D1 i4p
+D1 D2 o3h
+D1 $1 $9 $0 $5
+D1 $1 $3 $5 $7 $9
+D1 $0 $4 $0 $4
+D1 $0 $0 $0
+.0 ^f
+-5 *53 ,2
+-4 *63 ,5
+-2 $8
+-0 ^2
++6 -7 +6
++5 i5j
++5 -7
++2 *46
++0 -7
++0 -5 -3
++0 -2 -2
++0 $1 $4
+*65 E $1
+*61
+*54 ^c '7
+*54 D6 $n
+*54 ,2
+*54 $3
+*53 ^j
+*50 {
+*43 o3k
+*41 t
+*40 $2 scN
+*36 D4
+*35 $9
+*30 i4g
+*25 +8 ^0
+*21 i50
+*21 ^j
+*21 -1
+*20 $9 +4
+*13 *26
+*12 o0t
+*06 +6
+*05 i01
+'7 o0b
+'6 -1
+'6 +1
+$s $o $p
+$o $2 $3
+$o $1 $5
+$i $v $e
+$h *50 *25
+$e $1 $1
+$a $y
+$a $t $o
+$a $1 $2
+$F $C
+$9 +0
+$9 $4
+$7 $9
+$7 $0 $0 $7
+$6 +7
+$5 i5s
+$4 +0
+$3 $1 $1 $3
+$2 $9 $9 $2
+$2 $3 $5 $7
+$2 $3 $4
+$1 sux i35
+$1 $7 $2 $1
+$1 $4 $0 $1
+$1 $2 $5 $6
+$1 $2 $3 d ] ] ]
+$1 $1 $9 $0
+$1 $1 $1 $6
+$1 $0 $3 $3
+$0 o30
+$0 $9 $2 $6
+$0 $9 $2 $2
+$0 $8 $2 $9
+$0 $8 $2 $1
+$0 $7 $1 $7
+$0 $6 $2 $3
+$0 $5 $3 $0
+$0 $5 $2 $9
+$0 $5 $1 $5
+$0 $4 $2 $5
+$0 $4 $2 $4
+$0 $4 $1 $9
+$0 $4 $1 $5
+$0 $4 $1 $4
+$0 $3 $2 $8
+$0 $3 $1 $9
+$0 $2 $1 $6
+$! $! $! $!
+o5s c
+o5p Y2
+o5) s0(
+o3N
+o2x $1 $2 $3
+o2T
+o2E
+o1d *12
+o1B D3
+o0y $1 $1
+o0s i2y
+o0p i4o
+o0n ,2
+o0V ,3
+o0T ,3
+o0N $1 $4
+o0N $0 $3
+o0L ,2
+o0K o2K
+o0J $3 $0
+o0H $1 $2 $3 $4
+o0G ,2
+o0D ,4
+o0D $1 $0 $1
+l i5s '6
+l ] $p
+i94 'B
+i90
+i8a o9l
+i86 c z1
+i73 i84 o95
+i6y
+i6x o71
+i6r c
+i6o i7s
+i6o i7l
+i60
+i5u i6t
+i5s i6s
+i5m i6i o7a
+i5l i6a i7n
+i5l -6
+i5k +6
+i5h *76
+i5a o6r o7a
+i5a i6d o7a
+i52 i60 i70 o83
+i51 i62 i73 i84
+i51 i62 i72 o83
+i51 i60 ,7
+i50 i60 i74
+i4y i5o
+i4q i5u o6e
+i4o i5v o6i
+i4i i5l i6l
+i4d i5o i6n
+i4_ ,5
+i4A
+i43 i52
+i3l
+i3i i4m
+i3g ,4
+i30 i42 o51
+i2y i3o
+i2v *13
+i2r i3u
+i2n o4a
+i2n o3y
+i2l i3l i4a
+i2b i3b
+i20
+i1u D4
+i1s D3
+i1o o2g
+i1l ^m
+i1a i2m o3a
+i1a i2k
+i1a i2h
+i1a i2d i3i
+i0S i1h
+c i6o
+c i6C
+c '8 $6
+c $8 $7 $2
+c $7 $9 $9
+c $6 $6 $6 $6
+c $5 $7 $3
+c $5 $6 $3
+c $5 $5 $9
+c $4 $7 $7
+c $4 $6 $0
+c $4 $2 $4 $2
+c $2 $9 $5
+c $2 $5 $9
+c $2 $2 $3
+c $2 $1 $0 $4
+c $1 $2 $1 $3
+c $1 $2 $0 $2
+c $1 $1 $1 $0
+c $1 $0 $0 $6
+c $0 $9 $4
+c $0 $8 $0 $9
+c $0 $6 $0
+c $0 $5 $0 $8
+c $0 $5 $0 $2
+c $0 $4 $4
+c $0 $2 $0 $7
+^y ^t ^o ^o ^f
+^y ^p ^e ^e ^r ^c
+^y ^l ^r ^i ^g
+^y ^l ^r ^a ^k
+^y ^h ^c ^a ^e ^p
+^w ^a ^n
+^t ^e ^n ^r ^a ^g
+^s ^t ^u ^n
+^s ^n ^i ^u ^r ^b
+^s ^l ^w ^o
+^s ^k ^c ^o ^s
+^s ^e ^l ^d ^o ^o ^n
+^s ^a ^n ^a ^n ^a ^b
+^r ^u ^o ^k ^r ^a ^p
+^r ^e ^z ^a ^l ^b
+^r ^e ^t ^s ^a ^l ^b
+^r ^e ^g ^g ^i ^r ^t
+^r ^e ^g ^g ^a ^j
+^r ^e ^d ^n ^a ^z
+^q ^q ^q
+^p ^o ^i ^u ^y ^t ^r ^e ^w ^q
+^p ^c ^s
+^o ^t ^i ^r ^r ^e ^p
+^o ^t ^i ^l ^e ^g ^n ^a
+^o ^r ^d ^n ^a ^s ^s ^e ^l ^a
+^o ^p ^a ^p
+^o ^n ^e ^d
+^o ^m ^a ^t
+^o ^l ^l ^i ^t ^s ^a ^c
+^o ^e ^f
+^o ^d ^e ^l ^o ^t
+^n ^y ^r ^h ^t ^a ^k
+^n ^o ^o ^p ^s
+^n ^o ^o ^g
+^n ^i ^n ^e ^l
+^n ^i ^b ^r ^o ^c
+^n ^a ^m ^g
+^m ^u ^n ^g ^a ^m
+^m ^u ^h ^c
+^m ^l ^k
+^m ^j ^c
+^m ^i ^p
+^m ^c ^m
+^m ^a ^y ^o ^s ^e ^h
+^l ^y ^d
+^l ^w ^e ^k
+^l ^o ^b ^t ^u ^f
+^l ^l ^i ^t
+^l ^l ^e ^m ^s
+^l ^e ^p ^p ^a
+^l ^e ^n ^o ^i ^l
+^l ^a ^p ^o
+^l ^a ^e ^n
+^k ^y ^r ^t ^a ^p
+^k ^n ^u ^d
+^k ^i ^r ^n ^e ^h
+^k ^c ^i ^t ^s
+^k ^a ^o
+^i ^r ^o ^l ^f
+^i ^o ^h
+^i ^l ^u ^l
+^i ^d ^o ^j
+^i ^d ^n ^a ^r ^b
+^g ^n ^o ^h
+^g ^n ^i ^r
+^f ^e ^j
+^e i3c
+^e ^s ^a ^c
+^e ^r ^o ^c
+^e ^p ^a ^c
+^e ^n ^i ^m ^a
+^e ^n ^a ^z
+^e ^m ^o ^d
+^e ^l ^i ^m
+^e ^l ^a ^k
+^e ^i ^l
+^e ^e ^f
+^d ^r ^i ^e ^w
+^c ^r ^m
+^b ^r ^m
+^b ^r ^a
+^b ^o ^f
+^b ^c ^f
+^a ^s ^e ^m
+^a ^r ^o ^l ^f
+^a ^p ^s
+^a ^n ^a ^k
+^a ^j ^a ^r
+^a ^i ^n ^r ^o ^f ^i ^l ^a ^c
+^a ^e ^r ^o ^k
+^a ^d ^o ^s
+^a ^d ^n ^a
+^Z z1 c
+^K $1
+^J
+^C ^F
+^3 ^1 ^0 ^2
+^2 ^2 o22
+^1 ^2 ^3 ^4 ^5 ^6
+^0 ^0 ^2 o37
+] -8
+D9 ^7
+D8 o8a
+D8
+D6 $i
+D5 o6e
+D5 i2p
+D5 .4
+D4 o6s
+D2 i3c
+D2 +4
+D1 i2v
+D1 i2k
+D1 i2c i3h
+D1 -1
+D1 +2 D3
+D1 +1
+D1 $5 $5 $5
+D0 stp ]
+-A
+-4 -6 -5
+-2 o0T
+-2 -7
+-0 o1l
++7 c $1
++6 i5m
++6 i5l
++6 +5
++5 +6 +6
++4 -7 -7
++4 $n
++2 *73 *54
++0 y3
++0 $0 $0
+*B9 *30 i4l
+*87
+*75 o5g
+*54 ^9 {
+*50 z1
+*46 o2d
+*46 Z1
+*45 o0n
+*43 o1o
+*40 ^g
+*40 *35 z1
+*30 u {
+*30 c
+*23 -6
+*17 i13 $5
+*15 Z1
+*03 o1y [
+*03 +1 o2r
+'9 r
+'7 o6w {
+'7 i67
+'5 $2
+$p Y2
+$n Z2
+$h $u $a $n $g
+$e $a $n
+$c $o $p
+$a $v $i
+$_ $0
+$9 $9 $1 $1
+$9 $3
+$9 $0 $9 $1
+$8 +6
+$8 $3 $7
+$6 $7 $6 $7
+$4 $8 $4 $8
+$3 o5k
+$3 $2 $1 $4
+$2 -6
+$2 *24
+$2 $5 $5 $2
+$2 $4 $8 $6
+$2 $2 $5 $5
+$2 $0 $4 $0
+$2 $0 $2 $7
+$1 $9 $3 $3
+$1 $9 $2 $3
+$1 $9 $1 $8
+$1 $6 $0 $7
+$1 $5 $!
+$1 $4 $5 $2
+$1 $4 $3 $2
+$0 $8 $3 $0
+$0 $8 $1 $4
+$0 $7 $2 $2
+$0 $7 $1 $9
+$0 $7 $1 $4
+$0 $6 $1 $3
+$0 $5 $1 $8
+$0 $5 $1 $6
+$0 $4 $3
+$0 $4 $1 $7
+$0 $3 $2 $9
+$0 $3 $2 $3
+$0 $1 $3 $0
+$0 $1 $1 $7
+$0 $1 $0 $0
+$# $1 $0
+{ E
+o9s
+o91 Y1 c
+o7o
+o1w $1 $2 $3
+o1u -2
+o1i $p
+o1E D2
+o0y i3o
+o0t .2
+o0r i3o
+o0p $x sfc
+o0m $1 $2 $3 $4
+o0l i0O
+o0k ,2
+o0e .1
+o0_
+o0Z $1 $0
+o0Y D3
+o0N .2
+o0K $4 $4
+o0K $4 $2
+o0D .4
+o0C .2
+o0A ,1
+l +6 *65
+l $4
+k i1o
+k ^T
+k .1
+i8o o9r
+i77 o88
+i6u i7r
+i6r i7i
+i60 i70 i82
+i5r o6y
+i5p *34
+i5n i6g
+i5i i6a
+i5h -4
+i5c i6h o7o
+i5V c
+i5A
+i4y +3
+i4o
+i4l o6y
+i4i i5a i6n
+i4c i5h i6a
+i4a o2o
+i4a i5k o6o
+i4_ o53
+i48 i58 ,6
+i41 i53 i65 o77
+i3s D5
+i3n ,4
+i2y o3k
+i2t i0s
+i2p i3p
+i2p i3e
+i2p ] ]
+i2o o4i
+i2o D4
+i2n i3u
+i2l i3a i4n
+i2i o4o
+i1r i2i
+i1o i2n i3t
+i1o i2n i3g
+i1l D3
+i1k ]
+i1i o5a
+i1i i2c i3k
+i1c r
+i1c o2e
+i1a i2v
+i1a i2u i3r
+i1a D4
+c o6_
+c o1l
+c o1T
+c i49
+c i30
+c ^H
+c $d $1
+c $J
+c $5 $9 $9
+c $5 $6 $1
+c $4 $6 $1
+c $3 $0 $1 $1
+c $2 $4 $1 $2
+c $2 $3 $3
+c $2 $2 $0 $1
+c $1 $9 $0 $0
+c $1 $2 $3 $0
+c $1 $0 $2 $8
+c $1 $0 $1 $6
+c $1 $0 $0 $4
+c $0 $9 $0 $9
+c $0 $9 $0 $2
+c $0 $6 $6
+c $0 $6 $2
+c $0 $5 $5
+c $0 $3 $0 $6
+c $0 $2 $0 $3
+c $0 $0 $1 $2
+^y ^t ^a ^f
+^y ^o ^b ^l ^o ^o ^c
+^y ^l ^s ^e ^l
+^y ^l ^r ^a ^m
+^y ^k ^c ^a ^m
+^y ^f ^f ^u ^t
+^y ^d ^n ^i ^s
+^y ^b ^b ^a ^t
+^u ^h ^c ^i ^p
+^t ^r ^i ^u ^q ^s
+^s ^s ^a ^j
+^s ^r ^e ^g ^d ^o ^d
+^s ^o ^c ^n ^o ^r ^b
+^s ^k ^o ^o ^b
+^s ^e ^e ^r ^t
+^r ^o ^t ^s ^a ^c
+^r ^i ^m ^i ^d ^a ^l ^v
+^r ^e ^y ^a ^m
+^r ^e ^t ^s ^a ^f
+^r ^e ^h ^t ^u ^l
+^p ^r ^u ^p
+^o ^v ^e ^t ^s
+^o ^r ^e ^c
+^o ^n ^a ^n ^e
+^o ^l ^l ^e
+^o ^k ^k ^i ^n
+^o ^h ^l ^e ^o ^c
+^o ^h ^c ^n ^o ^p
+^n ^o ^t ^y ^a ^p
+^n ^o ^s ^w ^a ^d
+^n ^o ^s ^s ^i ^l ^a
+^n ^o ^o ^b
+^n ^o ^g ^a ^r ^e
+^n ^o ^b ^n ^o ^b
+^n ^e ^d ^d ^a ^m
+^n ^a ^m ^t ^a ^f
+^n ^a ^m ^g ^i ^b
+^n ^a ^i ^l ^l ^i ^l
+^n ^a ^d ^a
+^m ^e ^k
+^m ^a ^b ^m ^a ^b
+^l ^i ^e ^l ^o ^s
+^l ^e ^a ^k ^i ^m
+^k ^r ^a ^d ^e ^h ^t
+^k ^c ^o ^r ^i
+^i ^s ^s ^a ^c
+^i ^s ^a ^c
+^i ^r ^o ^c
+^i ^r ^a ^s
+^i ^n ^n ^a ^v ^o ^i ^g
+^i ^n ^e ^j
+^i ^a ^f
+^h ^s ^i ^m ^a ^h
+^h ^s ^a ^k ^a
+^g ^n ^i ^k ^l ^a ^w
+^f ^f ^u ^l ^f
+^e ^t ^t ^o ^l
+^e ^t ^i ^a ^m
+^e ^s ^a ^h
+^e ^p ^u ^l
+^e ^p ^p ^e ^s ^u ^i ^g
+^e ^n ^o ^z
+^e ^n ^i ^r ^e ^h ^t ^a ^k
+^e ^l ^l ^i ^u ^g
+^e ^l ^e ^d ^a
+^e ^e ^m
+^d ^r ^a
+^d ^e ^b
+^d ^a ^l
+^c ^r ^a ^M
+^c ^e ^t
+^a ^z ^m ^a ^h
+^a ^s ^s ^e ^t
+^a ^s ^i ^r ^a ^m
+^a ^r ^e ^i ^k
+^a ^o ^m
+^a ^o ^c ^o ^c
+^a ^n ^i ^s
+^a ^n ^e ^r ^e ^s
+^a ^n ^d ^e
+^a ^n ^a ^r
+^a ^n ^a ^i ^r ^a
+^a ^m ^i ^m
+^a ^m ^d ^n ^a ^r ^g
+^a ^m ^a ^r ^d
+^a ^m ^a ^b
+^a ^j ^a ^b
+^a ^d ^n ^a ^w
+^a ^c ^o ^l
+^_ ^x ^e ^l ^a
+^W +2
+^H D2
+^F D2
+^A o1n
+^< ] $>
+^3 ^2 ^1 o3d
+^0 ^1 ^1 o30
+^0 ^0 ^2 o34
+] $1
+[ i1g
+[ $3 $4 $5
+T1 T4 T3
+D8 o8o
+D7 $a
+D6 +6
+D6 +4
+D5 o5K
+D5 o2_
+D4 -5
+D3 o6a
+D3 i4m
+D3 T3
+D2 saj
+D2 i3m
+D2 $2 $2 $2
+D2 $2 $0 $0
+D2 $1 $2 $1
+D1 o3u
+D1 o2g ]
+D1 o2e
+D1 .4
+D1 +4
+D1 $7 $7 $7
+D1 $5 $6 $7
+D1 $5 $4 $3 $2 $1
+D1 $3 $3 $3
+D1 $0 $0 $2
+-5 i5n
+-5 *25 l
+-3 o0F
+-2 o3x
+-2 $9 $9
+-2 $1 $1
+-1 $8
++7 o6y
++7 -8 -8
++6 [
++5 i5z
++5 i5s
++3 D6
++3 -7
++3 $1 $2
++2 o0H
++1 D0
++0 i2j
++0 -4
+*69 '8
+*60 D6
+*56 o46
+*52 $6
+*45 $8
+*43 +0
+*42 ^k
+*35 ^e
+*25 *13 c
+*21 +1
+*20 y2
+*14 ,3
+*12 i49
+*10 i3r
+'A o8m l
+'9 $k
+'7 o1u *20
+'6 o5l
+'5 *14 *20
+'5 $7
+'5 $3
+$l $1 $2 $3
+$k $i $e
+$h $i $t
+$f c
+$_ $0 $4
+$_ $0 $2
+$K T5
+$8 $1 $8 $1
+$7 i5n
+$7 $4
+$5 $0 $6 $0
+$4 o4o
+$4 o1y
+$4 D7
+$4 $2 $2 $4
+$2 o6b
+$2 $9 $2 $9
+$2 $6 $2 $7
+$2 $3 $9 $0
+$2 $3 $5 $6
+$2 $0 $1 $8
+$1 o4. '6
+$1 -3
+$1 *34 $1
+$1 $8 $9 $9
+$1 $7 $1 $8
+$1 $7 $0 $3
+$1 $4 $2 $5
+$1 $3 $9 $0
+$1 $2 $3 $3
+$1 $0 $7 $7
+$1 $0 $1 $0 $1 $0
+$0 $8 $2 $6
+$0 $8 $2 $5
+$0 $6 $1 $6
+$0 $3 $2 $7
+$0 $2 $2 $5
+$0 $2 $2 $4
+$0 $0 $7 $0
+$0 $0 $1 $1
+} } i1o
+o6P
+o5G
+o4j
+o4H
+o4F ]
+o4E D5
+o4? *36
+o44 ss2 $0
+o3i
+o2t ^S
+o2L ]
+o2G D3
+o2F ]
+o1s
+o1i i0S
+o1O D2
+o0y y2
+o0y ,5
+o0k -2
+o0Z D2
+o0W $2 $1
+o0V *31
+o0V $3
+o0T $9
+o0R +4
+o0N $9
+o0M .1
+o0K $5 $6
+o0J ,2
+o0G $1 $8
+o0A i1C
+o0-
+l ] $u
+k ^S
+i8t o9e
+i7k i8i
+i7a o8n
+i6z D4
+i6o i7t
+i6e ,8
+i5s ,6
+i5p o6e
+i5a o3a
+i5a i6m i7a
+i5a $k
+i51 i61 i71
+i51 i60 o71
+i4y i5a
+i4t $5
+i4o u
+i4o i5m
+i4o i5g
+i4g i5e i6r
+i4e ,2
+i49 i59 ,6
+i49 i50 ,6
+i42 o50 i60 o76
+i3y o4l
+i3s i4e i5r
+i3o o5a
+i3o i4p
+i3m i4a i5s
+i3k -5
+i3i o4z
+i3i i4g
+i3h i4e
+i3e o5u
+i2z i3z
+i2r i3r
+i2p i3a
+i2l o3y
+i2f +4 o2i
+i2e o4o
+i2b o3y
+i2U u ]
+i2S E
+i1u D5
+i1o i2u
+i1i i2t
+i1i i2k D4
+i1h o2e
+i1e i2v
+i1e i2s
+i1c i2c
+i1a i2j
+c i4.
+c T7 i7_
+c $i $s
+c $b $1
+c $8 $7 $7
+c $5 $9 $4
+c $5 $5 $1
+c $4 $1 $2 $3
+c $3 $7 $6
+c $3 $5 $4
+c $3 $4 $6
+c $3 $0 $1 $0
+c $2 $1 $0 $8
+c $2 $0 $1 $4
+c $1 $9 $2 $1
+c $1 $2 $0 $0
+c $1 $0 $2 $6
+c $0 $8 $5
+c $0 $7 $1
+c $0 $6 $4
+c $0 $6 $1
+c $0 $6 $0 $7
+c $0 $5 $2 $0
+c $0 $5 $0 $7
+c $0 $4 $0 $4
+c $0 $3 $0 $5
+c $0 $3 $0 $2
+c $0 $0 $8
+c $0 $0 $3
+c $0 $0 $1 $0
+c $. $c $o $m
+^z ^e ^r ^a ^u ^j
+^y ^t ^r ^e
+^y ^t ^f ^a ^r ^c
+^y ^e ^n ^a ^l
+^y ^e ^l ^r ^a ^c
+^y ^e ^c ^a ^m
+^y ^b ^b ^u ^c
+^w ^s ^k
+^v ^b ^n ^m
+^u ^n ^a ^n
+^t ^e ^e ^f
+^t ^a ^l ^p ^s
+^s ^r ^e ^h ^t ^o ^r ^b
+^s ^r ^e ^h ^t ^n ^a ^p
+^s ^n ^e ^b ^u ^r
+^s ^i ^t ^r ^u ^k
+^s ^g ^n ^i ^k ^i ^v
+^s ^g ^e ^m
+^s ^e ^l ^d ^d ^u ^c
+^r ^o ^y ^a ^m
+^r ^o ^w ^s ^s ^a ^p
+^r ^e ^t ^t ^o ^p ^y ^r ^r ^a ^h
+^r ^e ^t ^a ^t
+^r ^e ^n ^n ^i ^w
+^r ^e ^h ^t ^a ^e ^w
+^r ^e ^d ^i ^r
+^r ^e ^b ^e ^w
+^o ^v ^e ^r
+^o ^t ^i ^s ^o
+^o ^t ^i ^h ^c
+^o ^t ^a ^g ^l ^e
+^o ^r ^r ^a ^c
+^o ^r ^e ^m ^o ^h
+^o ^l ^e ^l
+^o ^k ^i ^h ^c
+^o ^i ^c ^i ^r ^b ^a ^f
+^o ^d ^e ^d
+^n ^o ^s ^b ^o ^r
+^n ^o ^e ^l ^o ^p ^a ^n
+^n ^i ^x
+^n ^i ^l ^o ^i ^v
+^n ^i ^l ^e ^s
+^n ^a ^m ^r ^e ^d ^i ^p ^s
+^n ^a ^m ^a ^m
+^n ^a ^h ^k
+^m ^n ^b
+^m ^i ^m
+^l ^e ^d ^b ^a
+^l ^a ^t ^s ^i ^r ^c
+^l ^a ^m ^a ^k
+^k ^o *54
+^k ^c ^o ^l ^c
+^k ^a ^y
+^k ^a ^t
+^i ^t ^s ^i ^r ^c
+^i ^r ^e ^p
+^i ^l ^u
+^i ^l ^i
+^i *03
+^h ^t ^a ^c
+^h ^s ^i ^m
+^h ^s ^a ^n
+^h ^d ^j
+^h ^c ^e ^t ^i ^g ^o ^l
+^g ^u ^a
+^g ^n ^i ^z ^a ^l ^b
+^f ^s ^a
+^f ^l ^a ^r
+^f ^a ^l
+^e i3a
+^e ^t ^a ^g
+^e ^t ^a ^f
+^e ^s ^o ^n
+^e ^s ^i ^w
+^e ^r ^r ^o ^t
+^e ^n ^n ^e ^y ^e ^h ^c
+^e ^l ^o ^h ^s ^s ^a
+^e ^l ^e ^p
+^e ^h ^e ^h
+^e ^e ^z
+^e ^e ^l ^y ^a ^k
+^e ^d ^a ^f
+^e ^c ^i ^t ^s ^u ^j
+^e ^c ^a ^j
+^e ^b ^e ^o ^h ^p
+^e ^a ^j
+^d ^j ^d
+^d ^e ^c
+^d ^c ^m
+^c ^m ^d
+^c ^i ^t ^a ^t ^s
+^c -1
+^b ^r ^a ^b
+^b ^e ^f
+^b ^b ^a
+^a ^v ^l ^a
+^a ^s ^o ^p ^i ^r ^a ^m
+^a ^n ^n ^a ^v ^o ^i ^g
+^a ^n ^i ^m ^o ^r
+^a ^n ^i ^d ^e ^m
+^a ^m ^s
+^a ^l ^s
+^a ^j ^d
+^a ^i ^l ^a ^t ^i
+^a ^i ^c
+^a ^h ^k
+^a ^g ^e ^s
+^X ]
+^S C ^M
+^C o1a
+^B $1
+^A i1k
+^A ^A
+^9 $6
+^8 $7
+^6 ^0 ^0 ^2 ]
+] o8y
+] $1 o7m
+] $0
+[ o0Q
+[ +2
+[ $4 $4 $4
+[ $2 $0 $0 $6
+[ $1 $1 $1
+E i6l $1
+D8 o8e
+D8 ,8 +8
+D4 o5y
+D4 i6s
+D2 o5o
+D2 $5 $5 $5
+D1 i4e
+D1 D2 ^I
+.0 -2
+-7 o0d
+-7 i74
+-6 o5z
+-5 o2b D4
+-5 $1 $2 $3
+-3 D6
+-3 *64
+-2 i3b
+-1 ,2
++8 D4
++7 '9
++5 -4 +5
++4 .2
++3 ,5
++2 ,5
++2 +6 +6
++1 D5
++1 D2 ]
++0 i3k
++0 ^3
+*76 E $!
+*56 $1
+*54 o4q
+*52 $3
+*45 o3g
+*45 -7
+*43 o4l
+*41 ^j
+*40 *06
+*34 o2x
+*31 o2l D4
+*23 -4
+*17 '6
+*13 ^j
+*10 i1b
+*04 +6
+*02 D3 c
+'6 $k
+$o +4
+$k o7n
+$j $1 $2
+$i {
+$i *62
+$f $u $r
+$d $1 $1
+$a $c $a
+$_ $2 $0 $0 $7
+$O
+$L $P
+$@ $2 $3
+$9 Z1 +7
+$9 -6
+$7 i2r
+$6 $6 $8 $8
+$5 z1
+$5 o3t
+$5 o2x
+$5 *57
+$3 $3 $7 $7
+$3 $3 $4 $4
+$3 $3 $1 $0
+$2 $4 $!
+$2 $2 $1 $3
+$2 $1 $4 $4
+$2 $1 $2 $3
+$2 $0 $2 $4
+$1 $8 $8 $0
+$1 $8 $0 $7
+$1 $5 $9 $3
+$1 $5 $1 $6
+$1 $4 $2 $1
+$1 $3 $2 $3
+$1 $2 $8 $0
+$1 $1 $3 $4
+$0 Z4
+$0 $8 $1 $8
+$0 $7 $2 $4
+$0 $7 $1 $8
+$0 $6 $2 $9
+$0 $1 $3 $1
+$0 $0 $9 $9
+$! E
+} } } } } '5
+} *05
+{ o0D
+o4a i51 i62 i73 i84 o95
+o3y $2 $0 $0 $3
+o3y $1 $2 $3 $4
+o2e .3
+o2d ]
+o2Z D3
+o1q o3q
+o0w $1 $2 $3
+o0t i3o
+o0s .2
+o0k +2
+o0g $1 $2 $3 $4
+o0V $1 $3
+o0T $1 $9
+o0T $1 $1
+o0R o1A
+o0R $1 $9
+o0F $1 $1
+l i1l
+i91 iA2
+i8x
+i7t o8a
+i7I E
+i70 i80 i94
+i70 i80 i92
+i6o i7m
+i6l o7y
+i6k i7e
+i6i i7a
+i6f o7i
+i6S Z1 E
+i62 o70 i80 o91
+i5n i6d i7e
+i5e $e
+i57 $1
+i55 i60 i70
+i54 -6
+i4s o5y
+i4b o5y
+i4a o5z
+i46 i57 i68 o79
+i41 i52 i62 o73
+i3u +4
+i3s o5i
+i3r $5
+i3p o5o
+i3k k
+i3i o5e
+i3i o4r
+i3i o4o
+i3e o5o
+i3e i1a
+i31 o42 $3
+i2x i0a
+i2x +3
+i2v o3o
+i2v i3e
+i2u o4o
+i2s o4i
+i2r i3i
+i2p i3i
+i2p i3e i4r
+i2p +3
+i2i i3l
+i2a i3m
+i2T l
+i2K E
+i1o i2l i3l
+i1i i2r
+i1e i2s i3t
+i1a o4e
+i1a i2t i3e
+i1a i2n i3n
+i1. i3. o5.
+i0D ^H
+c i34
+c ^E
+c K ]
+c -8
+c '6 $4
+c $e $d
+c $5 $0 $5 $0
+c $4 $4 $7
+c $3 $6 $3
+c $3 $1 $0 $5
+c $2 $5 $0 $1
+c $2 $2 $1
+c $1 $9 $2 $0
+c $1 $0 $2 $9
+c $1 $0 $1 $7
+c $1 $0 $1 $5
+c $0 $7 $3
+c $0 $5 $4
+c $0 $4 $0 $8
+c $0 $2 $0 $5
+c $0 $0 $1 $1
+^y ^v ^a ^j
+^y ^r ^a ^d ^n ^e ^g ^e ^l
+^y ^n ^o ^h ^j
+^y ^l ^l ^i ^j
+^y ^l ^e ^g ^n ^a
+^y ^e ^t
+^y ^d ^a ^d
+^x ^i ^n ^o
+^x ^A
+^u ^r ^d ^n ^a
+^t ^t ^a ^c
+^s ^u ^t ^s ^u ^j
+^s ^r ^e ^t ^t ^u ^b
+^s ^o ^n ^i ^d
+^s ^e ^i ^l ^l ^i ^h ^p
+^s ^e ^d ^n ^e ^m
+^s ^a ^m ^o ^l
+^r ^i ^h ^s
+^r ^e ^t ^h ^g ^i ^f
+^r ^e ^s ^w ^o ^b
+^r ^e ^p ^m ^u ^b
+^r ^e ^l ^t ^u ^b
+^r ^a ^l ^u ^l ^e ^c
+^p ^m ^i ^h ^c
+^p ^O
+^o ^z ^o ^z
+^o ^v ^e ^k
+^o ^r ^o ^r
+^o ^r ^a ^g ^i ^f
+^o ^l ^r ^a ^m
+^o ^l ^e ^h ^c
+^o ^c ^s ^o ^r
+^n ^r ^a ^e ^l
+^n ^e ^l ^l ^u ^c
+^n ^a ^m ^e
+^m ^o ^l ^a ^h ^s
+^l ^y ^s
+^l ^o ^r
+^l ^l ^u ^b ^t ^i ^p
+^l ^l ^e ^m
+^l ^i ^c ^n ^e ^p
+^l ^a ^t ^r ^o ^m
+^k ^r ^o ^y
+^k ^a ^d
+^j o2y
+^i ^v ^a ^n
+^i ^t ^a
+^i ^l ^e ^b
+^i ^a ^r
+^i ^a ^h ^c
+^i ^P
+^h ^c ^t ^a ^w
+^h ^c ^r ^u ^h ^c
+^h ^c ^a ^r
+^g z2
+^g ^n ^e ^h ^c
+^g ^a ^l ^f
+^e ^v ^i ^l ^o
+^e ^t ^n ^a ^f ^e ^l ^e
+^e ^r ^i ^f ^t ^i ^p ^s
+^e ^r ^i
+^e ^n ^e ^b
+^e ^l ^d ^d ^i ^m
+^e ^l ^b ^a ^c
+^e ^d ^i ^s
+^e ^c ^a ^r
+^d ^n ^a ^m
+^d ^a ^h
+^c ^n ^u
+^c ^i ^h ^c
+^a ^t ^a ^p
+^a ^s ^e
+^a ^r ^a ^d
+^a ^n ^i ^m ^a
+^a ^m ^a ^k
+^a ^l ^o ^r ^o ^t ^o ^m
+^a ^k ^i ^n
+^a ^j ^n ^e ^b
+^a ^i ^s ^s ^e ^l ^a
+^a ^i ^n ^o ^t ^n ^a
+^a ^c ^i ^m
+^T ]
+^M D5
+^L D5
+^L D3
+^K -1
+^I D2
+^C o1H
+^B ^J
+^9 *14
+^6 ^5 ^4 ^3 ^2 ^1 D7
+T1 T4 T5
+T0 T1 T3 T4 T5
+E *78 *98
+D7 o7n
+D3 i4s
+D3 Y4
+D3 +5
+D2 $2 $3 $4
+D2 $1 $2 $2
+D1 $2 $2 $2
+D1 $2 $0 $0
+D1 $1 $1 $1
+D0 ^s ,3
+D0 E Z2
+C [ +6
+.2 D4
+-7 o5g
+-3 $4
+-3 $0 $1
+-1 r
+-0 ^5
++9 .8
++6 *54
++5 '8
++5 $e
++4 i44
++4 +5 +6
++3 i3d
++3 $1
++2 -7 -7
++2 +5 +2
++1 i2g
++0 ^d
++0 -3 -3
++0 +4 +6
++0 $3
+*86 *57
+*79 t *37
+*73 *02 o6k
+*58 ] {
+*56 ^l
+*53 o54
+*53 ]
+*52 z1
+*41 i68
+*40 [
+*40 E
+*35 *78 c
+*31 o3p *35
+*31 o3d
+*30 ,3
+*25 o2p
+*24 *70 ]
+*12 ^k
+*10 i2b
+*05 o5n
+*05 o52
+*05 o1z
+*02 *06
+'6 o3t
+'6 $2
+$i ^s
+$i -7
+$d *57
+$c +7
+$a $z $a
+$a $i $d
+$_ *68
+$G c
+$A D6
+$@ $9 $9
+$>
+$7 $3 $7 $3
+$6 i4s
+$5 $4 $6 $4
+$3 D8
+$3 $5 $1 $0
+$3 $3 $2 $1
+$2 $3 $2 $7
+$2 $1 $2 $8
+$1 $8 $2 $7
+$0 -5
+$0 $9 $1 $5
+$0 $8 $2 $2
+$0 $7 $2 $8
+$0 $6 $1 $9
+$0 $5 $2 $7
+$0 $2 $2 $1
+$0 $0 $5
+$/ $1 $2 $3
+} ^D
+smV
+o5I
+o5D ]
+o5B ]
+o4A
+o3S D4
+o2u
+o2W D3
+o2J D3
+o1p $1 $2 $3
+o0y o4z
+o0y $2 $3
+o0n $3 $2 $1
+o0Z $6
+o0Z $2 $1
+o0W $3
+o0W $!
+o0V +2
+o0U D2
+o0T $1 $2 $3 $4
+o0S *65
+o0O -1
+o0N $1 $5
+o0K $i
+o0J ]
+o0J $3 $4
+o0G o1O
+o0B $1 $2 $3 $4
+o0A o1J
+k ^R
+i9u
+i89 ,9
+i6u i7t
+i6t o7u
+i6l *13
+i6a i7m i8e
+i64 -7
+i5y D2
+i5r i6m
+i5r i6i o7a
+i5r i6d
+i5i i6o
+i5e i6r i7o
+i5a i7e
+i5?
+i57 $8
+i53 i60 i70
+i52 i60 ,7 o86
+i4r i5y
+i4o i5v
+i4i i5o
+i4e D1
+i4e +0
+i45 i54 i65 o74
+i41 i52 o61
+i4. i5. ,6
+i3o i4v
+i3i i4a i5n
+i3a o5u
+i3a o4z
+i3a i71
+i35 i40 ,5
+i2y o3d
+i2u i3l
+i2t i3h i4a
+i2o i3l
+i2k +4
+i2i o3a
+i2e o4a
+i2d o3y
+i2c i3h i4o
+i22 i30 i40 o53
+i1z ,2
+i1s i2h
+i1o i2t
+i1i i2p
+i1i i2n i3t
+i1i i2j
+i1e o3r
+i1a o3d
+i1a i2z
+i1M E
+c i8#
+c i3T
+c ^< $>
+c $7 $7 $5
+c $4 $6 $7
+c $3 $1 $1 $2
+c $3 $1 $1 $0
+c $2 $6 $2 $6
+c $2 $5 $1 $0
+c $2 $3 $1
+c $2 $3 $0 $9
+c $2 $1 $0 $9
+c $2 $1 $0 $5
+c $2 $1 $0 $2
+c $1 $9 $4 $3
+c $1 $9 $1 $0
+c $1 $2 $2 $4
+c $1 $2 $1 $4
+c $1 $0 $9 $0
+c $0 $9 $1 $2
+c $0 $7 $2
+c $0 $7 $0 $8
+c $0 $7 $0 $2
+c $0 $4 $5
+c $0 $4 $!
+^y ^r ^d ^n ^a
+^y ^r ^c ^r ^a ^f
+^y ^l ^l ^i ^d
+^y ^k ^r ^a ^h ^s
+^y ^f ^l ^o ^w
+^u ^r ^a ^g
+^t ^h ^g ^i ^l ^r ^a ^t ^s
+^s ^t ^b
+^s ^o ^o ^r
+^s ^n ^o ^c ^l ^a ^f
+^s ^j ^p
+^s ^i ^n ^e ^t
+^s ^e ^h ^g ^u ^h
+^s ^a ^d ^i ^n ^o ^e ^l
+^r ^o ^d ^u ^t
+^r ^e ^t ^a ^h
+^r ^e ^p ^p ^i ^k
+^r ^e ^p ^m ^u ^j
+^r ^e ^g ^g ^a ^w ^s
+^r ^a ^h ^a ^b
+^p ^e ^e ^r ^c
+^o ^t ^n ^o ^r ^o ^t
+^o ^t ^a ^h ^c
+^o ^n ^g ^a ^m
+^o ^n ^a ^i ^l ^i ^m ^e
+^o ^l ^e ^u ^b ^a
+^o ^f ^o ^f
+^n ^y ^l ^t ^i ^a ^k
+^n ^o ^m ^a
+^n ^o ^i ^p ^m ^a ^h ^c
+^n ^i ^k ^a
+^n ^i ^h ^t
+^n ^e ^m ^a
+^n ^e ^e ^l ^h ^t ^a ^k
+^n ^a ^w ^o ^r
+^m $1 $2 $3
+^l ^l ^a ^b ^t ^f ^o ^s
+^l ^a ^o ^c
+^k ^u ^k
+^k ^n ^e ^h
+^k ^j ^j
+^k ^i ^h ^c
+^k ^c ^u ^r ^t
+^i ^v ^e ^d
+^i ^m ^a ^g ^i ^n ^i ^h ^s
+^i ^l ^i ^m ^e
+^i ^k ^i ^t
+^i ^b ^u ^r
+^h ^a ^r
+^g ^p ^j
+^g ^n ^o ^k
+^g ^d ^a
+^g ^c ^m
+^g ^a ^l
+^e ^z ^e
+^e ^v ^i
+^e ^t ^s ^e ^l ^e ^c
+^e ^m ^i ^r ^p
+^e ^m ^a ^n ^y ^m
+^e ^m ^a ^k
+^e ^l ^b ^r ^a ^m
+^e ^i ^v ^o ^m
+^e ^i ^n ^n ^i ^v
+^e ^g ^a ^p
+^e ^d ^c ^b ^a
+^d ^l ^a ^r ^e ^g
+^d ^i ^a ^s
+^d ^e ^e ^r
+^d ^e ^d
+^c ^s ^a
+^b ^o ^o ^b
+^b ^e ^r
+^b ^a ^r ^a
+^b ^a ^d
+^b ^a ^b
+^a ^t ^r ^e ^b ^o ^r
+^a ^t ^o ^k
+^a ^t ^o ^j
+^a ^t ^i ^k
+^a ^r ^e ^g
+^a ^r ^a ^y ^a ^m
+^a ^o ^b
+^a ^n ^u ^t
+^a ^n ^i ^l ^e ^c
+^a ^m ^j
+^a ^l ^y ^k
+^a ^l ^y ^a
+^a ^l ^a ^g
+^a ^i ^l ^a
+^a ^b ^u ^b
+^_ ^3 ^2 ^1
+^T $1 $2 $3
+^S o1T
+^G o1h
+^G D5
+^3 ^2 ^1 o6a
+^2 ^9 ^9
+^2 ^3 ^4 o31
+^1 ^2 ^3 ^4
+^0 ^0 ^2 o36
+^0 ^0 ^2 o35
+^0 ^0 ^0 o30
+[ $2 $0 $0 $1
+T0 T6 T8
+T0 T1 T2 T4
+L1 .0
+D8 o6u
+D7 o7r
+D6 sbk o3l
+D6 $y
+D5 -5
+D4 $a $n
+D2 o5p
+D2 o4y
+D2 D3 ]
+D2 $0 $0 $3
+D1 o3a
+D1 i3n
+D1 D2 ]
+D1 $1 $2 $2 $7
+-7 -7 -7 -7
+-7 $a
+-5 i4_
+-5 *23
+-3 i4l
+-2 o5a
+-2 D5
+-2 $7
+-0 *52
++8 -9
++7 [
++7 +8 +8
++6 -7 -7
++5 i5H l
++5 -4 -4
++4 i4z
++2 o71
++0 i67
++0 i59
++0 ^r
++0 -3
++0 $0 $5
+*74 sds
+*62 -2
+*54 ^b
+*53 *46
+*46 o54
+*43 o0y
+*37 +3
+*34 .2
+*34 +3
+*34 $6
+*34 $0
+*26 -2 $5
+*20 o0W
+*14 r
+*13 i64
+*02 i2n
+'9 o7s
+'9 $r
+'8 i52
+'7 +5
+'7 $n
+'6 +4 c
+'6 $7
+'5 z1
+$l $o $x
+$h $1 $2 $3
+$g $1 $1
+$a $x $e
+$a $n $e
+$a $b $a
+$_ $5 $5
+$@ $1 $5
+$9 $8 $8 $9
+$9 $8 $7 $6 $5
+$8 $9 $1 $0
+$8 $0 $0 $8
+$7 $7 $7 $7 $7
+$5 *26
+$5 $9 $5 $9
+$4 i4s
+$4 i0p
+$4 $6 $8
+$3 -8
+$3 $5 $3 $5
+$2 $3 $8 $9
+$2 $3 $6 $9
+$2 $3 $2 $1
+$2 $3 $1 $4
+$2 $2 $7 $4
+$2 $2 $1 $5
+$2 $0 $2 $3
+$1 i6s
+$1 $9 $1 $3
+$1 $8 $0 $4
+$1 $7 $9 $0
+$1 $7 $7 $1
+$1 $5 $2 $3
+$1 $4 $2 $8
+$1 $3 $8 $9
+$1 $3 $2 $5
+$1 $2 $8 $1
+$1 $2 $4 $3
+$1 $2 $3 $2
+$1 $1 $7 $9
+$1 $0 $4 $7
+$0 $8 $3 $1
+$0 $8 $1 $7
+$0 $4 $2 $8
+$0 $2 $!
+$0 $1 $2 $8
+$0 $0 $8
+t ,3
+saA
+o6p o7R E
+o55 +6
+o4w $w
+o4V
+o4B
+o3x $1 $2 $3
+o2v $o
+o2A
+o1o $p
+o1e $y
+o0t $1 $2 $3
+o0T .2
+o0O D3
+o0K ,5
+o0J o1F
+o0J ,5
+o0H ,5
+o0H
+o0F o1A
+o0B ,6
+o0A o1R
+o0A o1M
+l ssd
+l ] $j
+k +1
+i95 -A
+i74 L7 L8
+i68
+i66
+i65
+i64 *75
+i62 i70 i81 i97
+i5o i6g
+i5e i72
+i5a i6n o7a
+i5D E -6
+i51 o62
+i4o *35
+i4i i5a
+i4a i5m o6a
+i41 i52 i62 o71
+i3v ]
+i3t i1r
+i3o o5o
+i3l o4y
+i3i o5o
+i3i i4a
+i3h i4u
+i3d o4y
+i3c i4k
+i2x T0
+i2r o4y
+i2r i3g
+i2n o4o
+i2m i3e i4r
+i2l $4
+i2i o3o
+i2h *35
+i2g D4
+i2a D4
+i22 i30 i40 o54
+i1y ]
+i1u o3s
+i1r i2o
+i1o o2p
+i1o i4o
+i1o i2k
+i1n ^h
+i1i o3n
+i1h o2y
+i1h i2o
+i1e i3d
+i1e i2r i3r
+i1e i1e
+i1e L2 L0
+i1a o3a
+i1a o2z
+i1a i3e
+i1a ,2
+i12
+d 'B c
+c si1 se3
+c i4j
+c i3_
+c T1 i1_
+c *97
+c '6 $5
+c $n $e
+c $8 $8 $8 $8
+c $8 $3 $4
+c $8 $0 $0 $0
+c $5 $7 $2
+c $5 $2 $2 $5
+c $4 $4 $3
+c $4 $3 $2
+c $3 $9 $9
+c $2 $2 $2 $2
+c $2 $2 $0 $3
+c $1 $9 $4 $7
+c $1 $9 $4 $2
+c $1 $9 $0 $3
+c $1 $2 $1 $5
+c $1 $2 $0 $7
+c $1 $1 $0 $0
+c $1 $0 $8 $0
+c $0 $9 $9
+c $0 $9 $0
+c $0 $8 $0 $2
+c $0 $6 $0 $3
+c $0 $5 $6
+c $0 $5 $0 $1
+c $0 $3 $0 $9
+c $0 $2 $0 $4
+c $0 $1 $2 $0
+c $0 $1 $1 $0
+c $0 $1 $0 $9
+c $0 $1 $0 $8
+c $0 $0 $1 $3
+^y ^u ^g ^l ^o ^o ^c
+^y ^t ^r
+^y ^o ^k
+^y ^o ^b ^y ^n ^n ^a ^d
+^y ^m ^m ^u ^g
+^y ^l ^n ^a ^m
+^y ^l ^l ^i ^g
+^y ^l ^h ^s ^a
+^y ^e ^s ^o ^r
+^y ^d ^o ^o ^g
+^w ^o ^c ^o ^o ^m
+^u ^r ^d ^n ^a ^x ^e ^l ^a
+^s ^v ^a ^c
+^s ^n ^i ^k ^s ^d ^e ^r
+^s ^k ^n ^u ^r ^t
+^s ^i ^v ^r ^a ^j
+^s ^i ^r ^o ^j
+^s ^e ^s ^m ^a ^r
+^s ^e ^s ^i ^l ^u
+^s ^a ^p ^a ^p
+^s ^a ^d ^n ^a ^p
+^r ^i ^m ^a ^d
+^r ^e ^y ^w ^a ^s
+^r ^e ^t ^s ^a
+^r ^e ^e ^m ^a ^s
+^r ^e ^d ^o ^p
+^r ^e ^c ^n ^a ^l
+^r ^e ^c ^a ^r
+^r ^a ^m ^a ^s
+^p ^o ^y
+^p ^m ^u ^h
+^o ^r ^i ^h ^s
+^o ^m ^a ^j
+^o ^k ^o ^h ^c
+^o ^i ^g ^e ^l ^o ^c
+^o ^h ^c ^n ^a ^u ^j
+^o ^h ^c ^i ^h ^c
+^o ^g ^n ^i ^p
+^o ^g ^n ^i ^m ^o ^d
+^o ^d ^b ^a
+^o ^c ^e ^n
+^n ^u ^y
+^n ^u ^p
+^n ^r ^u ^b ^u ^a
+^n ^o ^z ^a ^m ^a
+^n ^i ^e ^r
+^n ^a ^r ^i ^k
+^n ^a ^m ^e ^h ^t
+^m ^o ^h ^t
+^m ^j ^j
+^m ^i ^n
+^l ^r ^a
+^l ^o ^s ^i ^r ^a ^m
+^l ^e ^v
+^l ^a ^c ^i ^d ^a ^r
+^k ^n ^i ^t ^s
+^k ^m ^k
+^k ^j ^m
+^k ^e ^k
+^k ^c ^i ^r ^t
+^k -1
+^j ^m ^j
+^j $1 $2 $3
+^i ^y
+^i ^p ^a
+^i ^o ^n
+^i ^n ^o ^r
+^i ^n ^a ^l
+^i ^l ^o ^m
+^i ^l ^i ^p
+^i ^l ^a ^b
+^i ^k ^i ^h ^c
+^i ^g ^r ^o ^e ^g
+^i ^c ^a ^m
+^h ^s ^a ^m ^s
+^h ^m ^a ^i ^n
+^h ^j ^k
+^h ^c ^m
+^g ^u ^h ^t
+^g ^n ^i ^m
+^g ^n ^i ^b
+^g ^e ^d
+^f ^a ^c
+^e ^v ^u ^j
+^e ^v ^a ^c
+^e ^t ^i ^k
+^e ^t ^e ^l ^e ^d
+^e ^s ^p ^i ^l ^c ^e
+^e ^r ^o ^o ^m
+^e ^r ^a ^d
+^e ^n ^n ^a ^e ^j
+^e ^n ^i ^g ^a ^m ^i
+^e ^l ^p ^p ^a ^e ^n ^i ^p
+^e ^l ^d ^o ^o ^n
+^e ^k ^u ^n
+^e ^k ^e ^z
+^e ^k ^a ^h ^s
+^e ^i ^l ^l ^o ^m
+^e ^g ^n ^o ^p ^s
+^e ^f ^i ^n ^k
+^e ^f ^e ^f
+^e ^e ^t
+^d ^r ^i ^h ^t
+^d ^r ^a ^c ^u ^l ^a
+^d ^l ^a ^r ^e ^m ^e
+^c ^n ^i
+^c ^l ^a
+^b ^j ^c
+^b ^e ^j
+^a ^y ^a ^l ^p
+^a ^t ^i ^t ^a ^g
+^a ^t ^i ^t
+^a ^t ^i ^r ^a ^g ^r ^a ^m
+^a ^r ^i ^e ^r ^r ^e ^f
+^a ^r ^a ^f
+^a ^n ^e ^r ^o ^m
+^a ^m ^l ^e ^s
+^a ^k ^s ^l ^o ^p
+^a ^k ^i ^p
+^a ^k ^i ^a ^l
+^a ^h ^c ^a ^s
+^a ^b ^c
+^a ^G
+^T o1R
+^O
+^M *13
+^L $1
+^K D4
+^G $1
+^E +1
+^C D5
+^7 ^5 ^3 ^1 o49
+^1 *36
+] ] $i $e
+[ i2y c
+[ i2c E
+D7 o5v
+D6 o7i
+D6 o3g
+D6 ]
+D5 i3o -3
+D3 o3F
+D3 ^#
+D2 o4a
+D2 o3i
+D2 RB ,6
+D2 +3
+D2 $r $o
+D1 D3 ]
+D1 .3
+D1 +3
+D1 +0
+D1 $1 $1 $2 $2
+C T1
+@l i0n t
+-5 o0r
+-5 $2
+-3 o1b
+-3 $9
+-2 o5c
+-2 *05
+-1 i0g
+-1 .3
+-0 o1j
+-0 ^g *02
++9 +8
++7 o6_
++7 ^b
++4 o0M
++2 $1
++1 z1 t
++1 *45
++0 $1 $6
+*9A s1c
+*84 ^s '8
+*76 s17
+*76 +8
+*64 D7 iA8
+*64
+*63 slp
+*46 -7
+*45 o69
+*43 z1
+*43 +7
+*42 ^g
+*40 y2
+*40 D4
+*32 y2
+*32 k i0s
+*32 c ^3
+*32 Y2
+*31 o3j
+*31 '8
+*30 o2y
+*25 $7
+*23 i4n
+*23 $1 $2 $3
+*21 i2d
+*20 o6n
+*20 o0g
+*05 o4i
+*04 ^9
+*03 o3w
+'9 D4
+'9 *53
+'6 $l
+'5 i3r
+'2 p2
+$y t
+$l $a $p
+$e $t $a
+$a $t $a
+$a $h $a
+$a $1 $0
+$_ $7 $7 $7
+$J $J
+$9 $0 $0 $2
+$8 $7 $6 $5
+$6 *57
+$5 $7 $5 $7
+$4 i5s
+$4 $5 $6 $7 $8 $9
+$3 *57
+$3 $3 $6 $6
+$3 $2 $2 $3
+$2 $5 $0 $0
+$2 $1 $3 $5
+$1 ,7
+$1 $8 $1 $9
+$1 $4 $!
+$1 $0 $9 $7
+$1 $0 $7 $9
+$1 $0 $5 $0
+$0 $7 $2 $1
+$0 $6 $2 $4
+$0 $5 $2 $4
+$0 $3 $2 $2
+$0 $2 $1 $8
+$0 $1 $9 $2
+$0 $1 $2 $6
+$0 $1 $2 $2
+$0 $1 $1 $6
+$0 $1 $1 $4
+$0 $0 $1 $0
+{ ^d
+{ $0
+o5V
+o4Z
+o3a
+o3N ]
+o3H
+o1H D2
+o0y i2i
+o0k $2 $0 $0 $5
+o0W $2 $3
+o0V $2 $1
+o0T $1 $0 $1
+o0S ,3
+o0S *34
+o0Q D2
+o0N $1 $6
+o0K .5
+o0K $4 $5
+o0J $5 $6
+o0E o1S
+o0A .2
+l ,2 y2
+i6p i7e
+i6p i7a
+i6o $1
+i6n i7i
+i6l i7l o8a
+i6i i7o
+i62 i70 i80
+i60 ,7 ,8
+i5a i6y
+i5a i6m i7e
+i55 i66 i77
+i52 i60 i70 o84
+i52 i60 ,7 o83
+i52 i60 ,7 o82
+i52 +6
+i50 i60 i70
+i4u *25
+i4l i5e i6s
+i4a o6a
+i4a i5b o6i
+i44 i54 i65 ,7
+i44 i54 ,6 ,7
+i44 i53 i62
+i3y o4n
+i3y +4
+i3s $4
+i3o o5i
+i3m i4e i5r
+i3m *14
+i3i i4d
+i3d i4y
+i3a i4m i5e
+i3K l st1
+i2z *34
+i2r o0S
+i2o i3m
+i2n o4i
+i2l i3l
+i2i i3k
+i2i i3d
+i2h
+i2a i3p
+i1u i2z
+i1k o2y
+i1i i2s i3t
+i1e o3w
+i12 i23 i34 i45 i56 o67
+i0I ]
+c o4V
+c ^3 ^0 ^0 ^2
+c $9 $8 $7 $6
+c $6 $7 $0
+c $3 $4 $5 $6
+c $3 $2 $1 $0
+c $2 $1 $2 $3
+c $2 $1 $0 $7
+c $1 $9 $4 $9
+c $1 $9 $1 $1
+c $1 $4 $1 $2
+c $1 $2 $0 $1
+c $1 $1 $2 $1
+c $1 $1 $1 $2
+c $1 $0 $2 $3
+c $1 $0 $1 $8
+c $0 $7 $5
+c $0 $7 $0 $7
+c $0 $6 $8
+c $0 $5 $1 $2
+^y ^t ^t ^o ^h
+^y ^t ^i ^c ^i ^l ^e ^f
+^y ^r ^e ^f ^f ^e ^j
+^y ^p ^p ^i ^t
+^y ^p ^p ^a ^l ^s
+^y ^m ^a ^c
+^y ^e ^n ^o ^m ^g
+^y ^e ^l ^a ^k
+^y ^b ^o ^o ^b
+^y ^b ^b ^i ^g
+^t ^o ^o ^t
+^s ^x ^e ^l ^a
+^s ^u ^m ^e ^r
+^s ^t ^o ^i ^r ^t ^a ^p
+^s ^s ^j
+^s ^r ^e ^m ^a ^g
+^s ^n ^i ^u ^g ^n ^e ^p
+^s ^i ^d ^r ^a ^t
+^s ^e ^t ^r ^o ^c
+^s ^e ^s ^s ^i ^k
+^s ^e ^i ^b ^o ^o ^b
+^s ^e ^c ^n ^i ^r ^p
+^r ^r ^a ^t ^s
+^r ^e ^l ^d ^n ^a ^h ^c
+^r ^e ^i ^d ^i ^d
+^r ^e ^g ^r ^a ^h ^c
+^p ^p ^p
+^p ^e ^h ^s
+^o ^t ^i ^d
+^o ^r ^a ^l ^c
+^o ^o ^o
+^o ^n ^i ^r ^a ^m
+^o ^n ^a ^i ^t ^s ^i ^r ^c
+^o ^l ^l ^e ^c ^r ^a ^m
+^o ^l ^i ^p
+^o ^i ^l ^u ^t
+^o ^h ^c ^o
+^o ^c ^n ^o ^r ^b
+^o ^b ^m ^u ^d
+^n ^y ^l ^e ^t ^a ^k
+^n ^o ^o ^t ^r ^a ^c
+^n ^o ^g ^e ^r ^o
+^n ^n ^i ^l
+^n ^n ^a ^m
+^n ^e ^l ^a ^v
+^n ^a ^v ^o ^n ^o ^d
+^n ^a ^i ^l ^l ^i ^w
+^m ^o ^p
+^l ^l ^o ^d
+^l ^i ^a ^g
+^l ^e ^z
+^l ^a ^o ^g
+^l ^a ^g ^e ^l
+^k ^r ^e ^j
+^k ^r ^a ^p ^s
+^k ^o ^r
+^k ^i ^a ^m
+^i ^t ^e ^l
+^i ^r ^b ^a ^s
+^i ^r ^a ^d
+^i ^p ^i ^h ^c
+^i ^n ^a ^h
+^i ^l ^a ^l
+^i ^b ^b ^a
+^i ^a ^h ^i ^m
+^i ^T
+^i ^K
+^h ^t ^a ^k
+^h ^t ^a ^e ^h
+^h ^n ^i ^m
+^h ^c ^t ^u ^b
+^h ^a ^n ^n ^a ^v ^a ^s
+^h ^a ^l
+^g ^r ^u ^b ^m ^a ^h
+^g ^o ^d ^d ^a ^m
+^g ^n ^i ^n ^t ^h ^g ^i ^l
+^g ^n ^a ^h ^c
+^g ^n ^a ^b ^g ^i ^b
+^g ^m ^j
+^g ^i ^s
+^f ^a ^m
+^e i3r
+^e ^y ^b
+^e ^t ^a ^e ^r ^c
+^e ^s ^l ^i
+^e ^r ^i ^p ^s ^a
+^e ^o ^h
+^e ^n ^i ^l ^u ^a ^p
+^e ^l ^g ^a ^e ^b
+^e ^l ^e ^i ^r ^b ^a ^g
+^e ^i ^x ^e ^l
+^e ^i ^n ^o ^e ^l
+^e ^i ^n ^a ^d
+^e ^i ^g ^g ^a
+^e ^b ^u ^t ^u ^o ^y
+^e $1 $2
+^d ^r ^u ^t
+^d ^i ^p ^a ^r
+^d ^h ^o ^m
+^d ^e ^n
+^d ^d ^e
+^d ^b ^a
+^d ^a ^e ^r ^b
+^c ^a ^p
+^b o3a
+^b ^j ^j
+^b ^i ^l
+^b ^c ^m
+^a ^t ^e ^i ^l ^u ^j
+^a ^s ^o ^m ^r ^e ^h
+^a ^r ^z ^e
+^a ^r ^o ^s
+^a ^r ^a ^z
+^a ^n ^o ^z ^i ^r ^a
+^a ^n ^o ^z
+^a ^n ^i ^l ^e ^g ^n ^a
+^a ^n ^a ^y
+^a ^n ^a ^s ^u ^s
+^a ^m ^i ^n ^a
+^a ^l T2
+^a ^h ^s ^i ^l ^a
+^a ^h ^a ^h ^a ^h
+^a ^b ^u ^t
+^F -1
+^A $A
+^4 ^5 o23 r
+^4 ^3 ^2 ^1 D6
+^4 ^3 ^2 ^1 -4
+^3 ^2 ^1 o71 i82 o93
+^2 ^3 ^3 ^2 ^1 o51
+^1 ^1 o21 r
+] ] ] c
+] ] $1 $2
+] $3 ,2
+Z3 E .5
+T6 T7
+T2 ^I sY|
+T0 T6 T1
+K i2y
+D9 ,9
+D8 o8s
+D5 $i
+D4 o5i
+D4 -4
+D3 $1 $2 $3 $4
+D2 o51
+D2 i5i
+D2 +2
+D2 *54
+D1 $_
+-A +9
+-4 Y2
+-4 -5 -5
+-3 $4 Y1
+-1 z1
+-1 ^n
+-0 i3j
+-0 Z2
+-0 $3 $2 $1
++7 o6n
++7 ^w
++5 ] i3x
++5 $1
++2 $1 $2
++1 i2p
++0 i3b
++0 $1 $5
+*74 *45
+*65 o72
+*62 o2s
+*62 +2
+*59 *02 o0R
+*54 o3h
+*47 *76
+*43 K *35
+*30 Y2
+*26 K
+*17
+*14 o5z
+*14 *27 ]
+*07 D2
+*05 D5
+*02 ^s *24
+'9 i8e
+'8 o7a
+'8 o6u
+'8 $h
+'6 i4p
+$j Z1 s84
+$h $1 $2
+$g $1 $2 $3
+$e o0p
+$e *97 +6
+$e $9
+$a $r $y
+$_ $1 $2 $3 $4
+$L o1n }
+$@ $9
+$9 i55
+$7 '6 $t
+$7 $8 $9 $4 $5 $6
+$7 $7 $4 $4
+$7 $5 $7 $5
+$7 $5
+$4 -7
+$4 $5 $7 $8
+$4 $5 $!
+$4 $1 $1 $4
+$3 $5 $2 $4
+$3 $1 $2 $5
+$2 {
+$2 $4 $3 $6
+$2 $1 $3 $2
+$1 $8 $0 $0
+$1 $6 $2 $5
+$1 $6 $1 $7
+$1 $6 $1 $4
+$1 $4 $7 $2
+$1 $4 $2 $3
+$1 $3 $2 $8
+$1 $2 $4 $7
+$1 $2 $3 $a $b $c
+$1 $1 $5 $5
+$0 $8 $1 $9
+$0 $6 $1 $5
+$0 $6 $!
+$0 $5 $2 $3
+$. $2 $0
+s`Q '5 ,2
+o6R
+o6G
+o4s ,8
+o4n
+o3a $p
+o2k $2 $0 $0 $4
+o0y i4i
+o0o o3o
+o0k $2 $0 $0 $3
+o0j $1 $2 $3 $4
+o0c $2 $0 $0 $3
+o0Z $0 $8
+o0X D1
+o0R $1 $1
+o0R
+o0N $1 $8
+o0M o2K
+o0K $9 $7
+o0K $2 $0 $0 $0
+o0G o1A
+o0C .3
+l $1 $2 $3
+l $1 $2
+i80 i90 iA3
+i7o i8o
+i6t i7y
+i6i i7e
+i62 i70 ,8 o95
+i5x *76
+i5r i6t
+i5o o6m
+i5g ,6
+i5c o6e
+i5a o6m
+i5a i6m o7a
+i4s Z1 c
+i4r ,5
+i4i *64
+i4a i5r o6a
+i4a ,5
+i4P c
+i45 i50 ,6
+i3z i4y
+i3y D5
+i3o y2
+i3o i4d
+i3e o4y
+i3a o5o
+i38 i48 ,5
+i2w i3e
+i2s D4
+i2r o4o
+i2r i3t
+i2n i3y
+i2n i3n
+i2l i3e i4n
+i2k +3
+i2e o3z
+i2a o3y
+i1i i2l i3l
+i1e o2y
+i1a o2y
+i1a i72
+i1a i2m i3a
+i1.
+f '8 i5m
+c *52 +0
+c $x $1
+c $b $o $y
+c $2 $5 $1 $1
+c $2 $4 $!
+c $2 $2 $0 $5
+c $1 $9 $4 $6
+c $1 $5 $0 $0
+c $1 $2 $3 $4 $5 $6 $7 $8 $9
+c $1 $2 $0 $4
+c $1 $1 $2 $3
+c $1 $1 $0 $1
+c $1 $0 $8 $8
+c $0 $7 $0 $4
+c $0 $7 $0 $3
+c $0 $5 $1 $1
+c $0 $4 $0 $3
+c $0 $3 $0 $8
+c $0 $0 $0 $1
+c $# $2
+^z ^n ^a ^l
+^z ^e ^r ^a ^u ^s
+^y ^t ^t ^a ^k
+^y ^n ^a ^v
+^y ^l ^l ^a ^c
+^y ^k ^i ^n
+^w ^e ^b
+^u ^y ^t ^r ^e ^w ^q
+^t ^y ^u ^i ^o ^p
+^t ^e ^m ^a ^s
+^t ^d ^d
+^s ^u ^o ^i ^r ^u ^f
+^s ^u ^m ^a ^s
+^s ^p ^o ^o ^p
+^s ^p ^o ^o ^h
+^s ^n ^i ^h ^p ^l ^o ^d
+^s ^n ^e ^k ^c ^i ^h ^c
+^s ^e ^t ^n ^o ^m
+^s ^e ^t ^a ^r ^i ^p
+^s ^e ^l ^f ^f ^a ^w
+^s ^a ^s ^a
+^s ^a ^l ^o ^l
+^s ^a ^j ^o ^r
+^r ^r ^r
+^r ^o ^t ^c ^e ^v
+^r ^o ^m ^r ^a
+^r ^e ^t ^s ^i ^w ^t
+^r ^e ^t ^s ^b ^e ^w
+^r ^e ^t ^a ^m
+^r ^e ^p ^e ^e ^k
+^r ^e ^m ^l ^a ^p
+^r ^e ^b ^m ^i ^k
+^p ^j ^j
+^p ^a ^y
+^o ^r ^i ^a ^c
+^o ^r ^e ^w
+^o ^r ^e ^m ^o ^r
+^o ^n ^y ^r
+^o ^l ^u ^m ^o ^r
+^o ^l ^u ^a ^s
+^o ^j ^e ^n ^o ^c
+^o ^h ^c ^u ^h ^c
+^o ^g ^n ^i ^m ^a ^l ^f
+^o ^c ^i ^v
+^n ^y ^r ^b
+^n ^o ^t ^t ^u ^b
+^n ^o ^s ^y ^r ^b
+^n ^n ^y ^l ^f
+^n ^n ^a ^h
+^n ^i ^u ^q
+^n ^e ^l ^a
+^n ^e ^g ^a ^h
+^n ^a ^m ^l ^o ^o ^c
+^n ^a ^m ^e ^r ^i ^f
+^n ^a ^i ^d ^r ^a ^u ^g
+^n ^a ^g ^i ^h ^c ^i ^m
+^m ^s ^m
+^m ^o ^d ^s ^i ^w
+^m ^i ^h ^a ^r ^b ^i
+^l ^y ^m
+^l ^o ^t
+^l ^l ^u ^b ^d ^e ^r
+^l ^e ^j
+^l ^a ^l ^i ^b
+^l ^C
+^k ^u ^m
+^k ^r ^o ^d
+^k ^r ^d
+^k ^l ^m
+^k ^c ^i ^r ^e ^v ^a ^m
+^k ,7 .1
+^i ^w ^e ^d
+^i ^s ^o ^r
+^i ^r ^i ^k
+^i ^o ^h ^c
+^i ^h ^s ^a
+^h ^i ^t ^a ^f
+^h ^a ^k
+^g ^n ^i ^t ^n ^u ^h
+^g ^n ^i ^h ^s ^i ^f
+^g ^a ^s
+^g ^a ^c
+^f ^f ^f
+^f ^c ^m
+^e i3s
+^e ^v ^i ^g
+^e ^t ^e ^t
+^e ^n ^i ^x ^a ^m
+^e ^n ^i ^n ^a ^j
+^e ^n ^e ^n
+^e ^n ^e ^l ^r ^a ^m
+^e ^n ^e
+^e ^n ^a ^n ^a ^b
+^e ^m ^a ^n
+^e ^l ^l ^i ^v
+^e ^l ^l ^i ^m
+^e ^l ^l ^e ^i ^r ^b ^a ^g
+^e ^l ^e ^m
+^e ^k ^e ^k
+^e ^i ^z ^n ^e ^k
+^e ^i ^l ^o ^j
+^e ^i ^l ^l ^a ^c
+^e ^i ^h ^c ^i ^r
+^e ^e ^l ^h ^s ^a
+^e ^c ^i ^n ^a ^j
+^e ^a ^m ^a ^m
+^c ^j ^c
+^c ^a ^s ^s ^i
+^b o2y
+^b ^v ^c
+^b ^b ^u ^b
+^a ^y ^n ^e ^k
+^a ^r ^i ^m ^a
+^a ^n ^i ^l ^o ^p
+^a ^m ^t ^a ^f
+^a ^m ^a ^l
+^a ^m ^a ^g
+^a ^l ^r ^e ^p
+^a ^l ^a ^p
+^a ^k ^o ^m
+^a ^h ^c ^a ^h ^c
+^a ^b ^o ^b
+^T o1H
+^K D3
+^J D2 D3
+^G D2
+^E i1r
+^D i1d
+^D D5
+^C i1c
+^C D3
+^A $7
+^0 ^2 $0 $3
+^0 ^1 ^0 ^1
+[ ^g '7
+[ -0 T0
+D6 o2w
+D5 o6o
+D5 $1 $2 $3 $4
+D3 y3 c
+D3 o4y
+D3 $i
+D3 $2 $0 $0 $6
+D2 $1 $9 $9 $9
+D1 i2t
+D1 i2c
+D1 $i
+D1 $2 $0 $0 $7
+D1 $1 $0 $0 $4
+.0 *20
+-8 $1
+-7 o6.
+-6 o5x
+-4 -7
+-2 o3j
+-2 o0G
+-2 o0D
+-0 +4
+-0 $5
++8 D3
++7 r [
++7 -8
++7 -2
++6 +7 +6
++5 o4_
++5 [
++5 +5 -6
++4 o54
++4 i75
++4 i5p
++4 +5 +5
++4 *75
++0 i3g
++0 Y2 *73
++0 $1 o2k
+*8B o3_ K
+*71 '7
+*67 K
+*67 *85
+*65 $4 $0
+*64 +0
+*63 .2
+*5B i7i '9
+*53 smb
+*43 o2o
+*42 z1
+*36 ^B l
+*36 D5
+*32 +A z1
+*31 i4d
+*27 D2
+*26 ^f
+*26 +4 z1
+*23 Z1 .3
+*21 o61
+*20 i2s
+*20 Z2
+*17 r
+*16 ]
+*13 z1 *16
+*13 i55
+*13 ^8
+*07 *34
+*05 o0r
+*04 sry ]
+*03 *47
+'B *97
+'A D7
+'3 t q
+$s $u $p
+$f @t
+$d i4s
+$_ $3 $0
+$J $B
+$9 $9 $8 $9
+$9 $5 $0 $0
+$9 $0 $0 $9
+$7 snm
+$7 i82
+$7 $7 $1 $1
+$7 $6 $7 $6
+$5 o2a
+$5 $5 $2 $5
+$4 $2 $3 $1
+$4 $1 $2 $0
+$3 o6z
+$3 $6 $9 $0
+$3 $1 $0 $9
+$2 $4 $4 $2
+$2 $4 $2 $8
+$2 $2 $1 $7
+$2 $1 $5 $0
+$2 $1 $2 $4
+$1 o0s +4
+$1 i2i
+$1 $8 $2 $3
+$1 $7 $1 $9
+$1 $6 $0 $0
+$1 $5 $2 $4
+$1 $3 $2 $6
+$1 $2 $9 $8
+$1 $2 $1 $2 $1 $2
+$0 $7 $2 $6
+$0 $7 $2 $0
+$0 $7 $1 $5
+$0 $6 $2 $5
+$0 $5 $1 $7
+$0 $4 $2 $9
+$0 $0 $1 $2
+t y2 *42
+o69
+o40
+o3P
+o3O
+o2B sxr l
+o1S D2
+o1L
+o1B
+o0s $o
+o0r $o
+o0n i3o
+o0g $2 $0 $0 $2
+o0Y D4
+o0V $1 $1
+o0U D3
+o0T +4
+o0K *14
+o0K $3 $2 $1
+o0K $2 $0 $0 $8
+o0K $2 $0 $0 $7
+o0J -1
+o0C o4C
+o0B i4y
+o0A ,4
+k o0e
+i82 o90 iA0 oB4
+i7t i8o
+i7Z c
+i6r i7d
+i6p i7o
+i6k o7e
+i6i ]
+i6J
+i5t i6a i7r
+i5r i6y
+i5a o2r
+i52 i60 i70 i82
+i4y *20
+i4r
+i4d $a 'B
+i4a o5y
+i45 Z1
+i43 i53 i64 ,7
+i42 i50 ,6 o78
+i40 i54 i60 o75
+i3l i4o i5n
+i3i i4p
+i3a o5i
+i3a $a $1
+i3K T0
+i35 ,4
+i2u *54
+i2r i3r i4o
+i2o i3r
+i2j o4e
+i2j ^a
+i2e o3y
+i2a i3n i4g
+i2A [ {
+i1y D4
+i1o o5a
+i1o o3h
+i1o -4
+i1l o2y
+i1l i2i
+i1l i2a i3n
+i1l i2a
+i1i o2o
+i1a o5i
+i1a i2r i3l
+i1a i2n i3s
+c o7r
+c o7M
+c i68
+c i6-
+c i4u
+c i4R
+c d 'B
+c D2 ]
+c $e $s
+c $7 $8 $9 $0
+c $6 $7 $8 $9
+c $3 $0 $3 $0
+c $2 $4 $1 $1
+c $2 $1 $1
+c $1 $8 $1 $9
+c $1 $6 $1 $7
+c $1 $3 $1 $0
+c $1 $2 $8 $9
+c $1 $2 $0 $3
+c $1 $1 $3 $0
+c $1 $0 $8 $1
+c $1 $0 $2 $2
+c $0 $9 $0 $3
+c $0 $7 $6
+c $0 $6 $0 $4
+c $0 $5 $0 $4
+c $0 $5 $0
+c $0 $4 $1 $0
+c $0 $4 $0 $9
+c $0 $1 $2
+c $0 $1 $0 $2
+c $0 $0 $6
+^y ^l ^l ^a ^t
+^y ^l ^d ^n ^e ^i ^r ^f
+^y ^l ^a ^l
+^y ^k ^y ^k
+^y ^k ^c ^i ^h ^c
+^y ^e ^l ^i ^a ^k
+^x ^o ^x
+^x ^o ^n ^n ^e ^l
+^x ^i ^r ^b
+^t ^n ^m ^t
+^t ^i ^r ^k
+^s ^t ^a ^n
+^s ^o ^c ^o ^c
+^s ^b ^o ^o ^b
+^r ^o ^t ^a ^d ^e ^r ^p
+^r ^e ^t ^s ^p ^i ^h
+^r ^e ^t ^e ^i ^p
+^r ^e ^d ^o ^j
+^r ^a ^z ^e ^c
+^o ^r ^j
+^o ^r ^i ^j
+^o ^p ^e ^p
+^o ^m ^l ^a ^s
+^o ^g ^n ^o ^p
+^n ^r ^e
+^n ^o ^s ^t ^a ^w
+^n ^o ^l ^o ^c
+^n ^e ^y
+^n ^e ^m ^x
+^n ^e ^l ^l ^e ^h
+^n ^e ^e ^w ^o ^l ^l ^a ^h
+^n ^a ^y ^r ^a
+^n ^a ^w ^i
+^n ^a ^u ^q
+^n ^a ^t ^l ^u ^s
+^n ^a ^m ^l ^i ^l
+^n ^a ^m ^d ^a ^m
+^n ^a ^m ^a ^g ^e ^m
+^n ^a ^h ^g ^e ^m
+^n ^a ^e ^l
+^m ^n ^a
+^m ^a ^r ^t
+^l ^s ^a
+^l ^l ^a ^i ^n
+^l ^a ^t ^r ^o ^p
+^k ^r ^m
+^k ^o ^t
+^k ^a ^h
+^i i0N
+^i ^v ^l ^i ^s
+^i ^s ^o ^j
+^i ^r ^o ^n
+^i ^n ^n ^e ^b
+^i ^n ^a ^m ^r ^a
+^i ^l ^i ^m ^a ^f
+^i ^l ^e ^g ^n ^a
+^i ^l ^a ^t
+^i ^k ^c ^i ^n
+^i ^h ^s ^a ^k ^a ^k
+^i ^d ^a ^h
+^i ^A
+^h ^o ^o ^p
+^h ^j ^d
+^h ^a ^y ^i ^l ^a ^a
+^h ^a ^i ^s ^o ^j
+^h ^A
+^g ^r ^m
+^g ^n ^o ^w
+^g ^n ^i ^m ^a ^g
+^g ^n ^i ^c ^a ^r
+^g ^a ^t
+^f ^e ^d ^c ^b ^a
+^f ^a ^j
+^e i2i
+^e ^z ^a ^h
+^e ^t ^o ^y ^o ^c
+^e ^t ^a ^m ^o ^t
+^e ^t ^a
+^e ^r ^o ^f ^e ^b
+^e ^n ^o ^t
+^e ^n ^i ^h ^c ^a ^m
+^e ^i ^n ^r ^e ^b
+^e ^i ^n ^n ^o ^c
+^e ^i ^m
+^e ^g ^r ^e ^s
+^e ^c ^n ^e ^r ^w ^a ^l
+^e ^c ^i ^r ^u ^a ^m
+^d ^r ^o ^j
+^d ^o ^r ^t ^o ^h
+^d ^l ^a
+^d ^e ^z
+^d ^d ^a ^m
+^d ^a ^f
+^d ^a ^d ^m ^o ^m
+^c ^x ^z ^d ^s ^a ^e ^w ^q
+^c ^o ^h ^c
+^c ^m ^m
+^b ^a ^n
+^a i3a
+^a ^r ^o ^l
+^a ^n ^a ^i ^t ^a ^t
+^a ^m ^m ^e ^j
+^a ^m ^a ^y
+^a ^l ^o ^k ^i ^n
+^a ^l ^a ^h
+^a ^g ^a ^s
+^a ^c ^m
+^a ^b ^u ^j ^u ^j
+^a ^F
+^S i1r
+^K +1
+^E $1
+^C ^D
+^A D7
+^9 $4
+^9 $2
+^' *04 o4k
+] ^R
+] $4 *57
+[ i0s y2
+E i5T
+E $l $e
+E $W
+D9 $1
+D6 .6
+D4 o5u
+D4 o4M
+D4 $y
+D3 svy s94
+D3 $o $o
+D2 o3a
+D2 i3l
+D2 $2 $4 $6 $8
+D2 $1 $0 $1
+D1 $4 $5 $4 $5
+D1 $4 $4 $4
+D1 $1 $9 $9 $9
+.0 ^w
+-7 -8
+-6 [
+-5 }
+-4 i3d ]
+-4 $1 $2
+-2 z1 Z1
+-1 $7
+-0 o4a
+-0 i2t
++9 +9 +9
++9 $1
++8 -6
++7 D8
++7 +7 +7
++6 o77
++6 -5 -5
++6 $p
++4 i4b
++3 Y2
++2 i2d
++2 .4
+*75 @? '7
+*65 o1u
+*65 i66
+*65 $n
+*64 o66
+*62 o2k
+*57 o5m
+*56 *76
+*48 '6 +5
+*46 '6
+*42 $s
+*36 o55
+*34 i5v
+*30 i3i
+*24 i12
+*23 o3q
+*20 s29
+*20 .2
+*15 d '3 p1
+*04 *17
+'8 ^a
+'8 D4 +6
+'7 *46
+'5 $r
+'4 z2
+'3 t
+$h $u $b
+$e $0 $1
+$c $h $i $n
+$c $1 $2
+$a $f $t
+$H $D
+$@ c *86
+$9 $7 $9 $7
+$9 $5
+$8 +0 *43
+$7 $9 $7 $9
+$6 $5 $4 $3
+$6 $0 $6 $0
+$5 o5l
+$5 i42
+$5 D8
+$5 $4 $3 $2
+$4 o57
+$4 +8
+$4 $4 $0 $0
+$3 $3 $6 $9
+$3 $2 $0 $0
+$2 $6 $0 $0
+$2 $5 $2 $6
+$2 $3 $4 $2
+$2 $2 $3 $5
+$2 $1 $1 $8
+$2 $1 $1 $7
+$1 *74
+$1 $9 $2 $4
+$1 $7 $2 $5
+$1 $4 $1 $8
+$1 $3 $2 $9
+$1 $3 $1 $5
+$0 seu
+$0 $7 $3 $1
+$0 $6 $3 $0
+$0 $6 $2 $7
+$0 $2 $2 $7
+$0 $0 $7 $8
+$$ $1 $2 $3
+} i0S
+u ^x $x
+o5d
+o5P
+o55
+o4H ]
+o4B ]
+o3G ]
+o3D ]
+o1v $1 $2 $3
+o1e .2
+o1A
+o0t i3y
+o0t '7
+o0p $i
+o0k $2 $0 $0 $4
+o0Z $7
+o0Q
+o0L i1L
+o0K +1
+o0G ,4
+o0A o1K
+k sob o1a
+k o0k -1
+iAs ^S K
+i80 i90 iA4
+i77 ,8
+i6s Y1
+i6r i7t
+i6i i7l
+i69 i79 i88
+i62 i70 i80 o91
+i5n Z1
+i59
+i54 i70
+i51 R6
+i51 $8
+i50 Y1
+i4t i5h i6a
+i4s T6
+i4i ]
+i4a i5d i6o
+i4_ o51
+i4D
+i3o $4
+i3a o4z o5a
+i3a o4u
+i3a i4h
+i3a i1e
+i3a $5
+i2x i3i
+i2u D4
+i2k o4i
+i2k o4a
+i2j *13
+i2Y c
+i1v i1i
+i1n *31
+i1i y2
+i1i i2a i3n
+i1g ]
+i1e i2n i3n
+i1e i2k
+i1e -4
+i1c
+i1a i3d
+d t ]
+c i1i
+c $7 $6 $7 $6
+c $4
+c $3 $1 $0 $7
+c $3 $0 $1 $2
+c $3 $0 $0 $9
+c $3 $0 $0 $3
+c $3
+c $2 $7 $1 $0
+c $2 $4 $6 $8
+c $2 $4 $1 $0
+c $1 $9 $4 $4
+c $1 $9 $0 $9
+c $1 $7 $0 $1
+c $1 $6 $1 $8
+c $1 $5 $1 $2
+c $1 $5 $1 $0
+c $1 $4 $1 $5
+c $1 $4 $1 $1
+c $1 $2 $2 $1
+c $1 $2 $0 $5
+c $1 $0 $2 $1
+c $0 $7 $0
+c $0 $4 $1 $2
+c $0 $4 $0 $5
+c $0 $3 $1 $0
+c $0 $1 $0 $6
+c $0 $0 $5
+^z ^l ^l ^a ^b
+^z ^e ^r ^r ^e ^i ^t ^u ^g
+^y ^y ^y
+^y ^m ^a ^r
+^y ^j ^n ^e ^b
+^y ^e ^l ^s ^i ^a ^p
+^y ^b ^s ^o ^r ^c
+^y ^a ^r ^a ^s
+^t ^t ^a ^w
+^s ^w ^a ^p
+^s ^u ^n ^u ^y
+^s ^r ^e ^t ^s ^n ^o ^m
+^s ^i ^m ^o ^m
+^s ^e ^g ^n ^a ^r ^o
+^s ^a ^m ^a ^l ^l
+^s ^a ^i ^a ^s ^i
+^r ^r ^m
+^r ^i ^s ^a ^n
+^r ^e ^p ^p ^o ^h
+^r ^e ^k ^c ^i ^n ^s
+^r ^e ^f ^a ^m
+^r ^e ^d ^l ^e ^h
+^r ^e ^d ^a ^e ^l
+^p ^e ^t
+^o ^y ^a ^y
+^o ^t ^i ^s
+^o ^s ^n ^o ^f ^a
+^o ^r ^e ^r ^r ^e ^u ^g
+^o ^n ^o ^t
+^o ^j ^u ^a ^r ^a
+^o ^h ^n ^i ^t ^a ^g
+^o ^h ^c ^n ^a ^h ^c
+^o ^e ^r
+^n ^o ^x ^i ^n
+^n ^o ^s ^p ^m ^i ^s
+^n ^o ^d ^l ^e ^h ^s
+^n ^i ^l ^e ^v ^e
+^n ^i ^a ^k
+^n ^e ^i ^b
+^n ^a ^m ^c ^a ^p
+^n ^a ^i ^s
+^n ^a ^a ^m
+^m ^r ^e ^h
+^m ^r ^e ^g
+^m ^o ^o ^l ^b
+^m ^i ^b
+^l ^d ^a
+^l ^a ^r
+^l ^a ^m ^a
+^k ^a ^n
+^k ^a ^l ^a ^m
+^j ^n ^e ^b
+^i i0V
+^i ^u ^o ^l
+^i ^r ^o ^d
+^i ^r ^e ^g
+^i ^p ^a ^c
+^i ^n ^e ^l
+^i ^k ^a ^k
+^i ^j ^a ^h
+^i ^G p4
+^g seo
+^g ^o ^d ^l ^l ^u ^b
+^g ^n ^a ^k
+^g ^g ^a
+^f ^a ^l ^o
+^e ^p ^y ^t
+^e ^n ^h ^p ^a ^d
+^e ^n ^a ^v
+^e ^n ^a ^m
+^e ^m ^p ^l ^e ^h
+^e ^l ^p
+^e ^i ^s ^u ^s
+^e ^i ^k
+^e ^i ^g ^g ^e ^r
+^e $1 $2 $3
+^d ^k ^t
+^d ^i ^o ^r ^d ^n ^a
+^d ^a ^r ^n ^o ^c
+^d -1
+^c ^y ^c
+^c ^s ^c
+^c ^j ^d
+^c ^e ^l
+^c ^e ^h
+^c ^d ^e ^x ^s ^w ^z ^a ^q
+^c $1 $2
+^b ^m ^e
+^b ^a ^t
+^b $1 $2 $3
+^a ^z ^u ^o ^s
+^a ^y ^a ^s
+^a ^y ^a ^j
+^a ^t ^r ^o ^p
+^a ^o ^n
+^a ^n ^i ^r ^t ^a ^k
+^a ^n ^a ^t ^n ^o ^m
+^a ^m ^l ^e
+^a ^m ^a ^r
+^a ^i ^e ^l
+^a ^h ^a
+^a ^b ^m ^o ^b
+^T o1H i2E
+^M +1
+^K D2 D3
+^J i1k
+^I +1
+^H D4
+^G *31
+^F D4
+^D $1
+^8 $4
+^5 ^0 ^0 ^2 D5
+^3 ^2 ^1 o34
+^1 ^1 ^1 o31
+] ] D1 ]
+] ] $e $r
+[ $2 $0 $0 $5
+[ $2 $0 $0 $2
+[ $0 $0 $0 $0
+LA ^M K
+K Z3
+E $1 *68
+DB DB
+DA E $1
+D5 o7i p5
+D4 o4R
+D4 o4@
+D4 +3
+D4 $1 $2 $3 $4
+D3 +3
+D2 y4 c
+D2 o4i
+D1 $1 $9 $0 $3
+D1 $0 $1 $0 $3
+D0 .4
+-4 i64
+-3 i33
+-3 $2 $2
+-2 i40 scY
+-1 [ i0j
+-0 ^e
+-0 ^a o4o
+-0 $7 $7 $7
+,A *45 .6
++9 i6s $2
++8 o6a
++7 i6I .6
++6 +7 +7
++5 o7n
++5 o72 *2A
++5 Y3
++5 +5 +6
++4 ,6
++1 r
++0 i3w
++0 K
++0 $2 $4
+*B9 'A
+*9A i3e K
+*98 '9
+*76 scv
+*67 -5
+*57 k +3
+*54 D7
+*52 o1u +2
+*52
+*51 o5u
+*47 D4
+*34 o4d
+*34 ^x
+*32 ^s
+*31 i1a
+*25 i5a
+*23 i2w
+*14 C *10
+*13 +7
+*12 Z1
+*06 *15
+*04 $1
+'B ^1
+'9 i8t
+'9 i8r
+'8 $s
+'7 -3
+'6 ^j
+$s Z3
+$k t
+$h $o $u
+$h $a $w
+$c o4n
+$c $1 $2 $3
+$b $1 $1
+$_ $1 $0 $1
+$@ $1 $4
+$9 $7 $5 $3
+$7 i7s
+$7 $7 $0 $7
+$7 $6 $5 $4
+$7 $5 $0 $0
+$5 $5 $7 $7
+$5 $5 $0 $0
+$5 $2 $4 $3
+$4 $5 $8 $9
+$4 $3 $4 $3
+$3 $5 $0 $0
+$2 i70
+$2 $3 $3 $0
+$2 $2 $8 $8
+$2 $1 $2 $9
+$2 $0 $3 $4
+$2 $0 $0 $7 $!
+$1 D6 *45
+$1 $8 $9 $6
+$1 $4 $1 $9
+$1 $3 $2 $1
+$1 $2 $7 $2
+$1 $1 $7 $5
+$1 $1 $3 $3
+$0 ,3
+$0 $7 $8 $9
+$0 $6 $1 $4
+$0 $5 $2 $8
+$0 $5 $2 $2
+$0 $3 $!
+$0 $1 $5
+$0 $1 $1 $5
+$0 $0 $7 $7
+$# $2 $2
+{ o0G
+{ ,4
+y2 o0i ^M
+t o4S
+p3
+o7G
+o4P
+o3W
+o2v $1 $2 $3 $4
+o2r i0O
+o2c sck
+o2C D3
+o1U D2
+o0y $0 $3
+o0k i1a $1 $2 $3
+o0Z $5
+o0Y $8
+o0X D3
+o0W .2
+o0V $2 $3
+o0P *65
+o0M o3A
+o0K $7 $2
+o0J o1O
+o0G i1G
+o0G $1 $2 $3 $4
+o0D o1M
+o0D ,7 *A3
+o0C ,5
+i80 i90 iA2
+i7t i8e
+i7r T0
+i7o $1
+i72 ,8
+i70 i81 i91
+i70 i80 i93
+i6u D4
+i6s i72
+i6M
+i62 i70 i80 i93
+i5g .4
+i5e i7a
+i55 i64 i73 i82 o91
+i4y o5b
+i4o i5m o6a
+i4i o6a
+i4_ -0
+i41 i51 o62
+i4# o51
+i3o i4c
+i3k i4y
+i3e o5i
+i3e i71
+i3e -2
+i2w T0
+i2s o4o
+i2r i3k
+i2o i3b
+i2l o4o
+i2l o0K
+i2k i3e i4r
+i29 -0 L2
+i29
+i1u +0
+i1e i2s i3s
+i1a i2r i3i
+i0p ^S
+c o2C
+c i37
+c d 'A
+c ^5 ^0 ^0 ^2
+c $o $n
+c $9 $0 $9 $0
+c $8 $3 $3
+c $3 $?
+c $2 $8 $1 $0
+c $2 $4 $2 $4
+c $2 $2 $0 $8
+c $2 $2 $0 $0
+c $2 $1 $0 $0
+c $1 $7 $1 $1
+c $1 $6 $5
+c $1 $4 $1 $0
+c $1 $2 $3 $1
+c $1 $2 $2 $6
+c $1 $2 $1 $9
+c $1 $1 $2 $4
+c $0 $9 $0 $6
+c $0 $8 $0 $5
+c $0 $7 $7
+c $0 $7 $1 $0
+c $0 $6 $1 $0
+c $0 $4 $0 $2
+c $0 $3 $!
+^z ^o ^r ^r ^a
+^y ^v ^v ^i ^l
+^y ^t ^r ^a ^m ^s
+^y ^s ^s ^o ^b
+^y ^l ^e ^e ^k
+^y ^k ^r ^a ^d
+^y ^f ^f ^u ^l
+^y ^f ^f ^i ^t
+^y ^d ^o ^r
+^y ^b ^l ^o ^k
+^w ^s ^x ^z ^a ^q
+^v ^v ^v
+^t ^t ^a ^p
+^t ^o ^r ^r ^a ^p
+^t ^c ^i ^d ^e ^n ^e ^b
+^s ^t ^a ^b
+^s ^s ^i ^l
+^s ^o ^t ^a ^g
+^s ^o ^g ^e ^l
+^s ^n ^i ^a ^r ^t
+^s ^l ^i ^a ^t
+^s ^k ^k
+^s ^i ^l ^o ^p
+^s ^e ^n ^u ^n
+^s ^e ^l ^t ^r ^u ^t
+^r ^i ^d ^a ^k
+^r ^e ^t ^s ^i ^l ^l ^o ^h
+^r ^e ^m ^m ^a ^j
+^r ^a ^l ^i ^u ^g ^a
+^p ^a ^s ^a
+^o ^t ^r ^e ^b ^m ^u ^h
+^o ^t ^n ^o ^t
+^o ^r ^a ^m ^a
+^o ^i ^r ^r ^a ^b
+^o ^g ^u ^l
+^o ^d ^r ^a ^n ^r ^e ^b
+^o ^d ^n ^u ^c ^a ^f
+^o ^d ^n ^a ^m ^o ^c
+^n ^y ^l ^e ^c ^o ^j
+^n ^r ^o ^p
+^n ^o ^m ^i ^l
+^n ^o ^d ^n ^e ^r ^b
+^n ^i ^w ^r ^a ^d
+^n ^i ^l ^y ^a
+^n ^e ^w ^r ^a
+^n ^e ^r ^e
+^n ^e ^e ^l ^l ^o ^c
+^n ^a ^i ^l ^l ^i ^g
+^n ^a ^h ^o ^r
+^n ^a ^g ^e ^t
+^m ^e ^l ^l ^i ^w
+^l ^l ^a ^d ^n ^e ^k
+^l ^c ^m
+^l ^a ^t ^s ^y ^r ^k
+^l ^a ^e ^t
+^k ^j ^b
+^k ^j ^a
+^k ^e ^r ^a ^t
+^k ^e ^l
+^k ^c ^o ^l ^b
+^k ^c ^i ^v
+^k ^c ^e ^n ^d ^e ^r
+^i ^z ^i ^z
+^i ^z ^a
+^i ^r ^t ^i ^m ^i ^d
+^i ^r ^r ^e ^t
+^i ^n ^a ^v
+^i ^j ^n ^e ^k
+^i ^h ^s ^o ^t
+^i ^h ^d ^o ^b
+^i ^g ^n ^a
+^i ^d ^n ^a ^c
+^i ^d ^d ^a ^m
+^h ^t ^e ^d
+^h ^s ^a ^s
+^h ^n ^a
+^h ^g ^f
+^h ^c ^j
+^h ^a ^s
+^h ^a ^n
+^g o3e
+^g ^o ^d ^t ^o ^h
+^g ^n ^u ^h
+^g ^n ^i ^p
+^g ^n ^i ^l ^w ^o ^b
+^e ^v ^o ^m
+^e ^u ^q ^i ^n ^u
+^e ^t ^a ^c
+^e ^s ^i ^o ^l ^e
+^e ^r ^e ^m
+^e ^r ^e ^h ^w
+^e ^r ^a ^m ^t ^h ^g ^i ^n
+^e ^p ^y ^h
+^e ^p ^o ^l ^e ^n ^e ^p
+^e ^n ^o ^e ^h ^t
+^e ^m ^o ^s ^w ^a
+^e ^m ^l ^l ^i ^k
+^e ^l ^k ^r ^a ^p ^s
+^e ^l ^c ^a ^r ^i ^m
+^e ^k ^i ^r ^t ^s
+^e ^i ^r ^a
+^e ^i ^n ^n ^o ^d
+^e ^i ^j
+^e ^e ^k ^n ^a ^y
+^e ^c ^i ^r
+^d ^u ^a
+^d ^m ^d
+^d ^l ^e ^i ^f ^r ^a ^g
+^d ^j ^a
+^d ^e ^r ^g ^i ^b
+^d ^a ^t
+^c ^d ^a
+^c *30
+^b ^o ^b ^m ^i ^j
+^b ^a ^k
+^a ^u ^q
+^a ^r ^r ^a ^b
+^a ^r ^a ^a ^g
+^a ^n ^i ^t ^s ^i ^r ^k
+^a ^m ^a ^t
+^a ^l ^u ^c ^a ^r ^d
+^a ^l ^e ^u ^b ^a
+^a ^i ^s ^s ^u ^r
+^a ^i ^l ^i ^l
+^a ^i ^l ^e
+^a ^i ^h ^a ^b
+^a ^g ^a ^n
+^a ^d ^n ^a ^l ^o ^y
+^a ^c ^s
+^X $X ^x $x
+^N o1u
+^L ]
+^K o2i
+^J ^A
+^J $1
+^H D5
+^F *13
+^C $1
+^A $5
+^4 ^1 ^0 ^2
+^1 ^2 ^3 ^4 r
+[ '6
+[ $4 $3 $2 $1
+E s1Q
+D9 o9a
+D7 'B
+D3 *34
+D3 $2 $0 $0 $1
+D2 o5u
+D1 $A
+.0 i1z
+-9 s91
+-7 *32
+-6 ,7
+-5 o60
+-5 o1h
+-4 -0 '7
+-4 *57
+-1 o0t
+-1 ]
+-0 i2p
+-0 i2g
+-0 .2
+-0 $2
++9 +9
++7 D2
++4 ,7
++3 -4
++3 $9 $9
++2 D5
++1 D4 -6
++0 o5t
++0 o4u
++0 ,1
++0 '6
++0 $2 $2
++0 $0 $1
+*74 ,7
+*73 o0d
+*70
+*57 o0g
+*56 ^j T6
+*46 i58
+*43 -5
+*31 o0L
+*30 D3 T8
+*16 o27
+*14 i0m
+*13 i2n
+*13 i2l
+*05 ^j
+*04 i4t
+*04 i0m
+*02 i1i sih
+*01 i1u
+'8 -5
+'7 s1-
+'7 o6z
+'6 i5r
+'6 ^a
+'5 ^z
+$i @a
+$e o6p
+$e $r $o
+$c T0
+$c $r $e $e $d
+$b $l $o $o $m
+$_ $2 $0 $0 $6
+$I .7
+$9 $9 $8 $8
+$7 $9 $1 $1
+$5 o65
+$5 $5 $1 $0
+$5 $1 $5 $1
+$4 $7 $8 $9
+$4 $1 $4 $1
+$3 D4 z1
+$3 $2 $4 $5
+$2 *14
+$2 $7 $1 $5
+$2 $4 $9 $9
+$2 $3 $9 $8
+$2 $3 $7 $7
+$2 $3 $2 $8
+$2 $3 $2 $6
+$2 $1 $7 $9
+$2 $1 $3 $7
+$2 $0 $8 $0
+$2 $0 $3 $6
+$1 +8
+$1 $8 $9 $0
+$1 $5 $2 $5
+$1 $3 $5 $9
+$1 $2 $4 $0
+$1 $1 $5 $1
+$1 $0 $3 $4
+$0 Z5
+$0 $8 $0 $0
+$0 $7 $2 $7
+$0 $6 $2 $0
+$0 $1 $1 $9
+$0 $0 $7 $1
+$# $2 $4
+} *50 K
+{ $4
+ssD i1u
+o9l
+o4d
+o4D ]
+o4D
+o3T ]
+o3S
+o3D
+o2X
+o1P D3
+o0y $1 $3
+o0x $1 $2 $3
+o0p ,2
+o0k .2
+o0Z $4
+o0Y $1 $2
+o0Y $0 $1
+o0T ,2
+o0N $2 $6
+o0K o4M
+o0K o3K
+o0J ,4
+o0J $4 $4
+o0J $2 $0 $0 $7
+o0J $0 $0 $1
+o0I o1L
+o0E ]
+o0C o2C
+o0A i1K
+l $e
+i9s E
+i8k
+i7s i8t
+i70 o89
+i70 ,8
+i6u i7l
+i6K
+i68 o1o
+i65 -7
+i62 +7
+i5_ o61
+i5R
+i5M
+i52 i64 o76
+i52 i60 i71 o83
+i52 i60 i70 i84
+i52 i60 i70 i83
+i52 R4
+i4y o51
+i4u o0r
+i4p $s
+i4g $s
+i4a i5d o6o
+i3z o2i k
+i3l i4y
+i3i i4o
+i3e i4y
+i3a i72
+i3O o0P c
+i2z c
+i2v
+i2i o4e
+i2A { [
+i1s ,2
+i1r +0
+i1i i4a
+i1i i2n i3e
+i1h i2i
+i1c o3e
+i1a o4a
+i1a i2l i3e
+i0z i1o
+d '7
+c sio
+c i3.
+c ^6 ^0 ^0 ^2
+c +6
+c '6 $8
+c $i $n $g
+c $9 $9 $0 $0
+c $4 $5 $6 $7
+c $4 $4 $5 $5
+c $3 $1 $3 $1
+c $3 $1 $0 $3
+c $3 $0 $0 $6
+c $3 $0 $0 $5
+c $3 $0 $0 $1
+c $3 $$
+c $2 $9 $0 $1
+c $2 $3 $1 $2
+c $2 $3 $0 $5
+c $2 $2 $0 $9
+c $2 $$
+c $1 $9 $0 $8
+c $1 $8 $1 $2
+c $1 $7 $1 $7
+c $1 $3 $0 $1
+c $1 $2 $3 $$
+c $1 $2 $2 $9
+c $1 $1 $2 $8
+c $1 $0 $9 $2
+c $1 $0 $4 $0
+c $0 $9 $8 $8
+c $0 $9 $0 $5
+c $0 $8 $1 $1
+c $0 $8 $0 $1
+c $0 $7 $1 $3
+c $0 $7 $0 $5
+c $0 $5 $1 $0
+c $0 $5 $0 $3
+c $0 $5 $!
+c $0 $3 $2 $9
+c $0 $2 $0 $1
+^y ^s ^s ^o ^m
+^y ^s ^s ^i
+^y ^r ^e ^n
+^y ^e ^l ^l ^a
+^w ^j ^k
+^t ^s ^u ^d ^r ^a ^t ^s
+^t ^r ^e ^z ^a
+^t ^r ^a ^k ^o ^g
+^t ^a ^o
+^s t
+^s ^e ^u ^g ^i ^r ^d ^o ^r
+^s ^d ^s
+^s ^a ^n ^a ^n ^a
+^s ^a ^i ^m ^e ^r ^e ^j
+^s ^a ^i ^c ^a ^m
+^r ^o ^j ^e ^m
+^r ^e ^p ^p ^i ^z
+^r ^e ^d ^n ^a ^m ^m ^o ^c
+^o ^t ^i ^t ^a ^p
+^o ^t ^a ^m ^a ^y
+^o ^n ^e ^u ^b
+^o ^n ^a ^m ^o ^r
+^o ^m ^a ^n ^y ^d
+^o ^i ^b ^u ^r
+^o ^d ^n ^a ^l ^o ^r
+^o ^c ^u ^c
+^n ^r ^e ^y ^a ^b
+^n ^o ^t ^l ^i ^m ^a ^h
+^n ^o ^s ^y ^a ^j
+^n ^o ^l ^a ^t
+^n ^o ^h ^c
+^n ^g ^i ^s
+^n ^e ^d ^a ^r ^b
+^n ^a ^r ^a ^t
+^n ^a ^h ^p ^e ^t ^s
+^m i2x
+^m ^e ^r ^p
+^m ^a ^y ^r ^a ^m
+^l ^o ^o ^p ^d ^a ^e ^d
+^l ^l ^o ^c
+^l ^i ^r ^y ^c
+^l ^i ^m ^a ^j
+^l ^h ^c
+^l ^e ^n ^o ^e ^l
+^l ^e ^i ^r ^u
+^l ^e ^g ^a ^b
+^l ^e ^a ^g
+^l ^a ^e ^l
+^l ^a ^c ^s ^a ^r
+^k ^m ^a
+^k ^a ^r
+^k $1 $2 $3
+^j ^s ^s
+^j ^M
+^i ^r ^i ^s
+^i ^n ^n ^a ^d
+^i ^n ^i ^r ^t
+^i ^n ^i ^m ^o ^d
+^i ^n ^a ^m ^i
+^i ^m ^o ^n
+^i ^m ^k ^a ^z ^e ^a
+^i ^l ^l ^a ^k
+^i ^e ^d
+^i ^a ^w
+^h ^j ^c
+^g ^u ^p
+^g ^n ^i ^t ^s
+^g ^m ^s
+^f ^o ^k
+^f ^l ^o ^d ^a
+^f ^e ^r
+^f ^d ^s
+^e ^z ^e ^e ^r ^f
+^e ^v ^o ^d
+^e ^v ^a ^l ^s
+^e ^n ^o ^h ^p
+^e ^m ^e ^r ^t ^x
+^e ^m ^e ^r ^p ^u ^s
+^e ^m ^a ^j
+^e ^l ^l ^a ^v
+^e ^l ^d ^o ^o ^d
+^e ^l ^b ^a ^t
+^e ^e ^e
+^e ^d ^e
+^e ^d ^a ^d ^i ^c ^i ^l ^e ^f
+^d ^a ^p
+^c ^o ^j
+^c ^e ^s
+^c ^e ^n
+^c ^e ^m
+^c ^D
+^b ^i ^b
+^b ^e ^n
+^a ^z ^o ^d ^n ^e ^m
+^a ^y ^i ^r ^p
+^a ^t ^e ^g ^e ^v
+^a ^s ^i ^m
+^a ^m ^g
+^a ^m ^a ^d
+^a ^m ^a ^b ^o
+^a ^l ^o ^b
+^a ^l ^l ^i ^z ^d ^o ^g
+^a ^l ^i ^c ^s ^i ^r ^p
+^a ^k ^u ^s
+^a ^k ^i ^n ^a
+^a ^i ^n ^i ^g ^r ^i ^v
+^a ^i ^l ^a ^h ^t
+^a ^i ^c ^i ^l ^e ^f
+^a ^h ^e ^n
+^a ^g ^n ^i ^k
+^a ^f ^f ^a ^j
+^a ^e ^m
+^a ^d ^l ^i ^t ^a ^m
+^a ^a ^j
+^D -1
+^2 ^3 ^4 ^5 o41
+^1 ^2 ^3 ] r
+^0 ^0 o20 r
+[ o1D
+[ c *31
+K i6m
+E slr
+E o3Z
+D6 o7o
+D5 i2y
+D5 i1j
+D4 o5o
+D3 i5e
+D3 +4
+D3 $1 $2 $3 $4 $5 $6
+D2 $o
+D2 $2 $0 $0 $7
+D1 o4o
+D1 o4a
+D1 i3a
+D1 $1 $2 $1 $2
+.0 ,5
+-6 o0t
+-6 T0
+-6 -7 -7
+-5 $y
+-3 Z1
+-3 *65
+-3 $i
+-1 D2 D3
+-0 y2 y2
+-0 ^g
+-0 ^9
+-0 D2
++9 +9 +9 +9
++8 Z1
++7 o90
++6 i8a
++6 -8
++5 i3o
++5 -6
++4 y2 *35
++4 Y1 *54
++4 $_ '6
++3 i4k
++3 K
++2 i3j
++2 *32
+*97 'A
+*85 '7
+*71 D2 r
+*69 *87
+*67 *56
+*56 +4
+*51 '5 y2
+*46 -4
+*43 $e
+*35 o5u E
+*35 o1u
+*32 i4s
+*24 -4
+*20 o0o
+*05 u D0
+*02 o0s
+'8 $a
+'7 -4
+'5 *03
+$o +8
+$j $1 $2 $3
+$_ $4 $5
+$R $1
+$M $C
+$9 $9 $6 $6
+$9 $8 $1 $2
+$9 $0 $1 $2
+$8 .3
+$8 $8 $8 $9
+$7 $2 $7 $2
+$7 $1 $7 $1
+$6 o4i
+$6 $3 $6 $3
+$5 $6 $7 $8 $9
+$4 $6 $4 $6
+$3 srl
+$3 o58
+$3 $D
+$3 $9 $3 $9
+$3 $5 $4 $5
+$3 $3 $9 $9
+$3 $3 $2 $2
+$3 $1 $4 $5
+$3 $0 $1 $4
+$2 o62
+$2 *57
+$2 $8 $3 $0
+$2 $6 $3 $0
+$2 $2 $7 $8
+$2 $2 $2 $3
+$2 $1 $1 $4
+$2 $0 $0 $7
+$1 o7l
+$1 C *12
+$1 $9 $3 $2
+$1 $8 $2 $8
+$1 $6 $2 $4
+$1 $6 $2 $0
+$1 $5 $6 $0
+$1 $5 $2 $0
+$1 $4 $7 $1
+$1 $3 $4 $2
+$1 $3 $2 $0
+$1 $2 $5 $4
+$1 $2 $4 $1
+$1 $2 $3 $4 $!
+$1 $1 $9 $9
+$1 $0 $5 $5
+$0 i5_
+$0 *65 o67
+$0 $7 $3 $0
+$0 $0 $4 $4
+o7S
+o76 s6z
+o4X .5
+o3J
+o2V
+o2K
+o2F
+o2D ]
+o1z
+o0n $o
+o0m $1 $2 $3 $4 $5
+o0h $1 $2 $3 $4
+o0e $o
+o0W ,2
+o0W $1 $4
+o0V $1 $5
+o0V $0 $2
+o0V $0 $0
+o0Q D3
+o0O ]
+o0N $1 $7
+o0M o2N
+o0K ,6
+o0K $3 $5
+o0J +1
+o0< iA>
+l ] $b
+i90 iA1
+i8E
+i82 i90 iA0 oB1
+i7k i8a
+i72 o80
+i72 i80 i90 oA5
+i71 o87
+i70 i80 i96
+i6t i7a i8r
+i6c i7k
+i62 i70 i80 i94
+i5a o6z
+i52 o60 ss0 $2
+i51 i62 o71
+i4r ,6
+i4e i5m i6a
+i4e $1 $2
+i4a i5n i6a
+i4a $4
+i4_ o52
+i4M
+i43 +5
+i42 i50 i61 o76
+i3z -2
+i3y u
+i3k o4y
+i3a i5a
+i2i o4i
+i2i i3m
+i2g i3a i4n
+i2e o5i
+i2e .4
+i2e -6
+i2O l
+i1u ]
+i1o i2o i3l
+i1o i2m i3b
+i1o +2
+i1n .3 *13
+i1j
+i1i -0
+i1a o5a
+i1a i2n i3e
+i1a i2m i3e
+i1a $1
+i1H l
+i10
+i0c i1o i2c
+d c 'A
+c i71
+c i2o
+c i2g
+c '6 $3
+c $b $a $b $y
+c $7 $4 $6 $5
+c $5 $5 $6 $6
+c $3 $3 $2 $1
+c $3 $1 $0 $0
+c $2 $9 $1 $1
+c $2 $8 $0 $4
+c $2 $5 $2 $5
+c $2 $4 $0 $7
+c $2 $3 $0 $3
+c $2 $2 $0 $2
+c $2 $1 $0 $6
+c $2 $0 $3 $1
+c $2 $0 $2 $4
+c $1 $9 $0 $4
+c $1 $7 $1 $8
+c $1 $7 $1 $0
+c $1 $6 $0 $2
+c $1 $5 $2 $1
+c $1 $5 $0 $2
+c $1 $2 $1 $8
+c $1 $2 $0 $8
+c $0 $9 $0 $7
+c $0 $9 $0 $0
+c $0 $7 $1 $4
+c $0 $6 $0 $6
+c $0 $6 $0 $5
+c $0 $3 $1 $3
+c $0 $2 $2 $0
+c $0 $1 $3 $0
+c $0 $1 $1
+^z ^l ^u ^j
+^y ^r ^u ^a ^m
+^y ^r ^o ^l ^l ^a ^m
+^y ^n ^a ^l ^e ^m
+^y ^l ^o ^r ^b
+^y ^l ^e ^m ^e
+^y ^l ^a ^t ^a ^n
+^y ^f ^f ^e ^j
+^y ^e ^t ^a ^k
+^y ^d ^e ^t
+^y ^a ^r ^a ^s ^a ^t ^a ^l ^a ^g
+^t ^u ^y
+^t ^u ^n ^o ^i
+^t ^e ^p ^p ^u ^p
+^s ^u ^o ^l ^u ^b ^a ^f
+^s ^s ^e ^l ^a
+^s ^n ^e ^t ^t ^i ^m
+^s ^k ^s
+^s ^k ^r ^a ^h ^s
+^s ^e ^k ^a ^c
+^s ^e ^h ^c ^t ^a ^p
+^s ^b ^l
+^s ^a ^i ^r ^a
+^r ^i ^s T3
+^r ^e ^y ^o ^r ^t ^s ^e ^d
+^r ^e ^s ^a ^h ^c
+^r ^e ^h ^p ^o ^t
+^r ^e ^d ^a ^j
+^r ^a ^o ^r
+^o ^t ^e ^t
+^o ^r ^h ^t ^e ^j
+^o ^n ^a ^i ^l ^u ^j
+^o ^m ^o ^r
+^o ^l ^l ^i ^k
+^o ^l ^i ^h
+^o ^h ^c ^o ^h ^c
+^o ^h ^c ^i ^r ^e ^j
+^n ^n ^a ^d
+^n ^e ^e ^l ^i ^a
+^n ^a ^r ^u ^d
+^n ^a ^n ^a
+^n ^a ^i ^m ^e ^d
+^n ^a ^i ^j
+^n ^a ^g ^a ^e ^m
+^m ^u ^t
+^m ^p ^j
+^m ^o ^t ^m ^o ^t
+^m ^k ^j
+^m ^e ^t
+^m ^a ^e ^b
+^l ^e ^v ^e ^l
+^l ^a ^s ^i ^a ^f
+^l ^a ^m ^e ^k
+^l ^a ^l
+^l ^a ^g ^u ^t ^r ^o ^p
+^l ^a ^b ^i ^n ^a
+^k i0K
+^k ^e ^d
+^k ^e ^b
+^k ^d ^j
+^k ^c ^a
+^j y1 c
+^j o3o
+^j ^e ^r ^d ^n ^a
+^i ^u ^y
+^i ^t ^s ^i ^r ^k
+^i ^r ^e ^t
+^i ^r ^e ^l ^a ^v
+^i ^n ^a ^m ^a
+^i ^m ^i ^s
+^i ^m ^a ^r
+^i ^l ^a ^s
+^i ^k ^u ^k
+^i ^d ^r ^e ^f
+^h ^t ^y ^m
+^h ^m ^a
+^h ^j ^j
+^h ^g ^u ^a ^l
+^h ^c ^t ^i ^w
+^g ^n ^a ^m
+^g ^j ^d
+^g ^i ^g
+^e ^s ^u ^a ^c ^e ^b
+^e ^s ^a ^d ^o ^f
+^e ^o ^n
+^e ^n ^i ^p
+^e ^n ^e ^p
+^e ^m ^o ^s ^d ^n ^a ^h
+^e ^l ^b ^m ^u ^b
+^e ^k ^o ^j
+^e ^i ^v
+^e ^i ^d ^l ^o ^g
+^e ^h ^c ^a ^p ^a
+^e ^e ^v
+^e ^e ^n
+^e ^e ^l ^y ^k
+^e ^e ^k
+^e ^d ^n ^a
+^e ^b ^o ^t
+^d ^r ^a ^z ^z ^i ^l ^b
+^d ^a ^m ^m ^a ^h ^u ^m
+^d -6
+^c ^d ^e
+^c ^a ^f
+^c ^A
+^c *01 +0
+^b o1y
+^b ^r ^e
+^b ^r ^b
+^b ^e ^h
+^a ^y ^a ^m ^a
+^a ^t ^s ^a ^p
+^a ^t ^e ^z
+^a ^t ^e ^l ^o ^i ^v
+^a ^s ^m
+^a ^s ^i ^k
+^a ^s ^a ^n
+^a ^r ^a ^y
+^a ^r ^a ^m ^a ^s
+^a ^n ^i ^r ^a ^c
+^a ^n ^i ^b ^a ^s
+^a ^n ^a ^i ^d ^n ^i
+^a ^m ^a ^s
+^a ^l ^o ^c ^s ^e
+^a ^k ^i ^n ^n ^a
+^a ^j ^a ^k
+^a ^g ^i ^l
+^a ^e ^r ^a
+^a ^d ^i ^e ^m ^l ^a
+^a ^c ^i
+^a ^b ^e ^b
+^T ^T
+^J ^B
+^J D3
+^G o1H
+^D +1
+^C ]
+^B D6
+^1 ^2 ^3 D5 r
+^1 ^2 ^1 ^2
+] ^L ]
+] -1 ]
+[ ^C *31
+[ -3
+[ $2 $0 $0 $7
+[ $1 $2 $3 $4 $5
+[ $1 $2 $3 $4
+Y1 u i43
+T4 ^/
+R4 Z3
+L6 $e
+K i0x z1
+E o2c $3
+D9 o9o
+D9 o9e
+D7 o4I sIu
+D7 -7
+D6 $t
+D5 $a $n
+D4 *26
+D3 o4o
+D2 o5a
+D2 i4i
+D2 -3
+D2 -2
+D1 o3y
+D1 o1B
+D1 i2e
+D1 ] ,2
+D0 i5x
+-8 t
+-6 i5r
+-6 $3
+-5 Z2 -0
+-4 $2
+-1 ^A
+-0 o2k
+-0 $2 $0 $0 $0
++8 +8
++6 o0M
++6 *68 +8
++1 .3
++0 i1v
+*B9 s1m D6
+*7B o74 D3
+*76 o6g
+*76 i74
+*75 *23
+*64 K
+*63 T2
+*43 D2
+*3B *37 ]
+*35 i3i
+*32 i68
+*24 i5o
+*23 o4a
+*14 .3 E
+*13 *65
+'9 l
+'9 T5
+'9 +2
+'8 z1
+'7 i5_
+'6 z1
+$m ^M
+$b $u $t
+$a $r $o
+$A [ r
+$9 $5 $9 $5
+$8 $9 $9 $0
+$8 $4 $8 $4
+$8 $2 $8 $2
+$6 E -3
+$6 $6 $7 $7
+$6 $5 $0 $0
+$6 $2 $6 $2
+$5 o66
+$4 .4
+$4 $4 $2 $2
+$3 o62
+$3 $3 $5 $5
+$3 $3 $1 $1
+$3 $2 $4 $1
+$3 $1 $2 $4
+$3 $0 $2 $0
+$2 $9 $3 $0
+$2 $4 $5 $3
+$2 $4 $3 $4
+$2 $3 $8 $0
+$2 $3 $2 $5
+$2 $3 $1 $3
+$2 $2 $7 $7
+$2 $2 $3 $0
+$2 $2 $1 $8
+$2 $1 $2 $6
+$2 $0 $4 $8
+$1 $5 $9 $6
+$1 $3 $7 $7
+$1 $3 $5 $5
+$1 $2 $8 $4
+$1 $1 $8 $0
+$1 $1 $4 $7
+$1 $0 $5 $6
+$0 $9 $8 $1
+$0 $8 $2 $8
+$0 $1 $1 $1
+s1[
+oAt
+o8r $s
+o6X
+o4P ]
+o4K ]
+o3z $1 $2 $3 $4 $5
+o3W ]
+o2M ]
+o2B ]
+o1o -2
+o1W D2
+o1M D3
+o1L D3
+o1C D2
+o0s $2 $0 $0 $3
+o0n i2y
+o0k $1 $2 $3 $4 $5
+o0d $2 $0 $0 $3
+o0Z $1 $3
+o0Z $!
+o0V ]
+o0V $1 $4
+o0V $0 $5
+o0T .3
+o0P si1
+o0G .3
+o0A o1G
+l *68 o6y
+l $i
+i7l i8i
+i7M E
+i71 +8
+i69 R5
+i61 i72 o83 i94 oA5
+i61 i72 o83
+i5j *5B .6
+i5c i77
+i51 i62 o73
+i50 R4
+i4y o5p
+i4y o5o
+i4o *31
+i4i +0
+i4_ o55
+i42 i50 i60 o79
+i42 i50 i60 i71
+i40 i57 i60 o77
+i3i o5u
+i3i i4r
+i3e $s
+i3d $1 $2 $3
+i3a o5e
+i3a o4y
+i31 i45 o52
+i2y o3l
+i2y o3e
+i2v i3i i4n
+i2s sa@
+i2r i3a i4n
+i2l i3y
+i2l +0
+i2a o4o
+i21 i32 i43 o54
+i1y -0
+i1u o3n
+i1t i2a
+i1r i2o i3n
+i1h o3u
+i1a i2y
+i1a i2x
+i0K o1h
+c o6R
+c i6u
+c i35
+c ^-
+c $b $a $l $l
+c $8 $8 $9 $9
+c $5 $$
+c $3 $1 $0 $8
+c $2 $8 $0 $9
+c $2 $8 $0 $8
+c $2 $7 $2 $7
+c $2 $6 $1 $0
+c $2 $4 $0 $1
+c $2 $3 $2
+c $2 $3 $0 $7
+c $2 $1 $0 $3
+c $1 $6 $1 $1
+c $1 $5 $2 $0
+c $1 $4 $2 $3
+c $1 $4 $2 $0
+c $1 $3 $3 $1
+c $1 $2 $2 $5
+c $1 $1 $1 $8
+c $0 $9 $2 $9
+c $0 $9 $0 $1
+c $0 $8 $2 $4
+c $0 $8 $0 $0
+c $0 $6 $1 $2
+c $0 $6 $1 $1
+c $0 $6 $0 $1
+c $0 $4 $1 $7
+c $0 $4 $1 $1
+c $0 $2 $1 $7
+c $0 $1 $1 $4
+c $0 $1 $0 $4
+c $0 $1 $0 $3
+^y ^s ^s ^a ^c
+^y ^p ^p ^i ^l ^f
+^y ^o ^b ^e ^u ^l ^b
+^y ^o ^b ^d ^o ^o ^g
+^y ^l ^l ^i ^e ^r
+^y ^e ^u ^l ^b
+^y ^e ^r ^r ^e ^t ^n ^o ^m
+^v ^t ^s
+^u ^y ^t
+^t ^t ^e ^h ^r
+^t ^o ^h ^s ^t ^o ^h
+^t ^a ^c ^l ^o ^o ^c
+^s ^s ^d
+^s ^o ^t ^u ^p
+^s ^g ^i ^m
+^s ^d ^n ^o ^m ^a ^i ^d
+^s ^a ^x ^o ^r
+^s ^a ^n ^i ^l ^a ^s
+^r ^e ^p ^m ^a ^c
+^r ^e ^g ^u ^r
+^r ^e ^d ^n ^a ^w
+^r ^a ^d ^r ^e ^s
+^o ^t ^i ^r ^r ^u ^b
+^o ^t ^i ^p ^a ^p
+^o ^t ^i ^l ^b ^a ^p
+^o ^t ^i ^a ^k
+^o ^t ^a ^v
+^o ^n ^e ^b
+^o ^l ^l ^a ^b ^a ^c
+^o ^k ^n ^a ^r ^f
+^o ^k ^m
+^o ^h ^o ^h
+^o ^h ^n ^i ^r ^d ^e ^p
+^o ^h ^c ^r ^e ^f
+^o ^c ^i ^r ^e ^p
+^o ^a ^g ^a ^r ^d
+^n ^o ^o ^t
+^n ^n ^e ^p
+^n ^i ^t ^p ^a ^c
+^n ^a ^z ^r ^a ^t
+^n ^a ^k ^r ^e ^s
+^n ^a ^j ^e ^d
+^n ^a ^h ^k ^o ^g
+^m ^s ^j
+^m ^i ^r ^p
+^m ^a ^l ^a
+^l ^i ^o
+^l ^e ^z ^t ^i
+^l ^a ^t ^n ^a ^h ^c
+^k ^c ^o ^s
+^k ^c ^a ^s
+^k ^c ^a ^p
+^k ^a ^p
+^i ^r ^b ^a ^f
+^i ^n ^n ^i ^m
+^i ^m ^o
+^i ^l ^o ^s
+^i ^l ^a ^h
+^i ^k ^a ^m ^u ^z ^u
+^i ^i ^i
+^i ^h ^c ^a ^m
+^i ^d ^n ^a ^s
+^i ^d ^d ^a
+^i ^a ^n
+^h ^t ^a
+^h ^s ^j
+^h ^s ^e
+^h ^g ^f ^d ^s ^a
+^h ^e ^l
+^h ^c ^n ^u ^l
+^h ^a ^h ^s
+^g ^n ^e ^p
+^f ^f ^i ^t
+^e i3e
+^e ^y ^k
+^e ^w ^a
+^e ^s ^e ^e ^r
+^e ^o ^p
+^e ^n ^i ^t ^s ^u ^j
+^e ^n ^i ^l ^y ^k ^s
+^e ^n ^a ^i ^l ^e
+^e ^m ^o ^r
+^e ^m ^i ^h
+^e ^m ^a ^s
+^e ^m ^a ^f
+^e ^l ^l ^a ^h
+^e ^l ^i
+^e ^l ^a ^s
+^e ^l ^a ^h ^w
+^e ^i ^s ^l ^e
+^e ^i ^d ^o
+^e ^a ^r
+^e ^a ^k
+^d ^m ^s
+^d ^e ^m ^m ^a ^h ^o ^m
+^d ^J
+^c ^j ^j
+^c ^i ^d
+^c ^a ^d
+^b ^n ^m
+^a ^t ^e ^n ^a ^l ^p
+^a ^t ^a ^b
+^a ^r ^r ^e ^s
+^a ^p ^a ^m
+^a ^n ^n ^a ^e ^r ^b
+^a ^n ^a ^t ^n ^a ^s
+^a ^n ^a ^i ^l
+^a ^m ^a ^c
+^a ^l ^i ^u ^g ^a
+^a ^l ^e ^x
+^a ^k ^i ^h ^c
+^a ^i ^n ^a ^v
+^a ^e ^h ^s
+^a ^d ^r ^e ^m
+^a ^d ^l ^i ^h
+^a ^a ^k
+^_ ^e ^v ^o ^l
+^S $1 $1
+^H ]
+^D D3
+^B -1
+^A +1
+^A $2
+^9 ^1 T2
+^9 $3
+^4 ^4 ^4 o34
+^3 ^2 ^1 i64 i75 o86
+[ o1G
+T3 T4 T5 T6
+L6 *04 }
+E i2b
+D6 i3o
+D6 i1i
+D5 Z2
+D3 i5n
+D3 $2 $0 $0 $5
+D2 o2X
+D2 i3g
+D2 -4
+D2 ,5
+D1 o2D D3
+D1 .2
+D1 $2 $4 $6 $8
+@i u
+@9 i3-
+.0 i1w
+-6 o2h
+-5 -6 -6
+-4 D7
+-3 *26 sIT
+-2 o55
+-2 o4y
+-2 i3l
+-2 Y3
+-2 ,3
+-2 *75 c
++B .A
++9 $2
++7 o46
++7 .6
++6 Y2
++4 o5y
++4 i66
++4 $1 $2 $3
++4 $0
++3 t s27
++1 i1l
++1 ,2
++0 i2z
++0 $1 $1
+*86 +7
+*69 D7
+*68 +8
+*65 o0r
+*57 o64
+*57 +0
+*52 .2
+*46 o4y
+*43 ] c
+*42
+*35 i6a
+*35 *56
+*34 }
+*34 $n
+*32 D6
+*25 *60
+*15 $9 Z1
+*13 s73
+*03 i1r
+'7 sat
+'7 *30
+'7 $s
+'6 q
+$l $e $g $o
+$c $i $o
+$_ $3 $4
+$_ $3 $2
+$9 $9 $0 $1
+$9 $6
+$8 $1
+$6 $8 $6 $8
+$6 $1 $6 $1
+$5 $3 $1 $2
+$4 i79
+$4 +9
+$4 $4 $8 $8
+$4 $2 $2 $3
+$3 {
+$3 i2n
+$3 i1a
+$3 $7 $3 $7
+$3 $3 $1 $2
+$2 i57
+$2 i2a
+$2 +8
+$2 +6
+$2 $4 $5 $6
+$2 $4 $0 $0
+$2 $3 $4 $5
+$2 $2 $2 $7
+$2 $2 $1 $9
+$2 $2 $1 $4
+$2 $2 $0 $0
+$2 $1 $3 $6
+$2 $0 $2 $6
+$1 $8 $8 $3
+$1 $6 $2 $7
+$1 $5 $9 $7
+$1 $5 $8 $9
+$1 $5 $7 $8
+$1 $5 $3 $0
+$1 $3 $5 $0
+$1 $3 $4 $5
+$1 $3 $3 $3
+$1 $2 $7 $5
+$1 $1 $8 $2
+$1 $1 $6 $9
+$1 $1 $6 $0
+$1 $0 $9 $9
+$1 $0 $3 $2
+$0 $7 $7 $7
+$0 $6 $1 $7
+$0 $1 $2 $4
+$0 $1 $1 $3
+$0 $1 $1
+{ -4 c
+sj< sl>
+o7s -B *78
+o7X
+o5G ]
+o51
+o4Q
+o4G
+o4E
+o3M ]
+o3A
+o1a .2
+o1R D3
+o1K
+o1D D3
+o0t $o
+o0j $2 $0 $0 $2
+o0g $1 $2 $3 $4 $5
+o0b $1 $2 $3 $4 $5
+o0Z -2
+o0Y $7
+o0X ]
+o0X D2
+o0W ]
+o0V $9 $9
+o0U
+o0P ,2
+o0O D4
+o0N ,2
+o0K o5K
+o0J o2J
+o0J ,1
+o0C ,2
+o0/
+l ] $v
+i7r o8y
+i7r +6
+i6o o7s
+i6j i7u
+i6S
+i6H
+i61 i83 i72
+i5l i6l o7a
+i5l i6l
+i5a o7a
+i52 i63 o74
+i4i $o
+i3n $1 $2 $3
+i3k .1
+i3i o5i
+i3e ,5
+i3d i4i i5e
+i3a o5a
+i3a i4n i5e
+i32 i40 i50 o63
+i3.
+i2y o4e
+i2u o3a
+i2p *57
+i2i o4a
+i1u o3i
+i1s ^g
+i1o i2w
+i1i i2n i3o
+i1h o4o
+i1h $1 $2
+i1e o5a
+i1e o4a
+i1e i5e
+i1a i71
+i1a i2r i3k
+c i5'
+c $7 $1 $2 $3
+c $4 $0 $5 $0
+c $3 $2 $3 $2
+c $3 $0 $0 $4
+c $2 $7 $1 $2
+c $2 $7 $0 $7
+c $2 $6 $0 $9
+c $2 $6 $0 $7
+c $2 $6 $0 $0
+c $2 $4 $0 $5
+c $2 $1 $2 $2
+c $2 $0 $9 $0
+c $2 $0 $4 $0
+c $1 $9 $1 $4
+c $1 $7 $0 $7
+c $1 $7 $0 $3
+c $1 $6 $2 $0
+c $1 $4 $0 $2
+c $1 $3 $2 $5
+c $1 $3 $1 $2
+c $1 $2 $9 $0
+c $1 $0 $9 $9
+c $0 $9 $2 $0
+c $0 $8 $1 $2
+c $0 $6 $0 $2
+c $0 $3 $1 $5
+c $0 $2 $1 $2
+c $0 $2 $0 $6
+c $0 $1 $2 $2
+c $0 $0 $1 $9
+^z ^y ^o ^b
+^z ^n ^e ^r
+^z ^e ^u ^q ^r ^a ^m
+^z ^e ^b ^a ^j
+^y ^z ^z ^i ^g
+^y ^x ^e ^r
+^y ^t ^i ^k
+^y ^s ^s ^i ^l
+^y ^o ^b ^t ^o ^h
+^y ^e ^l ^y ^r
+^y ^e ^l ^s ^e ^r ^p
+^y ^e ^d ^a ^j
+^y ^b ^m ^a ^l
+^s ^r ^e ^t ^s ^i ^s
+^s ^n ^s
+^s ^n ^o ^t ^t ^u ^b
+^s ^n ^a ^d ^r ^o ^j
+^s ^l ^a ^m ^i ^n ^a
+^s ^i ^n ^a ^y
+^s ^i ^l ^o ^s
+^s ^e ^t ^n ^a ^v ^r ^e ^c
+^s ^e ^i ^k ^s ^u ^h
+^r ^e ^k ^c ^i ^k
+^p ^o ^o ^b
+^o ^y ^o ^t
+^o ^t ^i ^l ^l ^o ^p
+^o ^r ^i ^e ^b ^i ^r
+^o ^r ^e ^m ^u ^n
+^o ^r ^e ^l ^l ^a ^b ^a ^c
+^o ^k ^o ^j
+^o ^h ^t ^n ^a
+^o ^h ^c ^a ^p
+^o ^c ^o ^r
+^n ^o ^t ^s ^e ^w
+^n ^o ^m ^a ^n ^n ^i ^c
+^n ^l ^a
+^n ^i ^r ^t
+^n ^i ^m ^r ^e ^f
+^n ^i ^a ^c
+^n ^e ^d ^y ^a ^k
+^n ^e ^d ^m ^a ^c
+^n ^a ^r ^m ^i
+^n ^a ^r ^a ^k
+^n ^a ^n ^n ^e ^r ^b
+^n ^a ^m ^a ^s
+^n ^a ^i ^l ^l ^i ^j
+^n ^a ^g ^o ^h
+^n ^a ^g ^e ^e ^k
+^n ^a ^d ^n ^a ^d
+^n ^a ^a ^d
+^m ^o ^o ^r
+^m ^g ^a
+^m ^e ^d ^a
+^l ^l ^e ^r ^r ^a ^d
+^l ^l ^e ^k
+^l ^l ^a ^b ^s ^s ^u ^f
+^l ^k ^m
+^l ^a ^e ^s
+^k ^s ^m
+^k ^r ^o ^p
+^k ^r ^a ^b
+^k ^i ^r
+^k ^e ^l ^e ^m
+^k ^c ^m
+^k ^c ^i ^p
+^i ^r ^o ^b
+^i ^n ^u ^j
+^i ^n ^o ^t ^n ^a
+^i ^n ^o ^b
+^i ^n ^a ^t
+^i ^m ^u ^y
+^i ^m ^s
+^i ^l ^l ^i ^b
+^i ^g ^e ^r
+^i ^d ^n ^a ^m
+^h ^s ^u ^m
+^h ^s ^i ^n ^a ^d
+^h ^s ^a ^t
+^g ^r ^a ^m
+^g ^n ^i ^l ^b
+^g ^e ^j
+^f ^r ^a
+^f ^i ^r ^a
+^f ^f ^u ^t ^s
+^e ^t ^i ^b
+^e ^r ^u ^s
+^e ^n ^o ^e ^m ^o ^s
+^e ^l ^o ^k
+^e ^l ^i ^m ^e
+^e ^k ^i ^l ^e ^m
+^e ^i ^z ^z ^o
+^e ^i ^x ^i ^r ^t
+^e ^i ^t ^t ^o ^l
+^e ^i ^g ^r ^e ^f
+^e ^h ^t ^t ^a ^h ^w
+^e ^g ^a ^s ^u ^a ^s
+^e ^e ^l ^y ^m ^a
+^e ^d ^a ^r ^d ^n ^a
+^e ^c ^i ^n ^u ^e
+^e ^c ^a ^r ^t
+^e ^c ^a ^m
+^e ^b ^u ^c
+^e ^P
+^d i3i
+^d ^r ^a ^n ^o ^e ^l
+^d ^n ^e ^r ^b
+^d ^n ^e ^i ^r ^f
+^d ^i ^c
+^d $1 $2 $3
+^c ^a ^l ^i ^l
+^c ^a ^k
+^b o3e
+^b ^l ^e
+^a i4o
+^a ^y ^s ^a
+^a ^y ^i ^m
+^a ^y ^a ^y
+^a ^s ^s ^i ^r ^a ^m
+^a ^r ^y ^t
+^a ^r ^o ^b
+^a ^r ^d ^n ^a ^s ^s ^a ^c
+^a ^n ^i ^e ^r
+^a ^n ^e ^x
+^a ^n ^a ^s
+^a ^n ^a ^c
+^a ^m ^o ^s
+^a ^m ^e ^g
+^a ^k ^o ^l
+^a ^e ^r ^b
+^a ^d ^s ^a
+^a ^d ^n ^u ^b
+^a ^d ^n ^a ^n ^a
+^a ^c ^e ^m
+^a ^b ^e ^h ^s
+^a ^W
+^a *20
+^a $1 $2 $3
+^J y1
+^F $1
+^C z1
+^B D4
+E i4A
+D8 y2 ,5
+D5 o5N
+D4 o6o
+D4 $1 $2 $3 $4 $5
+D3 sao
+D3 $2 $0 $0 $4
+D2 o4o
+D2 o2P
+D2 $4 $3 $2 $1
+D2 $2 $0 $0 $5
+D1 o2L
+D1 o1F
+D1 $2 $0 $0 $6
+D1 $2 $0 $0 $2
+.0 +1
+.0 $1 $2
+-7 i0j
+-7 +2 r
+-6 o4z
+-6 $y
+-4 i5d
+-4 i51 i62 o73
+-2 o0n
+-0 sao
+-0 D1
+-0 *02 [
++7 Y1 *67
++7 -6
++4 i61
++3 D5
++0 D3
++0 $2 $1
++0 $2 $0 $0 $0
++0 $1 $0
+*67 $1
+*56 D7
+*56 $4
+*52 c ]
+*52 $9
+*46 o1u
+*46 T0
+*36 K
+*34 D7
+*32 i5s
+*31 i3n
+*23 i2f
+*20 o2s
+*02 ^y
+*02 $o
+'B l
+'9 $c
+'8 i4_
+'6 $r
+'6 $p
+'4 Z2
+$e $2 $2
+$a $r $k
+$_ $2 $0 $0 $5
+$9 $9 $1 $0
+$8 i59
+$8 $8 $9 $8
+$8 $8 $7 $7
+$8 $7 $9 $0
+$7 $8 $9 $6
+$7 $0 $7 $0
+$6 {
+$5 +3
+$5 $8 $5 $8
+$5 $5 $8 $8
+$5 $5 $2 $2
+$4 y1 l
+$4 -8
+$4 $3 $1 $6
+$4 $1 $2 $3
+$3 $2 $1 $1 $2 $3
+$2 $4 $2 $2
+$2 $0 $9 $0
+$2 $0 $7 $0
+$2 $0 $6 $0
+$2 $0 $3 $1
+$1 sea
+$1 i6e
+$1 Z4
+$1 +0
+$1 $6 $2 $8
+$1 $6 $2 $1
+$1 $5 $0 $1
+$1 $4 $8 $0
+$1 $4 $4 $1
+$1 $4 $2 $9
+$1 $4 $1 $6
+$1 $3 $6 $8
+$1 $3 $3 $4
+$1 $2 $9 $9
+$1 $2 $7 $7
+$1 $2 $7 $3
+$1 $2 $6 $5
+$1 $2 $4 $8
+$1 $1 $7 $0
+$0 o0B
+$0 $2 $3 $0
+$0 $1 $5 $5
+$0 $1 $1 $8
+$0 $0 $1 $3
+$0 $0 $0 $9
+$. $c $o $m
+} [ $a
+} D1 '4
+{ $1 E
+oBi
+o5W
+o3H ]
+o3F
+o2A ]
+o1W
+o1F
+o0r o3a
+o0j $2 $0 $0 $4
+o0j $2 $0 $0 $3
+o0Z -3
+o0Z +2
+o0Z $2
+o0Y
+o0V .2
+o0V $0 $7
+o0T Y2
+o0T $2 $0 $0 $7
+o0S ,2
+o0R ,5
+o0R $1 $2 $3 $4
+o0P ,5
+o0N $1 $1
+o0J o1T
+o0D ,1
+i82 i90 ,A oB5
+i7u i8n
+i7o
+i77 o0m
+i71 ,8
+i6p o7o
+i6o i7k
+i62 i70 i80 o94
+i62 i70 ,8 o94
+i5o i6y
+i5_ i61 o73
+i51 i69 i79 ,8
+i4y .5
+i4o i5l i6a
+i4k .5
+i4a *36
+i4_ i52 o60
+i46 i55 i64 i73 i82 o91
+i42 i50 i61 o72
+i3t $1 $2 $3
+i3n i4i i5s
+i3a $i
+i2y D4
+i2s i3o i4n
+i2i $5
+i2c *76
+i2a -3
+i1p
+i1i o4a
+i1i i2n i3i
+i1i $4
+i1e i2r i3e
+i0j i1o i2h
+i0A i1u i2g
+d ] ]
+c stD
+c i23
+c i11 i32 i53 i74
+c ^1 ^0 ^0 ^2
+c R5 D6
+c '6 $9
+c $_ $2
+c $8 $0 $8 $0
+c $7 $6 $5 $4
+c $7 $0 $0 $0
+c $6 $1 $2 $3
+c $5 $6 $6 $6
+c $4 $5 $4 $5
+c $3 $@
+c $2 $9 $1 $0
+c $2 $8 $0 $3
+c $2 $6 $1 $2
+c $2 $5 $5 $2
+c $2 $5 $0 $5
+c $2 $3 $0 $8
+c $2 $3 $0 $1
+c $2 $2 $1 $5
+c $2 $2 $0 $4
+c $2 $1 $0 $1
+c $1 $9 $2 $3
+c $1 $9 $1 $2
+c $1 $7 $8 $9
+c $1 $5 $1 $5
+c $1 $4 $!
+c $1 $3 $0 $7
+c $1 $2 $5 $5
+c $1 $1 $2 $7
+c $1 $1 $2 $5
+c $1 $0 $9 $8
+c $1 $0 $8 $9
+c $0 $8 $3 $1
+c $0 $8 $1 $6
+c $0 $6 $2 $6
+c $0 $6 $2 $4
+c $0 $3 $0 $1
+c $0 $1 $0 $7
+c $0 $0 $5 $5
+c $0 $0 $2 $2
+^z ^i ^f ^a ^h
+^z ^e ^d ^l ^a ^v
+^y ^p ^p ^o ^h
+^y ^n ^r ^e ^f
+^y ^d ^r ^e ^n
+^y ^a ^k ^y ^a ^k
+^s ^u ^x ^e ^l ^a
+^s ^t ^r ^e ^b ^o ^r
+^s ^t ^h ^g ^i ^n ^k
+^s ^r ^e ^m ^r ^o ^f ^s ^n ^a ^r ^t
+^s ^o ^n ^o ^r ^c
+^s ^o ^g ^a ^r ^d
+^s ^n ^i ^f ^f ^u ^m
+^s ^i ^r ^a ^h
+^s ^e ^v ^a ^h ^c
+^s ^e ^l ^i ^u ^q ^a
+^s ^e ^k ^a ^c ^n ^a ^p
+^s ^a ^b ^b ^a
+^r ^e ^t ^t ^e ^l
+^r ^e ^n ^n ^u ^r
+^r ^e ^n ^b ^a
+^r ^e ^h ^c ^t ^e ^l ^f
+^r ^e ^g ^n ^e ^v ^a
+^r ^a ^w ^n ^a
+^p ^u ^e ^k ^a ^m
+^o ^t ^i ^v ^a ^j
+^o ^t ^i ^n ^o ^m
+^o ^t ^i ^n ^o ^b
+^o ^r ^y ^p ^s
+^o ^r ^o ^z
+^o ^r ^e ^c ^u ^l
+^o ^n ^e ^n
+^o ^n ^a ^i ^b ^a ^f
+^o ^l ^r ^a ^k
+^o ^k ^c ^i ^n
+^o ^h ^n ^i ^n ^u ^r ^b
+^o ^h ^l ^a ^v ^r ^a ^c
+^o ^d ^l ^a ^v ^s ^o
+^n ^r ^o ^b ^e ^r
+^n ^r ^b
+^n ^o ^s ^w ^a ^l
+^n ^o ^s ^i ^b
+^n ^o ^i ^t ^a ^t ^s ^y ^a ^l ^p
+^n ^i ^v ^l ^e
+^n ^i ^t ^n ^e ^u ^q
+^n ^i ^l ^r ^a ^m
+^n ^i ^b ^a ^s
+^n ^e ^b ^u ^e ^r
+^n ^d ^a
+^n ^a ^m ^e ^l ^o ^c
+^m ^u ^g ^e ^l ^b ^b ^u ^b
+^m ^k ^t
+^m ^j ^k
+^m ^a ^h ^t ^s ^e ^w
+^l ^y ^r ^r ^a ^d
+^l ^j ^a
+^l ^i ^h ^k ^i ^n
+^l ^i ^b ^a ^n
+^l ^i ^a ^s
+^l ^f ^n
+^l ^e ^r ^r ^i ^u ^q ^s
+^l ^e ^i ^r ^a ^m
+^l ^a ^n ^a ^c
+^k ^l ^i
+^j ^k ^l
+^j ^h ^g
+^j ^a ^c
+^i ^v ^o ^j
+^i ^n ^a ^r
+^i ^m ^a ^n
+^i ^l ^r ^a ^c
+^i ^l ^o ^p ^a ^n
+^i ^j ^i ^j
+^i ^c ^a ^r ^g
+^i ^b ^u ^b
+^i ^a ^w ^a ^k
+^h ^u ^h
+^h ^s ^u ^r ^c
+^h ^s ^a ^l ^c
+^g ^r ^o ^m
+^g ^n ^i ^p ^m ^u ^j
+^g ^j ^j
+^g ^g ^o ^d
+^g ^e ^b
+^g ^a ^g
+^f ^f ^u ^r
+^e ^t ^t ^e ^n ^n ^a
+^e ^t ^r ^e ^u ^m
+^e ^s ^a
+^e ^n ^y ^a ^w ^d
+^e ^n ^o ^l ^c
+^e ^l ^u ^r
+^e ^i ^r ^b
+^e ^i ^b
+^e ^g ^d ^u ^m ^s
+^e ^f ^a ^m
+^e ^e ^p
+^e ^d ^a ^k
+^e ^c ^a ^f ^r ^a ^c ^s
+^d ^e ^p
+^c ^p ^m
+^c ^o ^r
+^c ^n ^a ^r ^f
+^c ^m ^s
+^c ^i ^l
+^c ^e ^j
+^b ^o ^t
+^b ^c ^a
+^a i3e
+^a ^z ^a ^m
+^a ^t ^r ^a ^p ^s
+^a ^t ^i ^n ^o ^b
+^a ^s ^d
+^a ^r ^e ^m
+^a ^r ^e ^h
+^a ^r ^a ^n
+^a ^n ^e ^r ^a
+^a ^n ^e ^r
+^a ^n ^e ^m ^i ^x
+^a ^m ^m ^o ^m
+^a ^m ^l ^a ^s
+^a ^m ^l
+^a ^m ^a ^j
+^a ^l ^u ^m ^r ^o ^f
+^a ^l ^l ^e ^i ^r ^b ^a ^g
+^a ^l ^e ^r ^t ^s ^e
+^a ^l ^e ^l
+^a ^l ^e ^a ^f ^a ^r
+^a ^i ^t ^t ^a ^m
+^a ^h ^s ^e ^k
+^a ^d ^a ^r
+^a ^c ^i ^a ^m ^a ^j
+^K ]
+^J D6
+^I o1'
+^I $2
+^F i1l
+^E -1
+^D D4
+^B D5
+^A ,2
+^9 ^0 ^9 o30
+^9 $8
+^7 ^2 ^2 ^1
+] k ^G
+] i79 .6
+[ $1 $2 $1 $2
+K sex o1k
+E T5 i46
+D7 o4e
+D5 $y
+D4 ,6
+D4 ,4 *9B
+D3 ]
+D3 $2 $0 $0 $2
+D1 o4y
+D1 .1
+D1 ,4
+-7 *57
+-6 $i
+-5 -5 -5
+-5 ,6
+-5 *46
+-5 '9
+-5 $1
+-3 o45
+-3 $1 $2
+-0 i2n
+-0 $1 $1
++A $1
++7 Z1 k
++7 +8
++5 *54
++3 $1 $2 $3
++2 i0D
++2 Y2 *52
++2 ,4
++2 ,3
++0 y2 u
++0 $0 $4
+*84 D8
+*76 Y1 *54
+*67 o7r
+*65 o43
+*58 D7
+*43 s25
+*34 ,6
+*21 i4t
+*15 snp r
+*12 i1g
+*12 [ o6o
+*03 i3e
+*01 t *51
+*01 $8
+'A s97
+'9 D3
+'8 $i
+'7 $e
+'6 ^h
+'6 T1
+'5 i1l
+'5 ^i
+$n $g
+$i *41
+$i $1 $0
+$h c
+$g sA9 .5
+$g $1 $0
+$c $r $u $s $h
+$a $n $c $e
+$a $2 $1
+$_ $1 $0 $0
+$M $1
+$I T6
+$B $R
+$@ $m $a $i $l $. $r $u
+$9 $9 $2 $2
+$9 $9 $0 $9
+$9 $1
+$8 s61
+$8 $9 $0 $0
+$8 $8 $0 $0
+$7 i54
+$5 $6 $6 $5
+$5 $3 $5 $3
+$4 ^2 o60
+$4 $5 $1 $2
+$4 $4 $1 $1
+$3 o85
+$3 i3a
+$3 $5 $7 $0
+$3 $4 $5 $0
+$3 $2 $0 $1
+$2 i2e
+$2 $5 $1 $5
+$2 $4 $8 $9
+$2 $4 $2 $6
+$2 $4 $1 $3
+$2 $3 $7 $9
+$2 $3 $1 $5
+$2 $2 $7 $2
+$2 $2 $2 $6
+$2 $2 $2 $4
+$2 $1 $4 $1
+$2 $0 $3 $3
+$1 $6 $4 $2
+$1 $5 $9 $0
+$1 $4 $5 $7
+$1 $3 $3 $5
+$1 $3 $1 $6
+$1 $1 $5 $3
+$0 $2 $2 $9
+o9z
+o7R
+o4S
+o4I
+o3R
+o3G
+o2y $1 $2 $3 $4
+o2L @d u
+o2L
+o0y $1 $2 $3
+o0t $2 $0 $0 $4
+o0r $2 $0 $0 $1
+o0c $1 $2 $3 $4 $5
+o0Z ]
+o0Z .2
+o0Y $1 $2 $3
+o0Y $1 $0
+o0S ,4
+o0N o1O
+o0J ,6
+o0I ,5
+o0A o4A
+o0A o3A
+o0A .3
+l ] $g
+l ] $c
+i81 i90 ,A
+i7l i8o
+i71 ]
+i6s i71
+i6o i7o i8l
+i6n i7o i81
+i6n i7g
+i6i i7n i8a
+i6a i7k i8e
+i6T
+i6L
+i67 i77 ,8
+i5m $i
+i5l i6l o7o
+i5a i6m o7o
+i5E
+i50 i60 ,7 ,8
+i4r o6y
+i4i +5
+i4a o2p
+i4_ $3
+i45 i56 i67 o78
+i42 i50 ss0 $5
+i42 i50 i61 o75
+i42 i50 i60 o78
+i41 i59 i68 o70
+i3y i2m
+i3w c
+i3o i4m i5a
+i3m o0C
+i3i $o
+i3e o5a
+i3e i5a
+i3e i2N E
+i3a $o
+i34 $1
+i2r i4y
+i2e D4
+i2e $e
+i2d o4o
+i2a i3v
+i2a +3
+i2N *20
+i1r o4i
+i1r o3y
+i1m
+i1k D3
+i1i i2e
+i1h o4y
+i1e i2r i3t
+i1a i2v i3i
+i1a i1a
+c o8o
+c i4C
+c ^5 ^0 ^9 ^1
+c $x $x
+c $a $l
+c $8 $8 $7 $7
+c $6 $6 $0 $0
+c $6 $2 $6 $2
+c $5 $5 $5 $5
+c $4 $5 $0 $0
+c $4 $4 $6 $6
+c $4 $2 $0 $0
+c $3 $5 $7 $9
+c $3 $3 $3 $3
+c $2 $9 $0 $8
+c $2 $8 $0 $2
+c $2 $8 $0 $0
+c $2 $7 $0 $8
+c $2 $7 $0 $1
+c $2 $5 $1 $2
+c $2 $5 $0 $8
+c $2 $3 $3 $2
+c $2 $3 $2 $5
+c $2 $3 $2 $1
+c $2 $2 $0 $6
+c $2 $1 $1 $7
+c $2 $1 $1 $3
+c $2 $0 $1 $6
+c $1 $9 $3 $0
+c $1 $9 $1 $9
+c $1 $8 $1 $8
+c $1 $8 $0 $8
+c $1 $8 $0 $4
+c $1 $7 $0 $2
+c $1 $7 $0 $0
+c $1 $6 $1 $6
+c $1 $6 $1 $2
+c $1 $3 $5 $7
+c $1 $3 $1 $1
+c $1 $3 $0 $0
+c $1 $2 $3 $5
+c $0 $9 $1 $6
+c $0 $9 $0 $4
+c $0 $8 $0 $7
+c $0 $8 $0 $4
+c $0 $7 $8 $9
+c $0 $7 $0 $6
+c $0 $5 $2 $8
+c $0 $4 $1 $5
+c $0 $3 $2 $6
+c $0 $3 $2 $0
+c $0 $3 $1 $6
+c $0 $1 $2 $5
+c $0 $1 $0 $0
+c $0 $0 $4 $1
+c $0 $$
+^z ^e ^m ^a ^g
+^y ^t ^r ^o ^p ^s
+^y ^p ^p ^a ^l ^f
+^y ^o ^p
+^y ^k ^i ^r
+^y ^f ^o ^s
+^y ^a ^b ^n ^e ^e ^r ^g
+^x ^i ^n ^o ^e ^h ^p
+^w ^j ^j
+^t ^u ^r ^a ^n
+^t ^s ^a ^e ^b ^e ^h ^t
+^t ^r ^a ^t ^p ^o ^p
+^t ^a ^k ^r ^e ^e ^m
+^s ^o ^c ^o ^l
+^s ^i ^m ^i ^m
+^s ^e ^r ^g ^i ^t
+^s ^e ^n ^i ^m
+^s ^e ^l ^i ^m ^s
+^r ^e ^z ^a ^r
+^r ^e ^t ^x ^a ^d
+^r ^e ^t ^o ^o ^h ^s
+^r ^e ^m ^m ^i ^w ^s
+^r ^e ^m ^a ^t
+^r ^e ^d ^l ^i ^w
+^r ^a ^j ^r ^a ^j
+^p ^u ^s ^t ^a ^h ^w
+^o ^v ^e ^u ^h
+^o ^r ^r ^u ^b
+^o ^o ^r ^a ^g ^n ^a ^k
+^o ^l ^u ^h ^c
+^o ^l ^a ^h ^c
+^o ^k ^i ^t
+^o ^i ^r ^o ^g ^e ^r ^g
+^o ^h ^n ^i ^l ^u ^a ^p
+^o ^h ^n ^i ^b ^o ^r
+^o ^h ^c ^a ^h ^c
+^n ^u ^h ^s
+^n ^o ^t ^s ^g ^n ^i ^k
+^n ^o ^r ^t ^a ^g ^e ^m
+^n ^o ^o ^c
+^n ^o ^m ^i ^g ^i ^d
+^n ^o ^l ^e ^m ^r ^e ^t ^a ^w
+^n ^o ^e ^d ^i ^g
+^n ^n ^e ^k
+^n ^i ^t ^e ^m
+^n ^e ^d ^y ^a ^r ^b
+^n ^a ^r ^o ^m
+^n ^a ^n ^r ^e ^f
+^n ^a ^m ^s ^o
+^m ^r ^e
+^m ^i ^k ^a
+^m ^d ^e
+^l ^y ^k
+^l ^o ^t ^s ^i ^p
+^l ^i ^a ^n
+^l ^e ^r
+^l ^a ^a
+^k ^o ^p
+^i ^u ^m
+^i ^r ^b ^a ^g
+^i ^m ^i ^d
+^i ^m ^a ^t
+^i ^k ^i ^v
+^i ^k ^i ^r
+^i ^d ^o ^c
+^h ^s ^a ^b
+^h ^r ^a
+^h ^o ^l ^i ^h ^s
+^h ^m ^s
+^h ^j ^l
+^h ^g ^n ^i ^s
+^h ^c ^n ^u ^m
+^h ^a ^i ^m ^e ^r ^e ^j
+^h ^a ^h
+^g ^n ^i ^k ^e ^h ^t
+^g .1
+^f ^u ^s ^u ^y
+^f ^e ^i ^h ^c ^r ^e ^t ^s ^a ^m
+^f ^a ^s
+^e ^u ^q ^o ^r
+^e ^t ^r ^a ^u ^d
+^e ^s ^i ^l
+^e ^p ^o ^c
+^e ^n ^o ^m
+^e ^m ^a ^m
+^e ^l ^b ^u ^o ^r ^t
+^e ^l ^a ^g
+^e ^i ^k ^o ^o ^m
+^e ^i ^c ^a ^m
+^e ^h ^c ^s ^r ^o ^p
+^e ^e ^r ^i ^s ^e ^d
+^e ^d ^c
+^e ^a ^s
+^e ^a ^d
+^e ^a ^c
+^d ^s ^a ^e ^w ^q
+^d ^s ^a ^d ^s ^a
+^d ^n ^a ^l ^l ^o ^h
+^d ^i ^e ^r
+^d ^i ^a ^m ^r ^e ^m
+^c ^l ^e
+^c ^i ^m ^o ^c
+^c ^a ^t
+^c ^a ^n
+^b ^e ^l
+^a ^z ^z ^a
+^a ^z ^n ^o ^g
+^a ^y ^n
+^a ^x ^e ^l
+^a ^t ^s ^i ^t ^a ^b
+^a ^t ^o ^m
+^a ^t ^i ^n ^a ^u ^j
+^a ^s ^u ^o ^s
+^a ^s ^s ^i ^l ^a
+^a ^s ^o
+^a ^r ^a ^r
+^a ^r ^a ^g
+^a ^n ^n ^a ^e ^d
+^a ^n ^e ^m
+^a ^n ^a ^u ^g ^i
+^a ^m ^u ^l
+^a ^m ^i ^r ^p
+^a ^m ^a ^b ^a ^l ^a
+^a ^l ^y ^e ^l
+^a ^l ^o ^k
+^a ^l ^e ^d ^a
+^a ^l ^d
+^a ^i ^s
+^a ^i ^r ^b
+^a ^i ^l ^e ^o ^n
+^a ^i ^l ^a ^t
+^a ^h ^s ^a ^p
+^a ^h ^n ^i ^l ^e ^b
+^a ^h ^n ^i ^f ^a ^r
+^a ^f ^o ^s
+^a ^c ^o ^p ^i ^p
+^a ^c ^j
+^a ^b ^l ^e
+^a D6 *10
+^J D2
+^G i1g
+^G ^S
+^B +1
+^9 $5
+^5 ^4 ^3 ^2 ^1 o56
+^0 ^0 ^2 o32
+] i9e
+] ] c ] ]
+[ $1 $1 $2 $2
+D8 ,7
+D7 o3e
+D7 ]
+D6 $o
+D5 $o
+D4 o4L
+D4 '7
+D2 y2
+D2 $2 $0 $0 $6
+D2 $2 $0 $0 $1
+D2 $1 $2 $3 $4
+D1 o4i
+@H @1 u
+@0 ^4
+-B y2 K
+-8 o6b
+-7 ^a
+-7 ^3
+-7 E
+-7 D4
+-6 o7e
+-6 '7 i3i
+-6 $o
+-5 T0
+-3 o0A
+-3 .2
+-3 '6
+-2 $5
+-0 ]
+-0 .1
+-0 ,3
++7 $3
++6 o82
++6 o0L
++6 Z1
++6 ,7
++5 ,7
++4 Z2 *52
++4 -5
++4 $5
++2 Z2
++1 z1
++1 o3o
++1 D3 ]
++0 D5
++0 ,2
++0 $8
++0 $1 $3
+*61 Y2 [
+*56 o5j
+*54 o0H
+*54 T0 *65
+*54 E +4
+*47 *75
+*32 i1u
+*32 ^3 c
+*32 Z2
+*15 z2 '6
+*12 o0D
+*12 +2
+*04 sai
+*04 +8 D0
+*03 o0r
+*01 -4 Y2
+'B i0a {
+'A o7h
+'9 sah
+'9 o7y
+'8 i6j
+'7 Z1 T0
+'7 Z1
+'6 ^w
+$n $u $b
+$g -0
+$_ $3 $1
+$_ $2 $0 $0 $0
+$G Z1 TA
+$9 $8 $0 $0
+$9 $0 $0 $1
+$8 {
+$8 $9 $9 $8
+$7 $8 $9 $4
+$7 $5 $3 $1
+$7 $2 $2 $7
+$5 $5 $1 $1
+$5 $2 $2 $5
+$4 {
+$4 $5 $6 $9
+$4 $5 $6 $1 $2 $3
+$4 $3 $1 $2
+$3 $6 $9 $9
+$3 $4 $7 $8
+$3 $4 $5 $3
+$3 $3 $2 $3
+$3 $1 $2 $1
+$2 syi
+$2 $8 $1 $9
+$2 $7 $3 $0
+$2 $6 $7 $8
+$2 $6 $6 $2
+$2 $5 $3 $6
+$2 $4 $2 $9
+$2 $3 $1 $9
+$2 $1 $6 $9
+$2 $1 $5 $6
+$1 $8 $2 $4
+$1 $7 $1 $5
+$1 $5 $9 $8
+$1 $4 $5 $8
+$1 $4 $3 $3
+$1 $3 $8 $0
+$1 $3 $2 $2
+$1 $3 $1 $8
+$1 $3 $1 $7
+$1 $2 $7 $8
+$1 $2 $7 $6
+$1 $2 $3 $7 $8 $9
+$1 $1 $7 $7
+$1 $0 $4 $5
+$0 i57
+$0 *23
+$0 $4 $9 $9
+$0 $1 $$
+} } } } } } } } *15 '4
+o3Z ]
+o3P ]
+o3I
+o2S ]
+o2R ]
+o1u .2
+o1X D2
+o1U l
+o1T
+o1I
+o1G D3
+o1G D2
+o0t $2 $0 $0 $3
+o0n $2 $0 $0 $1
+o0m
+o0l $2 $0 $0 $3
+o0d $2 $0 $0 $5
+o0d $2 $0 $0 $4
+o0Z $0 $9
+o0Y $2
+o0V $0 $6
+o0S .3
+o0R ,2
+o0P o1E
+o0N o1Y
+o0N o1E
+o0M o2H
+o0K $1 $2 $3 $4
+o0J $2 $0 $0 $0
+l i6r o7o $e
+l ] $w
+k i0D *41
+i8p
+i7r i8i
+i72 o80 i90 oA4
+i6w i7e
+i6t i7t
+i6o i7o
+i6a o4l
+i6P
+i5y $5
+i5s i61 i70
+i5B
+i49 i58 i69 o78
+i44 i50 i64 o70
+i42 i50 i60 i74
+i3t i4r i5o
+i3i o5a
+i3e $1 $2 $3
+i32 i40 i51 o65
+i32 i40 i50 i64
+i2m [
+i2l
+i2e -3
+i2a *42
+i2a $1 $2 $3
+i1y i2m
+i1v i2a
+i1u o5a
+i1r i2m
+i1o o3o
+i1o i2h
+i1o E .6
+i1l i2e i3x
+i1i i2a
+i1h i2a
+i1e y2
+i1a i70
+i1A
+c srH sWP
+c i6p
+c i46
+c ^7 ^0 ^9 ^1
+c $9 $9 $8 $8
+c $8 $9 $1 $0
+c $8 $1 $2 $3
+c $6 $3 $2 $1
+c $5 $6 $5 $6
+c $5 $4 $0 $0
+c $4 $8 $0 $0
+c $3 $3 $6 $6
+c $3 $3 $1 $0
+c $3 $1 $1 $3
+c $3 $1 $0 $1
+c $3 $0 $0 $7
+c $2 $9 $1 $2
+c $2 $6 $0 $6
+c $2 $6 $0 $2
+c $2 $5 $0 $7
+c $2 $5 $0 $6
+c $2 $4 $0 $4
+c $2 $3 $1 $3
+c $2 $3 $0 $4
+c $2 $2 $0 $7
+c $2 $1 $2 $4
+c $2 $0 $3 $3
+c $2 $0 $1 $8
+c $1 $9 $3 $2
+c $1 $8 $1 $5
+c $1 $7 $1 $2
+c $1 $5 $1 $6
+c $1 $4 $2 $1
+c $1 $4 $0 $6
+c $1 $4 $0 $5
+c $1 $2 $4 $5
+c $1 $2
+c $1 $1 $2 $9
+c $1 $1 $2 $6
+c $1 $0 $3 $5
+c $0 $8 $0 $6
+c $0 $7 $1 $9
+c $0 $5 $2 $2
+c $0 $4 $2 $9
+c $0 $4 $1 $6
+c $0 $3 $2 $5
+c $0 $2 $2 $5
+c $0 $0 $2 $1
+c $0 $0 $1 $5
+^z ^e ^u ^q ^z ^a ^v
+^y ^r ^a ^l ^l ^i ^h
+^y ^p ^o ^p
+^y ^e ^r ^b
+^y ^e ^n ^a ^l ^e ^d
+^y ^d ^n ^a ^p
+^y ^a ^l ^p ^s ^t ^e ^l
+^x ^o ^d ^d ^a ^m
+^x ^a ^r ^t ^n ^a
+^w ^e ^f
+^t ^t ^u ^b ^y ^e ^k ^n ^o ^m
+^t ^s ^a ^b ^e ^s
+^t ^e ^r ^r ^a ^g
+^s ^t ^t ^u ^b
+^s ^t ^a ^c ^d ^l ^i ^w
+^s ^o ^l ^l ^i ^m
+^s ^o ^b ^o ^l
+^s ^k ^c ^u ^b ^r ^a ^t ^s
+^s ^i ^r ^o ^l ^f
+^s ^e ^p ^a ^r ^g
+^r ^e ^p ^o ^o ^r ^t
+^r ^e ^m ^a ^s
+^r ^e ^f ^i ^n ^e ^j
+^r ^e ^d ^a ^n
+^r ^a ^e ^b ^y ^d ^d ^e ^t
+^o ^y ^o ^l ^o ^s
+^o ^t ^s ^i ^r ^h ^c
+^o ^t ^l ^a ^b
+^o ^r ^r ^e ^p ^l ^e
+^o ^r ^e ^u ^g
+^o ^r ^d ^e ^p ^o ^a ^o ^j
+^o ^o ^d ^y ^b ^o ^o ^c ^s
+^o ^n ^i ^t ^n ^a ^s
+^o ^n ^a ^i ^l ^i ^m ^i ^x ^a ^m
+^o ^i ^v ^a ^t ^c ^o
+^o ^d ^a ^h ^s
+^o ^c ^n ^a ^r ^b
+^o ^c ^e ^h ^c
+^o ^b ^m ^i ^t
+^n ^u ^t
+^n ^u ^j ^r ^a
+^n ^o ^t ^s ^a ^e
+^n ^o ^r ^e ^h
+^n ^o ^m ^o ^l ^a ^s
+^n ^o ^l ^a
+^n ^i ^a ^z
+^n ^e ^v ^a ^h
+^n ^e ^o ^k
+^n ^e ^e ^l
+^n ^e ^d ^i ^a ^j
+^n ^a ^h ^o ^g
+^m ^r ^a ^h ^c
+^m ^h ^a
+^l ^o ^b ^r ^a
+^l ^l ^a ^b ^y ^e ^l ^l ^o ^v
+^l ^l ^a ^b ^e ^r ^i ^f
+^l ^j ^j
+^l ^e ^n ^a
+^l ^e ^i ^r ^d ^a
+^l ^e ^i ^k
+^l ^a ^c ^i ^p ^o ^r ^t
+^l $1 $2 $3
+^k ^r ^u ^t
+^k ^o ^o ^h
+^k ^l ^o ^p
+^k ^i ^t
+^k ^i ^r ^t ^a ^p
+^k ^e ^r ^h ^s
+^j ^a ^j
+^i ^n ^o ^e ^l
+^i ^m ^m ^e
+^i ^l ^l ^o ^l
+^i ^k ^a ^j
+^i ^h ^s ^o ^j
+^i ^d ^o ^k
+^i ^b ^b ^o ^b
+^h ^t ^o ^l ^s
+^h ^t ^n ^a
+^h ^s ^u ^p
+^h ^l ^a
+^h ^c ^n ^u ^r ^c
+^h ^a ^r ^a ^f
+^g ^r ^u ^b
+^g ^o ^r
+^g ^n ^u ^k
+^g ^n ^u ^h ^c
+^g ^n ^i ^f ^r ^u ^s
+^g ^n ^i ^d ^d ^u ^p
+^g ^n ^a ^y ^a ^s
+^g ^n ^a ^g ^f ^l ^o ^w
+^g ^f ^d ^s ^a
+^g ^f ^d
+^g ^a ^w
+^f ^f ^i ^r ^g
+^e ^v ^e ^n
+^e ^p ^p ^e ^p
+^e ^n ^o ^r ^y ^t
+^e ^n ^o ^n
+^e ^n ^o ^i ^m ^r ^e ^h
+^e ^n ^f ^a ^d
+^e ^l ^a ^h
+^e ^i ^g ^g ^o ^d
+^e ^e ^h ^c
+^e ^e ^f ^f ^o ^t
+^e ^c ^i ^r ^p
+^d ^r ^a ^p ^o ^e ^l
+^d ^n ^a ^t ^s
+^d ^n ^a ^l ^e ^r ^i
+^d ^e ^s
+^d ^a ^k
+^d ^a ^e ^r
+^c ^i ^r ^e c
+^b ^i ^j
+^b ^g ^i ^b
+^b ^e ^c
+^a ^w ^s
+^a ^v ^e ^d
+^a ^t ^r ^a ^k ^a ^j
+^a ^t ^m
+^a ^t ^i ^p ^u ^l
+^a ^s ^s ^i
+^a ^s ^s ^e ^n
+^a ^s ^i ^r ^b
+^a ^s ^i ^l ^e ^m
+^a ^s ^e ^d
+^a ^r ^e ^t
+^a ^r ^d ^n ^o ^l ^a
+^a ^n ^o ^e ^l
+^a ^n ^i ^l ^e ^s
+^a ^n ^i ^l ^e
+^a ^m ^s ^i
+^a ^l ^u ^h
+^a ^k ^i ^l
+^a ^i ^b ^m ^o ^l ^o ^c
+^a ^h ^s ^i
+^a ^h ^i ^m
+^a ^f ^a
+^a ^d ^j
+^a ^c ^c ^u ^l
+^X ^X $X $X
+^M ]
+^J D4
+^I +3
+^H D3
+^G +1
+^E D6
+^E *23
+^E $2
+^D ^L
+^C $7
+^A o42
+^A $3
+^2 ^3 ^4 o31 r
+^0 ^9 ^1 o35
+^( $1 $)
+[ ,5
+[ $2 $0 $0 $3
+T0 T1 T3 T4
+K smk
+D9 o9s
+D9 o7a
+D6 o6M
+D6 i1o
+D5 o5C
+D4 o4Z
+D3 o3P
+D3 o3B
+D3 -4
+D2 i4o
+D1 o2M
+D1 i3i
+D1 i2y
+D1 $1 $2 $3 $4
+C ^1 i63
+@i '9 c
+@a $1
+@9 D0 Z3
+-8 -8 -8
+-7 i6_ c
+-7 ,5
+-3 E D1
+-0 Z1
+-0 ,2
++7 +9
++7 +7 -6
++7 +7
++6 i3_
++6 ^S
++6 -7
++5 o47
++2 r
++2 o4o
++0 y2 y2
++0 $0 $2
+*B8 f 'A
+*74 o0y K
+*64 ^r
+*62 i0z
+*42 l i5n
+*36 *50
+*36 $1
+*34 o3r
+*32 *67
+*13 i40
+*13 i1i
+*06 o4m
+*02 i4u
+*02 i3y
+'9 o4.
+'6 i5p
+'6 Z2
+'5 Z1
+$v Z1
+$s *75 t
+$h $o $o
+$e D8
+$e $r $i $c $k
+$a $z $o
+$X $x
+$S $G
+$M $m
+$9 @8
+$9 $9 $0 $3
+$9 $3 $5 $7
+$8 $7
+$8 $2
+$7 $7 $8 $9
+$7 $7 $2 $1
+$7 $7 $0 $0
+$7 $6
+$6 $9 $2 $1
+$5 $5 $6 $5
+$5 $4 $4 $5
+$4 o2o
+$4 $9 $4 $9
+$4 $7 $7 $7
+$4 $5 $2 $1
+$4 $3 $4 $4
+$4 $1 $3 $4
+$3 $6 $5 $0
+$3 $4 $7 $5
+$3 $4 $2 $2
+$3 $2 $5 $4
+$3 $1 $0 $2
+$3 $0 $9 $8
+$2 i6a
+$2 $8 $8 $3
+$2 $6 $1 $4
+$2 $5 $1 $7
+$2 $4 $3 $1
+$2 $4 $1 $6
+$2 $3 $9 $9
+$2 $2 $4 $2
+$2 $2 $3 $4
+$2 $1 $4 $3
+$2 $1 $1 $9
+$2 $1 $1 $6
+$1 ,8
+$1 $8 $2 $9
+$1 $8 $2 $2
+$1 $7 $2 $0
+$1 $6 $8 $8
+$1 $3 $5 $8
+$1 $2 $7 $1
+$1 $2 $6 $9
+$1 $2 $6 $2
+$1 $2 $5 $3
+$1 $1 $7 $8
+$1 $1 $6 $7
+$1 $1 $4 $4
+$1 $0 $7 $0
+$0 Z2
+$0 $7 $0 $0
+$0 $2 $3 $1
+$0 $0 $1 $4
+} } } } '4
+o5v T0
+o4Y
+o4C ]
+o3X
+o3S ]
+o2p y4 *42
+o2G
+o1O ]
+o1J D2
+o1E D3
+o1C D2 D3
+o0p i2o
+o0p $o
+o0n $i
+o0Z *31
+o0Z $9
+o0Y $9
+o0Y $2 $2
+o0X D4
+o0O D5
+o0N .3
+o0N $1 $2 $3 $4
+o0K o4B
+o0K o1D
+o0K $2 $0 $0 $5
+o0J .4
+o0J $3 $2 $1
+o0J $1 $0 $1
+o0H o1I
+o0C ,4
+k ^Z
+i7s i8s
+i6x i6z
+i6s i71 i81
+i6o i7c
+i6i i7t i8o
+i5r i6o ,7
+i5p $p
+i5k ,6
+i5a i3e
+i5S
+i52 i60 i71
+i52 R6
+i51 R6 R4
+i4e $0 $1
+i46 i57 i66 o77
+i3y K
+i3u D5
+i3s $1 $2 $3
+i3p o4y
+i3a ,4
+i34 i43 i52 o61
+i32 i40 i50 o61
+i31 i41 i52 ,6
+i2y o4a
+i2y i3a i4n
+i2r i3i i4s
+i2r -3
+i2o Z1
+i2n i3e i4r
+i2i i3t i4e
+i1u i2y
+i1u ^s
+i1s ^e
+i1o o2y
+i1o D4
+i1h $1 $2 $3
+i1e i2y
+i1e i2l i3i
+i1a o5o
+i1a i2r i3r
+i1a i2n i3i
+i1a i1e
+c o3x
+c ^0 ^0 ^0 ^2
+c R5 R4
+c D7
+c $x T5
+c $w $o $l $f
+c $a $n
+c $9 $8 $0 $0
+c $9 $1 $0 $0
+c $7 $9 $1 $3
+c $7 $4 $5 $6
+c $5 $6 $8 $3
+c $5 $5 $4 $4
+c $5 $4 $1 $2
+c $4 $1 $4 $1
+c $4 $1 $2 $1
+c $4 $0 $4 $0
+c $2 $8 $8 $2
+c $2 $7 $1 $1
+c $2 $6 $0 $1
+c $2 $5 $0 $0
+c $2 $3 $5 $8
+c $2 $3 $3 $3
+c $2 $3 $1 $1
+c $2 $3 $0 $2
+c $2 $2 $3 $3
+c $2 $2 $3 $0
+c $2 $1 $3 $1
+c $2 $0 $2 $6
+c $2 $0 $1 $9
+c $1 $9 $0 $6
+c $1 $8 $2 $0
+c $1 $8 $1 $1
+c $1 $7 $0 $4
+c $1 $5 $0 $9
+c $1 $4 $5 $3
+c $1 $4 $1 $4
+c $1 $3 $7 $9
+c $1 $3 $2 $1
+c $1 $3 $0 $9
+c $1 $2 $2 $7
+c $1 $1 $9 $9
+c $1 $1 $8 $0
+c $1 $1 $1 $9
+c $1 $1 $1 $6
+c $0 $@
+c $0 $9 $2 $4
+c $0 $9 $1 $8
+c $0 $8 $2 $7
+c $0 $7 $0 $1
+c $0 $6 $0 $0
+c $0 $5 $1 $5
+c $0 $4 $2 $7
+c $0 $4 $1 $4
+c $0 $4 $0 $1
+c $0 $3 $1 $2
+c $0 $2 $1 $8
+c $0 $2 $1 $3
+c $0 $2 $1 $1
+c $0 $1 $2 $7
+c $0 $1 $2 $4
+c $0 $0 $3 $3
+c $0 $0 $1 $8
+c $0 $0 $1 $7
+^z ^z ^z ^z
+^z ^e ^u ^q ^s ^a ^v
+^y ^z ^z ^u ^b
+^y ^u ^h ^t
+^y ^u ^g ^y ^r
+^y ^t ^t ^o ^p
+^y ^r ^r ^e ^f
+^y ^p ^p ^e ^p
+^y ^l ^e ^r ^a
+^x ^x ^x ^x
+^x ^x ^e ^l ^a
+^w ^s ^s ^a ^p
+^w ^o ^l ^l ^e ^h
+^u ^r ^u ^r
+^t ^t ^t
+^s ^u ^o ^m ^y ^n ^o ^n ^a
+^s ^e ^n ^a ^u ^j
+^s ^e ^l ^b ^b ^e ^p
+^r ^e ^v ^o ^e ^m ^a ^g
+^r ^e ^s ^o ^j
+^r ^e ^m ^l ^i ^w
+^r ^e ^h ^a ^m
+^r ^e ^d ^w ^o ^h ^c
+^r ^a ^m ^m ^a
+^p ^r ^o ^c ^s
+^p ^m ^a ^t ^s
+^o ^y ^a ^r
+^o ^v ^o ^n ^e ^l
+^o ^v ^a ^h ^c
+^o ^t ^o ^p
+^o ^t ^i ^n
+^o ^s ^e ^u ^q
+^o ^s ^a ^g ^e ^p
+^o ^p ^a ^h ^c
+^o ^m ^i ^n ^o ^r ^e ^j
+^o ^l ^l ^e ^y
+^o ^l ^b ^a ^p ^n ^a ^u ^j
+^o ^i ^c ^i ^r ^t ^a ^p
+^o ^g ^a ^g
+^o ^d ^l ^a ^w ^s ^o
+^n ^o ^t ^g ^n ^i ^h ^s ^a ^w
+^n ^o ^t ^a ^r
+^n ^o ^s ^r ^e ^g
+^n ^o ^r ^u ^b ^i ^t
+^n ^i ^r ^o ^c
+^n ^e ^v ^a ^r ^d
+^n ^e ^r ^g
+^n ^e ^h ^o ^c
+^n ^e ^d ^n ^a ^r ^b
+^n ^a ^u ^x
+^n ^a ^n ^e ^k
+^n ^a ^m ^d
+^n ^a ^i ^l ^e
+^m ^y ^m
+^m ^o ^m ^r ^u ^o ^y
+^m ^o ^k ^l ^e ^w
+^m ^l ^p ^z ^a ^q
+^m ^i ^u ^q ^a ^o ^j
+^m ^i ^l ^a
+^l ^l ^a ^d ^n ^a ^r
+^l ^l ^a ^b ^n ^o ^g ^a ^r ^d
+^l ^i ^l ^a ^h ^k
+^l ^e ^i ^m
+^l ^e ^b ^i ^r ^a ^m
+^l ^e ^a ^y
+^l ^c ^a
+^k ^j ^h
+^k ^i ^p
+^k ^c ^e ^d
+^k ^a ^s
+^j D2
+^i ^t ^t ^a ^g ^u ^b
+^i ^s ^s ^i ^m
+^i ^r ^t ^a ^p
+^i ^r ^e ^k
+^i ^o ^i ^o
+^i ^n ^a ^l ^e ^m
+^i ^l ^l ^e ^k
+^i ^l ^a ^v
+^i ^k ^r ^a ^m
+^i ^k ^n ^a ^r ^f
+^i ^h ^s ^i ^r
+^i ^h ^c ^a ^l ^a ^m
+^i ^d ^a ^s
+^i ^b ^a ^s
+^h o2y
+^h ^s ^u ^l
+^h ^s ^r ^a ^m
+^h ^c ^c
+^h ^a ^t
+^h ^a ^d
+^h ^J
+^g ^n ^i ^l ^r ^e ^t ^s
+^f ^d ^a
+^e ^z ^a
+^e ^t ^n ^e ^g ^a
+^e ^r ^i ^m
+^e ^r ^e ^j
+^e ^p ^i ^c ^n ^i ^r ^p
+^e ^n ^s
+^e ^n ^i ^l ^e ^d ^a ^m
+^e ^n ^i ^a ^l ^b
+^e ^m ^o ^l ^a ^s
+^e ^m ^i
+^e ^l ^u ^r ^i
+^e ^l ^e ^c
+^e ^l ^b ^i ^b
+^e ^j ^e ^j
+^e ^i ^l ^e
+^e ^e ^c
+^e ^d ^a ^s
+^e ^c ^e ^i ^p ^e ^n ^o
+^e ^c ^e ^c
+^d ^r ^m
+^d ^a ^h ^s
+^c ^t ^s
+^c ^m ^k
+^c ^e ^r
+^c ^e ^p ^s
+^c ^e ^c
+^c ^a ^h
+^c ^B
+^b ^j ^b
+^b ^a ^r
+^b ^J
+^a ^s ^e ^r ^e ^h ^t
+^a ^r ^s
+^a ^r ^r ^e ^u ^g
+^a ^r ^o ^k
+^a ^p ^e ^p
+^a ^n ^o ^r ^o ^c
+^a ^n ^n ^e ^s
+^a ^n ^n ^a ^i ^g
+^a ^n ^i ^r
+^a ^n ^a ^i ^r ^b
+^a ^m ^l ^a ^p
+^a ^l ^m
+^a ^i ^n
+^a ^i ^c ^e ^r ^g
+^a ^f ^e ^s ^o ^j
+^a ^e ^y
+^a ^d ^y ^a ^j
+^a ^d ^a ^u ^g
+^a ^d ^a ^b
+^a ^c ^i ^r
+^a ^a ^l
+^_ ^o ^e ^l
+^N D4
+^C -1
+^6 ^5 ^4 ^3 ^2 ^1 o67
+^5 ^4 ^3 ^2 ^1 D6
+^3 ^3 ^2 ^2 ^1 ^1
+] *86 smy
+[ i1y
+[ .2
+[ $9 $9 $9 $9
+[ $2 $0 $0 $4
+T0 i2o $1
+E y2
+E y1
+E -2
+D5 o5S
+D4 ^K
+D4 +5
+D4 $D
+D3 o5o
+D3 o3X
+D2 i3n
+D1 o2D
+D1 $2 $0 $0 $3
+D0 seh
+-8 ,5
+-6 o0j L1
+-6 .2
+-6 -8 -8
+-6 -7
+-5 Y2
+-5 $u
+-4 o7e
+-4 o6n
+-4 ^x
+-4 -4 -4
+-3 o2c
+-3 o2a -6
+-3 ,5
+-2 Z1
+-2 K oB2
+-2 .3
+-1 i1l
+-0 i1l
++8 .6
++6 o78
++6 -5
++5 o61
++5 o0A
++2 .3
++0 i4z
++0 D4
++0 *56
++0 '7
+*76 i6r
+*75 o6e
+*68 -6
+*64 o4x u
+*64 o3i
+*56 o33
+*40 o4i
+*36 o3g
+*32 +5
+*24 K
+*23 o4u o2x
+*20 ^r s9J
+*13 y2
+*13 i4y
+*10 $6 {
+*03 .4
+'A Y2
+'9 T4
+'9 -2
+'8 i5e
+$u Z3 D8
+$i *86
+$h $u $e
+$f $1 $2 $3
+$e $r $r
+$9 {
+$9 $1 $2 $3
+$8 z1 c
+$8 $9 $0 $7
+$8 $0 $9 $0
+$7 $8 $9 $1
+$7 $7 $7 $1
+$5 i57
+$5 $5 $4 $4
+$5 $2 $1 $0
+$5 $1 $0 $0
+$4 $5 $6 $8
+$4 $5 $5 $4
+$4 $4 $3 $3
+$4 $3 $2 $4
+$3 $8 $3 $8
+$3 $4 $6 $5
+$3 $1 $6 $2
+$3 $0 $1 $3
+$2 $7 $8 $9
+$2 $7 $7 $2
+$2 $5 $5 $5
+$2 $5 $3 $4
+$2 $5 $2 $9
+$2 $4 $5 $4
+$2 $3 $7 $8
+$2 $2 $4 $3
+$2 $2 $1 $6
+$1 $7 $2 $8
+$1 $5 $2 $9
+$1 $4 $1 $7
+$1 $3 $9 $8
+$1 $2 $7 $4
+$1 $2 $5 $0
+$1 $1 $7 $6
+$0 $6 $2 $2
+$0 $0 $2 $2
+$0 $0 $1 $6
+$0 $0 $0 $3
+} ^3
+t D6 Z2
+o3V
+o3Q
+o3E
+o3C ]
+o2S
+o2P
+o2G ]
+o2D
+o1o .2
+o1Z D2
+o1P ]
+o1J D3
+o1I ]
+o1H D3
+o0s $1 $2 $3 $4 $5
+o0o -1
+o0d $1 $2 $3 $4 $5
+o0Z $9 $9
+o0Z $2 $3
+o0Y +2
+o0V $2 $2
+o0T .4
+o0S ,6
+o0L o1O
+o0K $0 $0 $1
+o0J $7 $7 $7
+o0E ,2
+o0D '6
+o0B o1O
+l ] $l
+l RA o81
+i91 iA2 iB3
+i81 i92 oA3
+i6r i7u
+i6k i71
+i62 o70 ss0 $5
+i62 i70 ,8 o93
+i5o i6l i7a
+i5a
+i5_ i61 i72 o83
+i5D
+i4a i5v o6i
+i42 i50 i60 o75
+i40 i51 i60 o72
+i3u
+i3o o4y
+i3o i4l i5o
+i3o $1 $2 $3
+i3a i7e
+i31 o42 i53 o64
+i2r i3p
+i2p *31
+i2n ^A
+i2i $i
+i2d i3y
+i1u o2y
+i1u i2a i3n
+i1o i2l i3i
+i1l o3y
+i1a i2t i3o
+i1a i2t i3i
+i1a i2i i3l
+i1a i2c i3a
+i0u ^G
+i0N i1o i2v
+c o61
+c o1v
+c i3C
+c $x $x $x
+c $_ $8
+c $9 $7 $5 $3
+c $8 $6 $4 $2
+c $8 $3 $2 $1
+c $7 $7 $1 $1
+c $7 $0 $7 $0
+c $6 $6 $8 $8
+c $6 $5 $4 $1
+c $6 $3 $0 $0
+c $5 $5 $0 $0
+c $5 $3 $5 $3
+c $5 $2 $1 $0
+c $5 $1 $2 $3
+c $4 $6 $7 $9
+c $4 $6 $4 $6
+c $3 $5 $1 $2
+c $3 $2 $3 $3
+c $2 $9 $0 $4
+c $2 $8 $0 $1
+c $2 $7 $3 $0
+c $2 $7 $0 $4
+c $2 $6 $1 $1
+c $2 $6 $0 $3
+c $2 $5 $0 $2
+c $2 $4 $0 $9
+c $2 $4 $0 $3
+c $2 $3 $6 $9
+c $2 $3 $5 $5
+c $2 $1 $9 $0
+c $2 $1 $2 $9
+c $2 $1 $1 $6
+c $2 $1 $1 $1
+c $2 $0 $9 $9
+c $1 $9 $0 $2
+c $1 $8 $7 $7
+c $1 $6 $0 $9
+c $1 $6 $0 $5
+c $1 $5 $1 $1
+c $1 $5 $0 $6
+c $1 $4 $1 $7
+c $1 $4 $0 $9
+c $1 $4 $0 $7
+c $1 $3 $0 $8
+c $1 $2 $5 $0
+c $1 $2 $3 $3
+c $1 $2 $2 $3
+c $1 $0 $6 $3
+c $1 $0 $5 $5
+c $1 $0 $4 $1
+c $0 $9 $1 $7
+c $0 $8 $2 $3
+c $0 $8 $1 $8
+c $0 $7 $1 $2
+c $0 $6 $3 $0
+c $0 $4 $2 $1
+c $0 $4 $1 $3
+c $0 $3 $2 $7
+c $0 $3 $1 $8
+c $0 $2 $2 $6
+c $0 $1 $9 $0
+c $0 $1 $1 $1
+c $0 $0 $6 $6
+c $0 $0 $3 $1
+^y ^y ^e ^h
+^y ^v ^v ^a ^s
+^y ^v ^i ^l
+^y ^u ^g ^t ^a ^h ^t
+^y ^t ^t ^a ^c
+^y ^k ^c ^a ^z
+^y ^g ^g ^e ^m
+^y ^a ^d ^y ^a ^d
+^x ^X
+^t ^o ^r ^a ^k ^a ^k
+^s ^o ^v ^e ^u ^h
+^s ^o ^n ^a ^p
+^s ^i ^l ^o ^l
+^s ^g ^o ^d ^l ^l ^u ^b
+^s ^g ^n ^a ^t ^s ^u ^m
+^s ^e ^r ^a ^o ^s
+^r ^o ^d ^a ^u ^c ^e
+^r ^e ^t ^a ^c
+^r ^e ^k ^i ^r ^t ^s
+^p ^u ^t ^a ^h ^w
+^p ^e ^e ^m
+^o ^t ^i ^l ^e ^i ^n ^a ^d
+^o ^r ^e ^z ^b ^u ^s
+^o ^r ^a ^z ^a ^l
+^o ^i ^z ^i ^r ^b ^a ^f
+^o ^d ^a ^h ^c ^a ^m
+^o ^d ^a ^g ^l ^e ^d
+^n ^o ^x ^i ^d
+^n ^o ^s ^p ^m ^o ^h ^t
+^n ^o ^s ^n ^i ^b ^o ^r
+^n ^o ^s ^i ^d ^d ^a ^m
+^n ^o ^o ^p
+^n ^o ^n ^e ^x
+^n ^n ^o ^c
+^n ^n ^e ^b
+^n ^i ^p ^p ^i ^p
+^n ^e ^d ^r ^a
+^n ^e ^d ^i ^a ^r
+^n ^a ^v ^e ^d
+^n ^a ^n ^i ^s
+^n ^a ^m ^r ^a
+^n ^a ^m ^e ^v ^a ^c
+^n ^a ^i ^t ^s ^i ^r ^k
+^n ^a ^h ^d
+^m ^o ^m ^y ^m
+^m ^k ^m
+^m ^i ^l ^a ^s
+^m ^a ^w
+^l ^r ^m
+^l ^p ^j
+^l ^l ^e ^b ^p ^m ^a ^c
+^l ^e ^a ^m
+^l ^a ^b ^o ^t ^s ^i ^r ^c
+^k ^i ^r ^a ^t
+^k ^e ^l ^a ^m
+^k ^c ^i ^l ^f
+^k ^a ^h ^s
+^j ^p ^z ^s ^k ^j ^k
+^j ^l ^a
+^j ^a ^n
+^j ^a ^l
+^j ^C
+^i ^x ^e ^s
+^i ^x ^e ^m
+^i ^r ^d ^o ^r
+^i ^r ^a ^m ^a
+^i ^n ^a ^y
+^i ^m ^a ^y
+^i ^l ^o ^j
+^i ^k ^c ^a ^j
+^i ^c ^a ^j
+^i ^W
+^h ^o ^k
+^h ^g ^u ^o ^t
+^g ^s ^a
+^g ^r ^d
+^f ^e ^e ^r
+^e o2y
+^e ^u ^g ^i ^m
+^e ^t ^a ^t ^s
+^e ^s ^a ^m
+^e ^r ^u ^t ^n ^e ^v ^d ^a
+^e ^o ^l ^c
+^e ^o ^c ^s ^o ^r
+^e ^n ^o ^c
+^e ^n ^n ^a ^s
+^e ^m ^m
+^e ^m ^a ^p
+^e ^l ^y ^l
+^e ^l ^o ^p
+^e ^l ^l ^e ^s ^i ^g
+^e ^k ^a ^c ^n ^a ^p
+^e ^k ^a
+^e ^i ^s ^i ^a ^m
+^e ^i ^n ^w ^o ^r ^b
+^e ^i ^k ^o ^o ^p
+^e ^i ^d ^o ^r ^b
+^e ^i ^d ^e
+^e ^i ^d ^d ^a
+^e ^i ^b ^b ^o ^b
+^e ^g ^e ^g
+^e ^e ^d ^e ^e ^d
+^e ^d ^u ^d ^l ^o ^o ^c
+^e ^c ^i ^d
+^e ^a ^t
+^d ^r ^a ^w
+^d ^o ^o ^d
+^d ^n ^a ^n ^r ^e ^f
+^d ^a ^s ^a
+^d ^a ^g
+^c ^c ^e
+^c ^a ^i ^n ^a ^m
+^b i2a
+^b ^u ^r
+^b ^k ^a
+^b ^e ^m
+^a ^v ^l ^a ^s
+^a ^v ^e ^n
+^a ^t ^s ^u ^b
+^a ^r ^s ^i
+^a ^p ^p ^a ^k
+^a ^p ^i ^p
+^a ^n ^o ^n
+^a ^n ^i ^l ^o ^m
+^a ^n ^i ^h
+^a ^n ^e ^l ^a ^m
+^a ^n ^e ^g
+^a ^l ^e ^a ^c ^i ^m
+^a ^j ^e ^l ^a
+^a ^i ^r ^e ^t ^a ^b
+^a ^i ^n ^a ^f ^e ^t ^s ^e
+^a ^e ^r
+^a ^e ^p
+^a ^e ^h ^r
+^a ^d ^n ^i ^l ^e ^b
+^a ^c ^i ^l ^i ^l
+^a ^c ^i ^f ^n ^e ^b
+^a ^c ^c
+^a ^b ^j
+^a ^a ^r
+^a ^a ^h
+^O o1w
+^M $2
+^L +1
+^K i1e
+^J -1
+^D ]
+^A o51
+^A -5
+^A $0 $1
+^7 ^8 ^9 ^0
+^1 ^2 ^3 D4 r
+^# D2
+] i72
+[ ,3
+T4 T5 T6 T7
+D9 o8d
+D8 o8i
+D7 o3d
+D5 o5T
+D5 +5
+D4 ssx
+D4 o4T
+D4 o4H
+D3 $a $n
+D2 o2V
+D2 .3
+D2 ,4
+D1 o2K
+D1 i3o
+D1 $4 $3 $2 $1
+D1 $2 $0 $1 $3
+@h o4g
+@H '6 ^F
+-8 o0b
+-7 }
+-6 o0F
+-5 o64
+-5 *75 *56
+-5 $i
+-4 Z2
+-4 $i
+-1 D3 ]
+-0 ,5
++7 i85
++7 i6y
++6 o73
++5 c *65
++3 .4
++2 $o
++0 o2k
++0 ^i
++0 .4
+*73 o3m
+*62 *46 o18
+*50 i5e
+*48 t D1
+*42 o0D
+*34 i4a
+*34 ]
+*24 c o29
+*16 o1y
+*15 +A }
+*12 [ ^R
+*06 ,B K
+*06
+*03 .3
+'A $a
+'9 i57
+'8 Z1
+'7 ^n
+'7 Z2
+'6 i4g
+'6 i3m
+$e K
+$d $u $d
+$a $l $a $s
+$_ $6 $7
+$N
+$< ^>
+$9 Z4
+$9 $9 $3 $3
+$9 $8 $7 $8
+$9 $2
+$9 $1 $1 $0
+$7 i53
+$7 c -0
+$7 $7 $9 $9
+$6 Z1
+$6 $6 $7 $8
+$5 $7 $9 $0
+$5 $5 $0 $5
+$5 $0 $0 $5
+$4 i4t
+$4 $5 $3 $2
+$4 $5 $0 $0
+$4 $3 $5 $6
+$3 $4 $2 $1
+$3 $4 $0 $0
+$3 $3 $4 $5
+$3 $2 $1 $6
+$3 $2 $0 $3
+$2 i5y
+$2 +0
+$2 $7 $1 $3
+$2 $5 $9 $9
+$2 $4 $3 $5
+$2 $4 $3 $2
+$2 $3 $4 $0
+$2 $3 $1 $8
+$2 $1 $4 $5
+$2 $1 $3 $3
+$2 $1 $3 $0
+$1 i86
+$1 $8 $4 $5
+$1 $6 $3 $2
+$1 $5 $7 $7
+$1 $5 $3 $2
+$1 $4 $7 $8
+$1 $4 $2 $0
+$1 $4 $0 $0
+$1 $3 $2 $7
+$1 $2 $5 $2
+$1 $2 $3 $9
+$0 $4 $!
+$0 $0 $2 $3
+$0 $0 $1 $5
+$. $1 $2 $3 $4
+$" '7 D1
+} $e [
+y2 i2y
+u ^X $X
+ssX
+o5O
+o3L ]
+o3J ]
+o2k $1 $2 $3 $4 $5
+o2J
+o2C
+o1X
+o1W D3
+o1S
+o1R
+o1M
+o1K D3
+o1I D2
+o1D
+o0u $1 $2 $3
+o0t
+o0j $2 $0 $0 $5
+o0Z $0 $5
+o0Y $2 $3
+o0W $1 $1
+o0V ,5
+o0U +1
+o0T o5o
+o0O o1M
+o0K ,1
+o0K $9 $9 $9
+o0K $1 $0 $1
+o0J $2 $0 $0 $5
+o0E o1G
+o0E $1 $1
+o0A .6
+l $g
+i81 o94
+i7s i8a
+i7r i8o
+i72 i80 ,9 oA1
+i72 +8
+i6s i71 i82
+i6o i7u
+i6l i7l
+i62 i70 i81
+i62 i70 i80 o95
+i5a -6
+i5Z E *85
+i56 +6
+i52 i60 ,7 o84
+i50 R6
+i50 -6
+i4y o5.
+i4i i5t i6o
+i4a
+i4S
+i4E
+i3o i4o ,5
+i3k $1 $2 $3
+i3i $a
+i3a i4y
+i3a i4a ,5
+i2r $1 $2 $3
+i2l i3l i4y
+i2c i3a i4s
+i2c
+i2a +0
+i2a $a
+i1u o3z
+i1o i3o
+i1h i2e
+i1e i3a
+i1a o3o
+i1a i2t i3a
+i1a i2i
+i11 i32 i53 $4
+c y1 ,3
+c siu
+c ^<
+c ^2 ^0 ^9 ^1
+c $b $u $t $t
+c $9 $8 $9 $8
+c $7 $7 $8 $9
+c $7 $7 $8 $8
+c $7 $7 $0 $0
+c $7 $6 $4 $5
+c $7 $4 $7 $4
+c $6 $6 $7 $7
+c $6 $5 $6 $5
+c $6 $4 $4 $6
+c $5 $@
+c $5 $6 $0 $0
+c $5 $5 $7 $7
+c $5 $2 $8 $0
+c $5 $2 $0 $0
+c $5 $1 $5 $1
+c $4 $8 $8 $4
+c $4 $7 $8 $9
+c $4 $5 $8 $9
+c $4 $5 $7 $8
+c $4 $4 $0 $0
+c $4 $2 $2 $0
+c $3 $6 $5 $4
+c $3 $5 $0 $0
+c $3 $2 $2 $4
+c $3 $2 $1 $1
+c $3 $2 $0 $0
+c $3 $0 $0 $8
+c $2 $9 $3 $0
+c $2 $9 $0 $7
+c $2 $8 $2 $8
+c $2 $8 $0 $5
+c $2 $7 $1 $8
+c $2 $6 $0 $5
+c $2 $5 $0 $3
+c $2 $4 $0 $6
+c $2 $3 $5 $6
+c $2 $3 $2 $6
+c $2 $3 $2 $4
+c $2 $3 $0 $0
+c $2 $0 $5 $0
+c $2 $0 $4 $5
+c $2 $0 $2 $5
+c $1 $9 $2 $8
+c $1 $9 $2 $4
+c $1 $9 $2 $2
+c $1 $5 $1 $7
+c $1 $5 $0 $5
+c $1 $5 $0 $4
+c $1 $4 $3 $0
+c $1 $4 $1 $8
+c $1 $4 $0 $4
+c $1 $3 $2 $0
+c $1 $2 $1 $6
+c $1 $1 $7 $7
+c $1 $1 $1 $7
+c $1 $0 $5 $0
+c $1 $0 $4 $5
+c $0 $9 $9 $0
+c $0 $9 $1 $4
+c $0 $8 $2 $8
+c $0 $8 $2 $0
+c $0 $8 $1 $9
+c $0 $7 $2 $8
+c $0 $6 $2 $3
+c $0 $6 $1 $7
+c $0 $6 $1 $6
+c $0 $5 $1 $4
+c $0 $4 $2 $5
+c $0 $4 $2 $0
+c $0 $3 $3 $1
+c $0 $3 $2 $8
+c $0 $2 $1 $4
+c $0 $1 $3 $1
+c $0 $1 $2 $8
+c $0 $1 $2 $6
+c $0 $0 $4
+c $0 $0 $3 $4
+c $0 $0 $2 $4
+^z ^e ^t ^i ^n ^e ^b
+^z ^e ^n ^u ^n
+^y ^r ^a ^e ^b
+^y ^e ^n ^i ^a ^l
+^y ^d ^o ^m
+^y ^a ^m ^y ^a ^m
+^u ^l ^a ^n
+^t ^t ^a ^n
+^t ^e ^e ^p
+^s ^w ^e ^r ^d ^n ^a
+^s ^s ^l
+^s ^s ^k
+^s ^r ^e ^p ^i ^v
+^s ^n ^r ^o ^c ^i ^n ^u
+^s ^a ^t ^k ^i ^s ^e ^b
+^s ^a ^r ^e ^r ^t ^n ^o ^c
+^r ^o ^j ^e ^m ^l ^e
+^r ^e ^l ^l ^i ^k ^e ^h ^t
+^r ^a ^w ^f ^o ^d ^o ^g
+^r ^a ^u ^d ^e
+^p ^u ^s ^s ^a ^w
+^o ^t ^s ^e ^r ^p
+^o ^t ^i ^l ^a ^l
+^o ^t ^i ^e ^l
+^o ^r ^e ^r ^b ^e ^f
+^o ^n ^i ^p ^e ^p
+^o ^n ^a ^s ^u ^g
+^o ^m ^a ^h
+^o ^l ^o ^j
+^o ^l ^m
+^o ^l ^e ^m ^a ^r ^a ^c
+^o ^h ^w ^r ^d
+^o ^h ^n ^u ^j
+^o ^e ^h ^t ^a ^m
+^o ^c ^i ^a ^m
+^o ^b ^o ^c ^a ^j
+^n ^y ^d ^r ^o ^j
+^n ^o ^s ^r ^e ^f ^e ^j
+^n ^n ^a ^j
+^n ^i ^d ^y ^a
+^n ^i ^a ^r ^f ^e
+^n ^e ^r ^e ^s
+^n ^e ^h ^z
+^n ^a ^t ^a ^n
+^n ^a ^n ^o ^r
+^n ^a ^i ^r
+^n ^a ^a ^n ^a ^b
+^m ^y ^k
+^m ^u ^j
+^m ^s ^k
+^m ^h ^m
+^m ^e ^e ^r
+^l ^o ^k ^i ^n
+^l ^l ^e ^h ^c ^i ^m
+^l ^l ^e ^b ^r ^e ^k ^n ^i ^t
+^l ^i ^s ^a
+^l ^i ^n ^a ^d
+^l ^e ^m ^a
+^l ^e ^h ^s
+^l ^e ^b ^a ^n ^a
+^k ^s ^k
+^k ^o ^n
+^k ^k ^a ^z
+^k ^e ^a
+^k ^c ^u ^s ^u ^o ^y
+^k ^c ^o ^r ^e ^h ^t
+^j ^d ^j
+^i ^t ^a ^c
+^i ^r ^o ^k
+^i ^r ^d ^n ^a
+^i ^p ^p ^i ^s ^s ^i ^s ^s ^i ^m
+^i ^k ^i ^p
+^i ^h ^c ^i ^p
+^i ^d ^a ^n
+^i ^b ^o ^k
+^i ^a ^z
+^i ^a ^h ^s
+^i D2
+^h ^s ^i ^d
+^h ^j ^s
+^h ^d ^a
+^h ^a ^t ^u
+^g ^s ^m
+^g ^o ^d ^j
+^g ^o ^d ^g ^i ^b
+^g ^n ^u ^b
+^g ^n ^i ^y
+^g ^a ^p
+^g ^a ^n
+^f ^o ^c
+^f ^f ^u ^t
+^f ^e ^s ^s ^u ^o ^y
+^e ^y ^e ^p ^o ^p
+^e ^u ^q ^a ^j
+^e ^t ^r ^a ^m
+^e ^t ^o ^n
+^e ^t ^a ^t
+^e ^s ^o ^j ^n ^a ^u ^j
+^e ^p ^o ^p
+^e ^n ^o ^b ^t
+^e ^n ^a ^e ^k
+^e ^m ^s
+^e ^m ^j
+^e ^l ^o ^h
+^e ^l ^d ^o ^o ^p
+^e ^k ^i ^p
+^e ^i ^t ^t ^o ^h
+^e ^i ^l ^l ^e ^k
+^e ^d ^i ^s ^t ^s ^e ^w
+^e ^c ^i ^r ^b
+^e ^C
+^d ^r ^o ^f ^f ^i ^l ^c
+^d ^i ^r ^d ^a ^m ^l ^a ^e ^r
+^d ^e ^r ^e ^h ^t
+^d ^e ^e ^r ^c
+^d ^a ^o ^t
+^d ^a ^m ^m ^a ^h ^o ^m
+^d ^a ^a ^s
+^c ^a ^r
+^a ^y ^i ^h
+^a ^t ^o ^r ^a ^g
+^a ^t ^n ^o ^m
+^a ^t ^e ^p
+^a ^t ^a ^r
+^a ^s ^t
+^a ^s ^i ^v
+^a ^r ^e ^l ^a ^v
+^a ^p ^o ^c
+^a ^n ^o ^s
+^a ^n ^o ^m ^i ^s
+^a ^n ^i ^t ^n ^e ^g ^r ^a
+^a ^n ^e ^d
+^a ^m ^s ^a
+^a ^m ^i ^t
+^a ^m ^a ^n ^a ^p
+^a ^l ^l ^e ^t ^u ^n
+^a ^i ^r
+^a ^i ^n ^a ^m
+^a ^i ^h ^c
+^a ^h ^s ^i ^l ^e
+^a ^e ^k
+^a ^e ^h ^t
+^a ^d ^e ^s
+^a ^c ^e ^d
+^a ^c ^c ^a ^m
+^a ^a ^n
+^a ^a ^a ^a
+^_ ^l ^e ^g ^n ^a
+^S o1S
+^O ]
+^G ^B
+^A $1 $2
+^9 $1
+^0 ^0 ^0 o32 r
+[ o1C
+[ $1 $9 $9 $9
+E i5V
+E T8 T4
+D5 ,6
+D4 o4N
+D2 i6r
+D1 o5o
+D1 o3i
+D1 i3u
+D1 T1
+D1 ,3
+D1 $4 $5 $6 $7
+D1 $2 $0 $0 $5
+@i o4e
+@e o2j
+@6 *24 [
+.0 i1t
+.0 D4
+-8 o5d
+-8 -8 -8 -8
+-7 o63
+-7 i68
+-7 -7 -7
+-7 $9
+-6 Y2 D3
+-5 i3i
+-4 o0P
+-4 Z1 o61
+-4 '6
+-2 *23
+-1 o3z
+-0 z1
+-0 i2l
+-0 ,4
++8 ]
++7 i5j
++7 Z1
++6 +7
++5 +5 +5 +5
++4 +4 +5
++3 o4e
++3 ]
++1 o2a
++0 .3
+*85 D8
+*68 *95
+*65 -5
+*54 i6t
+*46 *76
+*45 z1
+*30 Z2
+*24 *37 c
+*12 k ss2
+*05 ^o
+*04 smv
+*03 o3e
+'A o7b
+'A $e
+'9 -3
+'8 i49
+'7 ^<
+$m $a $c $h $o
+$h $e $w
+$a i5o
+$_ $2 $0 $0 $1
+$9 $9 $7 $7
+$9 $8 $7 $6 $5 $4
+$9 $7
+$8 $6 $4 $2
+$7 $7 $6 $6
+$6 $7 $8 $9 $0
+$6 $7 $7 $6
+$5 i6s
+$5 $6 $8 $9
+$5 $6 $7 $4
+$5 $5 $3 $4
+$4 $4 $6 $6
+$4 $1 $3 $2
+$3 $5 $0 $5
+$3 $4 $5 $4
+$3 $4 $5 $2
+$3 $3 $0 $0
+$3 $2 $1 $2
+$3 $1 $0 $4
+$3 $1 $0 $0
+$2 $7 $1 $4
+$2 $6 $2 $8
+$2 $5 $2 $4
+$2 $5 $2 $2
+$2 $4 $2 $7
+$2 $4 $1 $7
+$2 $3 $6 $4
+$2 $2 $6 $6
+$2 $2 $5 $1
+$2 $1 $3 $1
+$2 $0 $1
+$1 $8 $1 $5
+$1 $7 $1 $4
+$1 $5 $7 $9
+$1 $5 $5 $1
+$1 $5 $5 $0
+$1 $5 $2 $1
+$1 $5 $1 $9
+$1 $4 $3 $6
+$1 $4 $3 $1
+$1 $3 $4 $6
+$1 $3 $0 $0
+$1 $1 $7 $2
+$1 $1 $5 $9
+$1 $1 $1 $1 $1 $1
+$1 $0 $7 $6
+$1 $0 $5 $2
+$0 o87
+$0 *67
+$0 $3 $3 $3
+$0 $0 $9 $8
+$0 $0 $4
+$! d ]
+oBc
+o8D
+o5T o6H
+o5O o6P
+o4W
+o4U
+o2Z
+o2P ]
+o2O t
+o2N ]
+o1y $1 $2 $3 $4 $5
+o1N
+o1K D2
+o1E
+o0o $1 $2 $3
+o0Y $0 $8
+o0W .1
+o0Q $1 $2 $3
+o0M i2C
+o0K ,2
+o0K $2 $0 $0 $6
+o0E o1R
+o0D .1
+l ] $i
+l $! $!
+i7s i82
+i7i i8n o9g
+i7i i8a
+i7e ,8
+i6t i7e i8r
+i6E
+i62 i70 o81 o95
+i5y i6b i7o o8y
+i5y '6
+i5X
+i52 i60 o71 o83
+i50 i60 ,7
+i42 i50 i60 o76
+i41 i53 i61 o73
+i41 i50 i60 ,7
+i4. i51 i62 o73
+i3r $1 $2 $3
+i3o $o
+i3o $a
+i3i i4l i5o
+i3i i4e i5l
+i3c i4h i5a
+i3a o4o
+i3a i4t i5a
+i3a $1 $2 $3
+i32 i40 i50 o65
+i2r i4o
+i2l $1 $2 $3
+i2a o3o
+i1u i2l i3i
+i1o ]
+i1e i3e
+i1e i2n i3e
+i1e R2 L2
+c snP
+c i8!
+c i7! .7
+c -3 '6
+c $a $m
+c $9 $0 $0 $1
+c $8 $7 $9 $0
+c $8 $7 $6 $5
+c $8 $3 $1 $2
+c $7 $5 $7 $5
+c $7 $0 $0 $7
+c $7 $$
+c $5 $6 $8 $9
+c $5 $0 $0 $1
+c $4 $@
+c $4 $8 $4 $8
+c $4 $7 $4 $7
+c $4 $5 $9 $0
+c $4 $5 $8 $7
+c $4 $5 $4 $6
+c $4 $4 $1 $0
+c $4 $3 $4 $3
+c $4 $3 $1 $2
+c $4 $3 $0 $0
+c $4 $2 $5 $5
+c $3 $4 $2 $1
+c $3 $3 $9 $9
+c $3 $1 $2 $4
+c $3 $1 $2 $3
+c $3 $0 $2 $1
+c $2 $9 $0 $9
+c $2 $8 $1 $2
+c $2 $7 $0 $5
+c $2 $6 $0 $4
+c $2 $5 $2 $0
+c $2 $3 $1 $8
+c $2 $2 $4 $0
+c $2 $2 $3 $4
+c $2 $1 $5 $6
+c $2 $1 $4 $7
+c $2 $1 $4 $5
+c $2 $1 $3 $3
+c $2 $1 $2 $0
+c $2 $0 $9 $8
+c $2 $0 $4 $8
+c $1 $9 $2 $5
+c $1 $9 $0 $1
+c $1 $8 $1 $0
+c $1 $8 $0 $9
+c $1 $8 $0 $0
+c $1 $6 $1 $0
+c $1 $6 $0 $6
+c $1 $5 $4 $3
+c $1 $5 $1 $8
+c $1 $5 $0 $7
+c $1 $4 $1 $3
+c $1 $4 $0 $0
+c $1 $3 $0 $6
+c $1 $3 $0 $4
+c $1 $2 $5 $6
+c $1 $2 $3 $*
+c $1 $2 $2 $8
+c $1 $2 $2 $0
+c $1 $1 $6 $8
+c $1 $1 $1 $5
+c $1 $1 $1 $4
+c $1 $1 $1 $3
+c $1 $0 $6 $5
+c $0 $8 $2 $2
+c $0 $8 $1 $3
+c $0 $6 $1 $5
+c $0 $5 $2 $5
+c $0 $3 $2 $4
+c $0 $3 $2 $3
+c $0 $2 $2 $7
+c $0 $2 $1 $6
+c $0 $2 $0
+c $0 $1 $1 $2
+c $0 $0 $9 $9
+c $0 $0 $5 $2
+c $0 $0 $4 $0
+c $0 $0 $2 $0
+c $0 $0 $1 $6
+c $0 $0 $1 $4
+^y ^t ^t ^e ^l
+^y ^r ^e ^l ^a ^v
+^y ^p ^p ^a ^p
+^y ^o ^c ^o ^c
+^y ^o ^b ^y ^x ^e ^s
+^y ^n ^n ^a ^h
+^y ^m ^i ^k
+^y ^g ^g ^i ^m
+^y ^e ^l ^g ^i ^r ^w
+^y ^d ^d ^o ^t
+^y ^b ^y ^b
+^y ^a ^n ^y ^a ^n
+^w ^e ^t
+^w ^e ^m ^w ^e ^m
+^t ^a ^b ^m ^o ^k ^l ^a ^t ^r ^o ^m
+^s ^s ^p
+^s ^s ^a ^s
+^s ^g ^u ^p
+^s ^e ^l ^a ^z ^n ^o ^g
+^s ^a ^l ^o ^h
+^r ^i ^d ^a ^n
+^r ^e ^l ^i ^k
+^r ^e ^b ^e ^l ^k
+^r ^a ^m ^u
+^r ^a ^m ^o ^j
+^o ^y ^o ^g
+^o ^t ^u ^t
+^o ^t ^r ^e ^b ^l ^i ^g
+^o ^r ^i ^p ^m ^a ^v
+^o ^n ^i ^n ^e ^m
+^o ^n ^a ^m ^r ^e ^h
+^o ^m ^i ^n ^o ^r ^e ^g
+^o ^l ^l ^i ^r ^a ^m ^a
+^o ^l ^l ^i ^m
+^o ^j ^n ^e ^b
+^o ^j ^a ^r ^a ^c
+^o ^i ^x
+^n ^y ^l ^h ^s ^a
+^n ^o ^s ^r ^e ^p
+^n ^o ^r ^r ^a
+^n ^o ^r ^e ^i ^k
+^n ^o ^o ^s
+^n ^o ^m ^i ^t
+^n ^o ^d ^i ^e ^s ^o ^p
+^n ^i ^v ^r ^a
+^n ^i ^v ^a ^d
+^n ^i ^t ^n ^i ^t
+^n ^i ^r ^p
+^n ^i ^m ^z ^a ^y
+^n ^i ^m ^o ^d
+^n ^e ^d ^i ^a ^c
+^n ^a ^y ^a ^r ^b
+^n ^a ^y ^a
+^n ^a ^m ^z
+^n ^a ^m ^y ^e ^k ^n ^o ^m
+^n ^a ^m ^w ^o ^n ^s
+^n ^a ^m ^w ^e ^n
+^n ^a ^m ^r ^e ^h ^s
+^n ^a ^l ^i ^m ^c ^a
+^n ^a ^l ^i ^d
+^m ^z ^l ^a ^p ^q
+^m ^u ^p
+^m ^o ^s ^s ^o ^l ^b
+^m ^m ^s
+^m ^i ^a ^n
+^m ^a ^r ^b ^a
+^l ^o ^b ^e ^t ^u ^f
+^l ^i ^h ^a ^s
+^l ^e ^t ^s ^a ^p
+^l ^a ^z
+^l ^a ^t ^i ^v
+^l ^a ^n
+^l ^J
+^k ^u ^p
+^k ^r ^a ^t ^s
+^k ^n ^a ^y
+^k ^m ^s
+^k ^e ^s
+^k ^a ^e ^t ^s
+^j ^r ^m
+^j ^c ^m
+^i ^v ^o ^n
+^i ^t ^u ^t
+^i ^t ^u ^g
+^i ^s ^i ^l
+^i ^r ^r ^a ^h
+^i ^r ^a ^p
+^i ^n ^e ^g
+^i ^n ^a ^k
+^i ^m ^u ^s
+^i ^m ^m ^a ^s
+^i ^k ^u ^s ^t ^a ^k ^a
+^i ^k ^a ^p
+^i ^h ^c ^i ^r
+^i ^d ^a ^l ^v
+^i ^b ^o ^r
+^i ^a ^n ^a
+^h ^s ^a ^l ^p ^s
+^h ^p ^o ^s
+^h ^g ^i ^e ^l ^y ^a ^k
+^h ^c ^t ^u ^h
+^h ^a ^t ^e ^e ^h ^c
+^h ^a ^d ^u ^j
+^g ^n ^o ^k ^g ^n ^i ^k
+^g ^n ^i ^m ^m ^i ^w ^s
+^g ^n ^a ^s
+^g ^e ^p
+^g $1 $2 $3
+^e ^s ^r ^e ^v ^n ^o ^c
+^e ^n ^i ^s
+^e ^m ^o
+^e ^m ^m ^e
+^e ^m ^a ^n ^o ^n
+^e ^l ^g ^g ^i ^g
+^e ^i ^t ^t ^i ^k
+^e ^i ^m ^m ^a ^s
+^e ^i ^g ^r ^o ^e ^g
+^e ^h ^c ^e ^l
+^e ^e ^r
+^e ^e ^l ^y ^r
+^e ^d ^a ^h ^s
+^d ^j ^j
+^d ^i ^r ^a ^f
+^c ^c ^j
+^b ^o ^l ^b
+^b ^b ^e ^w
+^a ^z ^e ^r
+^a ^t ^i ^r ^a ^s
+^a ^t ^i ^m ^a ^m
+^a ^s ^s ^i ^a ^r
+^a ^r ^r ^e ^i ^t
+^a ^r ^m
+^a ^r ^e ^v ^i ^r
+^a ^r ^e ^i ^v ^a ^j
+^a ^r ^a ^l ^i ^d
+^a ^m ^a ^s ^o
+^a ^l ^o ^p
+^a ^l ^o ^n
+^a ^l ^i ^v ^a
+^a ^l ^a ^y ^a
+^a ^k ^u ^k
+^a ^j ^c
+^a ^i ^f
+^a ^i ^c ^n ^e ^l ^a ^v
+^a ^h ^i ^h ^c ^u
+^a ^g ^e ^t ^r ^o
+^a ^e ^v ^o ^l ^i
+^a ^e ^c
+^a ^d ^l ^a ^r ^e ^m ^s ^e
+^a ^d ^a ^r ^t ^s ^e
+^a ^d ^a ^m ^a ^h
+^a ^b ^i ^k
+^N ]
+^N D5
+^N +1
+^K z1
+^H -1
+^D ^3
+^D '6
+^C +1
+^B ]
+^2 T1
+^1 ^0 ^2 o33
+] o5V o4T
+] $a Y1
+[ $1 $2 $3 $4 $5 $6
+E *75
+D8 o81
+D7 $i
+D4 i7s
+D3 o3K
+D3 o3G
+D2 o2S
+D1 $D
+D1 $2 $0 $0 $1
+D1 $1 $2 $3 $4 $5
+D1 $1 $2 $3 $3 $2 $1
+C z2 o04
+@0 o4x -7
+.0 ]
+.0 ,4
+.0 $2 $2
+-9 i6-
+-9 -9 -9 -9
+-7 z1 D2
+-7 sea
+-6 i74
+-6 ] $7
+-3 D5
+-2 $o
++7 i8e
++7 *67 Y1
++6 i64
++6 i3j
++5 ^B
++4 o82
++0 c $5
++0 ,4
+*87 o76
+*76 +5
+*75 c o4h
+*57 T5 D3
+*53 R5
+*52 Z2
+*45 o4h
+*32 ^A
+*14 i3l
+'7 o59
+'7 R5 o2c
+'7 $1 $2 $3 $4
+'6 p2
+'6 ^p
+'6 $9
+$s ^D
+$o $1 $2 $3 $4
+$a i6i
+$L $O $L
+$J $r
+$@ $1 $2 $3 $4 $5
+$9 $9 $0 $2
+$8 o4c L6
+$8 $8 $2 $2
+$7 $8 $9 $9
+$7 $8 $7 $9
+$5 $7 $8 $9
+$5 $4 $1 $2
+$5 $2 $3 $4
+$5 $0 $0 $1
+$4 D9
+$4 $5 $1 $3
+$3 $3 $0 $4
+$2 Z1 ,7
+$2 $7 $9 $9
+$2 $4 $2 $3
+$2 $3 $4 $1
+$2 $3 $3 $4
+$2 $2 $2 $5
+$2 $1 $9 $9
+$1 $8 $2 $0
+$1 $7 $2 $7
+$1 $5 $2 $2
+$1 $3 $1 $9
+$1 $2 $$
+$1 $1 $3 $7
+$0 $2 $2 $2
+$0 $1 $4
+$!
+q '5
+oAy
+o5T
+o5P ]
+o51 i62 i73 i84 sS5 $6
+o4O
+o2I
+o2H
+o1V D3
+o1H
+o1G ]
+o1G
+o0y $o
+o0t $1 $2 $3 $4
+o0Z $0 $7
+o0T o1Y
+o0T $2 $0 $0 $6
+o0N .4
+o0M o2R
+o0K o5M
+o0J .1
+o0D o2K
+o0D o2C
+o0C ,1
+o0A o5A
+o0A ,3
+i90 iA0 iB3
+i8a i9t
+i82 o95
+i7a i8n i9g
+i7P c
+i71 i82 i93 iA4 oB5
+i7$
+i6i i7t i8a
+i6R
+i62 i70 i80 o93
+i5e -6
+i5b i7e
+i5H
+i5C
+i59 i69 ,7
+i4a +5
+i45 i50 i60 ,7
+i44 i50 i60 ,7
+i43
+i41 i59 i67 ,7
+i41 i52 i63 o74
+i41 i52 i63 i74 i85 i96 iA7 iB8 oC9
+i41 i52 i63 i73 i82 o91
+i40 D6
+i3a ,4 ,5
+i3a $a
+i32 i40 ,5
+i2r i3i i4o
+i2l i3i i4e
+i21 i32 i43 i54 o65
+i1y i2l
+i1u i2i
+i1r i2e i3n
+i1r $1 $2 $3
+i1p i2p
+i1i i2k i3o
+i1g i2u
+i1e i2a i3n
+i1a o4o
+i1S c
+i0S i1h D4
+c i3H
+c ^4 ^0 ^0 ^2
+c '6 $2
+c $8 $9 $1 $1
+c $8 $9 $0 $1
+c $8 $8 $2 $2
+c $8 $0 $9 $0
+c $8 $0 $0 $8
+c $7 $9 $0 $0
+c $7 $8 $8 $7
+c $7 $5 $3 $1
+c $6 $9 $0 $0
+c $6 $7 $8 $0
+c $6 $6 $2 $6
+c $6 $5 $7 $8
+c $6 $5 $4 $3
+c $6 $3 $6 $3
+c $6 $0 $0 $0
+c $5 $7 $8 $9
+c $5 $7 $0 $0
+c $5 $6 $3 $2
+c $5 $3 $1 $3
+c $5 $2 $8 $8
+c $4 $6 $8
+c $4 $5 $1 $2
+c $4 $4 $8 $8
+c $3 $5 $5 $3
+c $3 $4 $3 $4
+c $3 $3 $1 $3
+c $3 $2 $0 $4
+c $3 $1 $2 $7
+c $3 $0 $1 $3
+c $2 $9 $0 $3
+c $2 $8 $1 $1
+c $2 $4 $1 $3
+c $2 $3 $4 $6
+c $2 $3 $1 $9
+c $2 $3 $1 $6
+c $1 $9 $3 $3
+c $1 $9 $1 $3
+c $1 $8 $0 $1
+c $1 $7 $2 $0
+c $1 $7 $1 $4
+c $1 $6 $2 $2
+c $1 $6 $0 $0
+c $1 $4 $5 $6
+c $1 $4 $2 $5
+c $1 $4 $2 $2
+c $1 $4 $0 $8
+c $1 $3 $2 $4
+c $1 $3 $0 $3
+c $1 $2 $9 $9
+c $1 $2 $6 $9
+c $1 $2 $1 $7
+c $1 $1 $3 $3
+c $1 $1 $3 $2
+c $1 $0 $7 $5
+c $0 $9 $2 $8
+c $0 $9 $1 $3
+c $0 $8 $3 $0
+c $0 $8 $2 $5
+c $0 $7 $2 $1
+c $0 $7 $2 $0
+c $0 $6 $2 $5
+c $0 $6 $2 $1
+c $0 $5 $2 $1
+c $0 $5 $1 $9
+c $0 $5 $1 $3
+c $0 $4 $1 $9
+c $0 $3 $2 $1
+c $0 $3 $1 $9
+c $0 $3 $0 $0
+c $0 $1 $2 $1
+c $0 $1 $1 $8
+c $0 $1 $1 $7
+c $0 $0 $3 $2
+c $0 $0 $2 $3
+^z ^i ^p ^a ^l
+^y ^t ^u ^c
+^y ^l ^o ^o ^c
+^y ^e ^l ^k ^r ^a ^b
+^y ^b ^b ^o ^t
+^u ^o ^y ^u ^o ^y
+^t ^a ^c ^y ^t ^t ^i ^k
+^s ^t ^u ^n ^o ^d
+^s ^s ^o ^b ^e ^h ^t
+^s ^s ^e ^n ^e ^m ^o ^s ^e ^w ^a
+^s ^r ^o ^i ^r ^r ^a ^w
+^s ^i ^l ^e ^g ^n ^a
+^s ^g ^u ^h
+^s ^e ^l ^k ^c ^e ^r ^f
+^s ^d ^r ^e ^n
+^s ^a ^l ^i ^u ^g ^a
+^r ^o ^d ^a ^t ^a ^m
+^r ^e ^t ^n ^u ^g
+^r ^e ^p ^p ^i ^h ^c
+^r ^e ^k ^a ^j
+^r ^b ^b
+^r ^a ^z ^a ^l ^a ^s
+^r ^a ^n ^o ^e ^l
+^p ^u ^y
+^p ^e ^e ^p
+^o ^z ^n ^o ^l ^a
+^o ^t ^r ^a ^g ^a ^l
+^o ^t ^i ^u ^q ^a ^p
+^o ^t ^i ^o ^c ^s ^i ^b
+^o ^t ^i ^d ^r ^o ^g
+^o ^r ^a ^j ^a ^p
+^o ^n ^a ^r ^r ^e ^s
+^o ^n ^a ^c ^l ^o ^v
+^o ^l ^o ^c ^o ^l ^o ^c
+^o ^l ^i ^m ^a ^k
+^o ^h ^w ^r ^o ^t ^c ^o ^d
+^n ^y ^r ^a ^t
+^n ^w ^o ^t
+^n ^o ^t ^y ^a ^d
+^n ^o ^o ^l ^l ^a ^b
+^n ^i ^l ^a ^t ^a ^c
+^n ^i ^k ^h ^c ^n ^u ^m
+^n ^e ^v ^e ^d
+^n ^e ^r ^o ^s
+^n ^a ^y ^a ^r
+^n ^a ^u ^e
+^m ^o ^r ^p
+^m ^o ^o ^b ^m ^o ^o ^b
+^m ^i ^k ^a ^h
+^m ^a ^z ^a ^h ^s
+^l ^u ^z
+^l ^o ^c ^a ^r ^a ^c
+^l ^l ^e ^w ^o ^p
+^l ^i ^j
+^l ^a ^r ^e ^g
+^k ^s ^j
+^k ^o ^o ^m
+^k ^e ^m
+^k ^c ^i ^r ^e ^d
+^i ^s ^s ^a ^m
+^i ^p ^e ^p
+^i ^m ^o ^r
+^i ^k ^u ^u ^y
+^i ^k ^a ^z
+^i ^h ^c ^o ^m
+^i ^b ^a ^s ^a ^w
+^h ^s ^i ^r ^t
+^h ^s ^i ^r ^k
+^h ^o ^i ^g ^u ^y
+^h ^c ^n ^u ^p
+^h ^a ^w
+^h ^a ^f
+^g ^n ^i ^t ^r ^o ^p ^s
+^g ^f ^a
+^g ^d ^j
+^f ^e ^s
+^f ^a ^k
+^e z1 E
+^e ^y ^t
+^e ^t ^y ^a ^m
+^e ^p ^u ^l ^a ^d ^a ^u ^g
+^e ^o ^t
+^e ^n ^o ^j
+^e ^n ^o ^d
+^e ^n ^a ^d ^i ^z
+^e ^n ^a ^b
+^e ^l ^k ^n ^i ^w ^t
+^e ^i ^z ^n ^e ^k ^c ^a ^m
+^e ^i ^r
+^e ^i ^f
+^e ^e ^r ^c
+^d ^r ^a ^z ^a ^h
+^d ^n ^a ^r
+^d ^i ^l ^a ^h ^k
+^d ^a ^e ^h ^d ^e ^r
+^c ^n ^a
+^c ^l ^d
+^c ^i ^p
+^b ^o ^k
+^b ^o ^b ^e ^g ^n ^o ^p ^s
+^b ^a ^a
+^a ^z ^a ^z
+^a ^t ^i ^l
+^a ^t ^a ^r ^i ^p
+^a ^s ^a ^p
+^a ^r ^y ^m
+^a ^r ^i ^m ^a ^s
+^a ^r ^e ^s
+^a ^p ^p ^i ^p
+^a ^n ^u ^y
+^a ^n ^n ^e ^i ^s
+^a ^n ^n ^a ^i ^r ^a
+^a ^n ^i ^p
+^a ^n ^i ^b
+^a ^n ^e ^s
+^a ^n ^a ^p
+^a ^n ^a ^i ^l ^e
+^a ^l ^y ^l
+^a ^l ^s ^e ^t
+^a ^l ^r ^o
+^a ^l ^o ^s
+^a ^l ^e ^u ^c ^s ^e
+^a ^h ^s ^e ^y ^a
+^a ^h ^p
+^a ^h ^c ^o ^r
+^a ^h ^a ^b
+^a ^g ^o ^g
+^a ^d ^r ^o ^g
+^P o1P
+^N D2 D3
+^J D5
+^E i1l
+^D $7
+^1 ^2 ^3 ^4 ^5
+^0 ^9 ^0 o39
+^0 ^0 ^6 o32 r
+] i5h c
+] ] $1
+] -7
+[ ,4
+E .5
+D3 sea
+D3 i4y
+D2 i3u
+D2 R4
+D2 $1 $2 $3 $4 $5
+D1 $5 $6 $7 $8
+-6 i4k
+-6 i4j
+-6 $4
+-3 y3
+-3 .4
+-2 i3h
+-2 D4
+-2 $1 $2
++9 *9A sjy
++8 soa
++8 o5s
++5 ] } } } } '4
++5 '9
++4 o56
++3 i2A c
++0 i17
++0 $o
++0 $7 $7 $7
++0 $0 $3
+*98 +9
+*79 -8
+*63 D3
+*54 o5m
+*52 o0B
+*49 .3 o2z
+*47 o4v
+*41 i2l
+*40 *12
+*31 o2y
+*23 o0T
+*23 i4u
+*09 s86
+'A K
+'9 i45
+'7 -5
+'6 i3r
+$g $i $r $l
+$a i5r
+$a $p $i
+$a $1 $2 $3 $4
+$9 *97
+$9 $9 $9 $8
+$9 $9 $0 $8
+$9 $1 $0 $1
+$8 $3 $8 $3
+$7 +A
+$7 $7 $7 $9
+$7 $3
+$5 o7o
+$5 .7
+$5 $6 $1 $0
+$5 $4 $6 $7
+$4 @5 t
+$4 $5 $5 $6
+$4 $3 $2 $3
+$3 @e
+$3 .5
+$3 +8
+$3 *74
+$3 $6 $0 $0
+$3 $4 $3 $5
+$3 $2 $3 $4
+$3 $2 $3 $1
+$3 $2 $2 $2
+$3 $1 $1 $1
+$2 o67
+$2 *56
+$2 $9 $0 $2
+$2 $8 $9 $8
+$2 $7 $2 $8
+$2 $5 $4 $6
+$2 $5 $3 $3
+$2 $5 $1 $6
+$2 $5 $1 $4
+$2 $4 $2 $1
+$2 $4 $1 $4
+$2 $3 $5 $4
+$2 $3 $4 $4
+$2 $2 $9 $9
+$2 $2 $5 $7
+$2 $2 $5 $4
+$2 $2 $3 $2
+$1 $7 $2 $3
+$1 $6 $2 $6
+$1 $6 $2 $3
+$1 $5 $7 $6
+$1 $4 $4 $4
+$1 $4 $1 $3
+$1 $3 $7 $8
+$1 $3 $5 $6
+$1 $2 $4 $4
+$1 $2 $4 $2
+$1 $2 $3 $8
+$0 o0G
+$0 D9
+$0 $0 $9 $0
+$0 $0 $3 $4
+{ i0K
+ssS
+o8E
+o64 ,8 Z1
+o5Y
+o4T ]
+o4C
+o3Y
+o1Y D2
+o1U ]
+o1K D2 D3
+o0r $1 $2 $3 $4
+o0k $2 $0 $0 $2
+o0j $1 $2 $3 $4 $5
+o0Z $3
+o0U ]
+o0T i1J
+o0K i1K
+o0J $4 $5 $6
+o0I o1P
+o0G ,5
+o0G ,1
+o0E $1 $2 $3 $4
+l ^y ^m
+l ] $Z
+i8k i9a
+i7y c
+i7l i8o i9l
+i7c i8o
+i6n i7t
+i62 i70 i80 i92
+i5o $k
+i4X
+i44 i53 i62 o71
+i42 i50 i60 i72
+i41 i59 i69 o78
+i41 i59 i68 o77
+i41 i52 i61 o72
+i41 i51 i61 ,7
+i41 i50 i61 o70
+i40 i54 i60 o74
+i40 i52 i60 o72
+i40
+i3u i4u ,5
+i3o ,4 ,5
+i3i $s
+i3a i41 o52
+i32 i40 i50 o62
+i32 i40 i50 i63
+i1u i3n
+i1i i3i
+i1i i2y
+i1i i2l i3i
+i1e o5m
+i1e i2x
+c sa@
+c o19
+c ^8 ^9 ^9 ^1
+c *80 +3
+c $9 $9 $8 $7
+c $9 $1 $2 $3
+c $9 $1 $1 $9
+c $9 $0 $8 $0
+c $8 $8 $0 $0
+c $8 $$
+c $7 $@
+c $7 $6 $6 $6
+c $7 $4 $1 $1
+c $7 $3 $7 $3
+c $7 $3 $2 $1
+c $7 $1 $7 $1
+c $6 $5 $4 $4
+c $6 $4 $6 $4
+c $6 $4 $3 $2
+c $6 $0 $6 $0
+c $5 $9 $1 $0
+c $5 $8 $5 $8
+c $5 $8 $0 $0
+c $5 $5 $1 $1
+c $5 $5 $0 $5
+c $5 $4 $6 $5
+c $5 $4 $2 $1
+c $5 $1 $4 $7
+c $5 $0 $1 $0
+c $4 $5 $2 $3
+c $4 $#
+c $3 $4 $3 $5
+c $3 $4 $0 $0
+c $3 $3 $1 $2
+c $3 $2 $3 $5
+c $3 $2 $1 $2
+c $2 $9 $0 $5
+c $2 $7 $0 $9
+c $2 $5 $0 $4
+c $2 $4 $5 $6
+c $2 $4 $2 $5
+c $2 $3 $8 $9
+c $2 $3 $5 $4
+c $2 $3 $4 $3
+c $2 $3 $4 $2
+c $2 $3 $1 $4
+c $2 $2 $2 $3
+c $2 $1 $1 $8
+c $2 $0 $2 $2
+c $1 $8 $9 $0
+c $1 $7 $0 $5
+c $1 $6 $0 $7
+c $1 $6 $0 $1
+c $1 $5 $9 $5
+c $1 $5 $2 $5
+c $1 $5 $0 $3
+c $1 $4 $8 $5
+c $1 $3 $1 $6
+c $1 $2 $7 $8
+c $1 $2 $5 $8
+c $1 $2 $2
+c $1 $1 $5 $5
+c $1 $0 $7 $7
+c $1 $0 $7 $0
+c $0 $9 $2 $7
+c $0 $7 $1 $7
+c $0 $6 $2 $8
+c $0 $6 $2 $0
+c $0 $6 $1 $9
+c $0 $5 $5 $5
+c $0 $5 $2 $6
+c $0 $5 $2 $4
+c $0 $5 $1 $8
+c $0 $4 $2 $6
+c $0 $4 $2 $2
+c $0 $2 $2 $8
+c $0 $2 $2 $3
+c $0 $2 $2 $1
+c $0 $1 $5 $9
+c $0 $1 $1 $3
+c $0 $0 $5 $6
+c $0 $0 $0 $7
+^y ^v ^a ^s
+^y ^u ^y
+^y ^l ^l ^i ^m ^e
+^y ^l ^a ^g ^a ^m
+^y ^e ^l ^r ^a
+^u ^k ^o ^g ^n ^o ^s
+^t ^a ^k ^y ^t ^t ^i ^k
+^t ^a ^c ^g ^o ^d
+^s ^t ^r ^a ^f
+^s ^s ^s ^s
+^s ^s ^a ^c ^u ^l
+^s ^r ^a ^g ^u ^o ^c
+^s ^o ^g ^e ^u ^j
+^s ^k ^w ^a ^h ^a ^e ^s
+^s ^i ^r ^a ^m ^a ^d
+^r ^i ^a ^y
+^r ^e ^v ^a ^e ^w
+^r ^e ^t ^u ^o ^w
+^r ^e ^n ^e ^f
+^r ^e ^k ^n ^a ^t
+^r ^e ^k ^a ^t ^r ^e ^d ^n ^u
+^r ^e ^g ^u ^s
+^p ^u ^z ^a ^w
+^p ^p ^o
+^p ^o ^i ^u ^y ^t ^r ^e ^z ^a
+^o ^y ^e ^y
+^o ^t ^i ^u ^g ^e ^i ^d
+^o ^t ^i ^l ^o ^n ^a ^m
+^o ^t ^i ^h ^c ^n ^a ^p
+^o ^l ^a ^c ^n ^o ^g
+^o ^h ^n ^i ^t ^i ^v
+^o ^d ^r ^a ^l ^l ^a ^g
+^o ^d ^i ^h ^c
+^n ^u ^s ^m ^a ^s
+^n ^u ^a
+^n ^o ^m ^a ^i ^d
+^n ^o ^l ^e ^p
+^n ^i ^v ^r ^i
+^n ^i ^l ^t ^i ^a ^k
+^n ^i ^k ^e
+^n ^e ^n
+^n ^e ^l ^r ^a ^m
+^n ^e ^d ^y ^a ^c
+^n ^e ^d ^n ^e ^r ^b
+^n ^a ^t ^a ^n ^o ^j
+^n ^a ^m ^z ^u ^g
+^n ^a ^m ^o ^y
+^n ^a ^i ^c
+^n ^a ^g ^a ^e ^r
+^m ^y ^s
+^m ^o ^b ^m ^o ^b
+^m ^k ^k
+^m ^k ^a
+^m ^a ^r ^i ^h
+^l ^a ^d ^i ^v
+^k ^l ^k
+^k ^a ^c
+^j ^r ^a
+^i ^r ^e ^j
+^i ^n ^i ^h ^g ^r ^o ^b ^m ^a ^l
+^i ^n ^a ^s
+^i ^n ^a ^h ^s
+^i ^l ^e ^k
+^i ^c ^a ^n
+^i ^c ^a ^l
+^i ^c ^a ^k
+^h ^t ^a ^b
+^h ^n ^i ^l
+^h ^c ^t ^i ^t ^s
+^g ^u ^b ^y ^d ^a ^l
+^g ^n ^o ^h ^c
+^g ^m ^l
+^g ^i ^t
+^f ^r ^e ^d
+^e ^t ^t ^a ^l
+^e ^t ^a ^t ^a ^p
+^e ^s ^n ^o ^m
+^e ^s ^a ^j
+^e ^o ^j ^e ^o ^j
+^e ^n ^o ^e ^l
+^e ^n ^i ^s ^s ^a ^y
+^e ^n ^i ^r ^e ^v ^l ^o ^w
+^e ^m ^a ^g ^e ^h ^t
+^e ^k ^e ^p
+^e ^i ^z ^z ^i
+^e ^i ^o ^z
+^e ^g ^r ^a ^s
+^e ^e ^j
+^e ^d ^a ^d
+^e ^c ^r ^e ^i ^p
+^e ^c ^a ^p
+^d ^r ^a ^u ^g
+^d ^r ^a ^t ^e ^r
+^d ^i ^a ^l ^o ^o ^k
+^d ^e ^y ^s
+^c $1 $2 $3
+^b i3a
+^a ^z ^a ^r
+^a ^y ^a ^n
+^a ^v ^l ^e
+^a ^t ^n ^a ^m
+^a ^s ^s ^a
+^a ^r ^r ^e ^p
+^a ^r ^o ^z
+^a ^n ^r ^i ^m
+^a ^n ^e ^p
+^a ^n ^e ^m ^i ^j
+^a ^n ^d ^a ^i ^r ^a
+^a ^n ^a ^v
+^a ^n ^a ^b
+^a ^l ^r
+^a ^l ^i ^s
+^a ^l ^i ^r ^o ^g
+^a ^l ^e ^n ^a ^c
+^a ^l ^a ^t
+^a ^k ^o ^k
+^a ^k ^o ^j
+^a ^j ^r ^o ^b
+^a ^i ^r ^d ^a
+^a ^i ^c ^i ^r ^t
+^a ^h ^c ^n ^a ^p
+^a ^g ^r ^a ^m
+^a ^f ^a ^s
+^a ^f ^a ^f
+^a ^c ^u ^c
+^a ^c ^i ^p
+^a ^c ^e ^b
+^G z1
+^E o63
+^A +6
+^4 T1
+^2 ^1 i61 o72
+^2 ^1 ^1 o32
+] $6
+T1 T2 T4
+DA
+D9 D6 o3t
+D7 i5i
+D3 o3C
+D1 o3P
+D1 o3D
+D1 o3C
+D1 o2P
+D1 o2H
+D1 o2F D3
+D1 o1F D3
+D1 $o
+D1 $X
+D1 $1 $1 $2 $2 $3 $3
+-8 -8
+-7 Z1
+-7 .6
+-6 ^#
+-5 o3_
+-5 o0G
+-5 l *68
+-4 o0G
+-4 $c $e
+-2 i62
+-2 i3f
+-1 o0T
+-0 $2 $0 $0 $1
++A +A
++6 o74
++6 *83 D3
++3 $1 $2 $3 $4
++1 ^D sG!
++0 i1h
++0 $1 $2
+*97 -9
+*87 o7z
+*76 .7 *56
+*67 .5
+*56 o5d
+*50 Y2
+*45 o4s
+*42 ^S
+*31 z1 c
+*28 '7
+*15 D1
+*13 D1
+*03 o3a
+'9 +0
+'8 siz
+'7 i1o
+'5 o25
+'4 r
+'4 ^8
+'3 q
+$m sms
+$e smp
+$e o4l
+$d $o $g
+$b $u $t $t $s
+$a $0 $2
+$R $G
+$I
+$D $M
+$@ $2 $0 $0 $6
+$9 $9 $9 $0
+$9 $0 $8 $0
+$8 $8 $8 $8 $8
+$8 $1 $2 $3
+$7 $8 $9 $8
+$7 $8 $6 $0
+$7 $7 $7 $6
+$7 $2 $0 $0
+$6 '4 Z5
+$6 $6 $5 $5
+$5 -8
+$5 *56
+$5 $3 $2 $1
+$4 sma @r
+$4 $7 $5 $6
+$4 $5 $6 $3
+$4 $4 $5 $4
+$3 $4 $5 $7
+$3 $3 $2 $4
+$3 $2 $2 $1
+$3 $2 $1 $5
+$3 $0 $4 $0
+$2 $9 $3 $8
+$2 $9 $0 $0
+$2 $5 $5 $0
+$2 $4 $6 $8 $0
+$2 $3 $1 $7
+$2 $2 $3 $1
+$2 $1 $2 $1 $2 $1
+$1 $7 $8 $0
+$1 $6 $6 $1
+$1 $5 $6 $9
+$1 $5 $6 $8
+$1 $5 $4 $2
+$1 $4 $7 $7
+$1 $4 $5 $0
+$1 $4 $2 $7
+$1 $2 $3 $7
+$1 $1 $7 $1
+$1 $1 $6 $6
+$0 i1e
+$0 $9 $8 $7 $6
+$0 $8 $9 $9
+$0 $5 $9 $9
+$0 $2 $9
+$0 $2 $0
+$0 $0 $2 $1
+$0 $0 $2
+$0 $0 $0 $4
+} ^G
+t y1
+t i5X
+oAr
+o4T
+o3c
+o1S D3
+o1O
+o0o .1
+o0Z *14
+o0Y $4
+o0Y $0 $6
+o0X +1
+o0U .1
+o0T o1H
+o0N .1
+o0N ,5
+o0K .2
+o0J o5L
+o0J $2 $0 $0 $4
+o0F K Z1
+i82 o90 iA0 oB1
+i7u i8l
+i7s i81 i90
+i6s
+i5a D3
+i4o .5
+i46 *58 *54
+i43 i54 i65 o76
+i43 i50 i63 o70
+i42 i51 i62 o71
+i42 i50 i60 o77
+i41 i52 i64 o73
+i41 i50 i60 o74
+i3A
+i31 i42 i53 o64
+i2s +8
+i2s $1 $2 $3
+i2p
+i2n i3n i4y
+i1o i2y
+i1i i2c i3o
+i1e i2d i3r
+i1a o3i
+i1a i2u
+i1a i2l i3o
+i1a $1 $2 $3
+i0J i1u i2l
+f ] ]
+d E ]
+c i7u
+c i1u
+c ^4 ^1 ^0 ^2
+c ^3 ^1 ^0 ^2
+c ,9 $1
+c $Q
+c $9 $9 $1 $0
+c $9 $8 $1 $2
+c $9 $7 $0 $0
+c $9 $5 $0 $2
+c $9 $4 $5 $6
+c $9 $0 $1 $2
+c $8 $9 $9 $0
+c $8 $2 $8 $2
+c $7 $2 $6 $5
+c $7 $2 $0 $0
+c $6 $8 $1 $0
+c $6 $7 $9 $0
+c $6 $7 $7 $8
+c $6 $4 $0 $0
+c $6 $0 $0 $9
+c $5 $9 $0 $0
+c $5 $8 $1 $3
+c $5 $5 $2 $1
+c $5 $5 $1 $0
+c $5 $3 $0 $0
+c $5 $1 $2 $1
+c $5 $1 $1 $7
+c $4 $6 $2 $0
+c $4 $6 $0 $1
+c $4 $4 $2 $2
+c $4 $1 $5 $1
+c $4 $0 $1 $0
+c $3 $6 $3 $6
+c $3 $4 $4 $5
+c $3 $3 $4 $9
+c $3 $3 $2 $3
+c $3 $1 $5 $2
+c $3 $1 $2 $1
+c $3 $1 $1 $9
+c $2 $8 $2 $9
+c $2 $8 $0 $7
+c $2 $8 $0 $6
+c $2 $7 $2 $8
+c $2 $7 $0 $3
+c $2 $4 $6 $9
+c $2 $4 $6 $0
+c $2 $3 $3 $4
+c $2 $3 $0 $6
+c $2 $2 $5 $6
+c $2 $2 $3 $1
+c $2 $1 $2 $5
+c $2 $0 $2 $8
+c $2 $0 $0 $5 $!
+c $1 $9 $1 $8
+c $1 $7 $2 $3
+c $1 $5 $5 $1
+c $1 $5 $2 $7
+c $1 $5 $2 $6
+c $1 $5 $0 $1
+c $1 $4 $1 $6
+c $1 $3 $6 $5
+c $1 $3 $1 $7
+c $1 $3 $0 $5
+c $1 $3 $0 $2
+c $1 $2 $3 $4 $5 $6 $7 $8 $9 $0
+c $1 $1 $9 $8
+c $1 $1 $8 $8
+c $1 $1 $7 $1
+c $1 $0 $3 $2
+c $0 $9 $9 $9
+c $0 $8 $5 $2
+c $0 $8 $1 $7
+c $0 $7 $3 $1
+c $0 $7 $2 $5
+c $0 $7 $2 $3
+c $0 $6 $1 $3
+c $0 $5 $2 $3
+c $0 $5 $1 $7
+c $0 $4 $2 $8
+c $0 $3 $2 $2
+c $0 $2 $1 $9
+c $0 $1 $9 $2
+^z ^n ^i ^v
+^y ^n ^n ^a ^v ^o ^i ^g
+^y ^k ^a ^j
+^y ^g ^g ^u ^p
+^y ^g ^g ^u ^h
+^y ^f ^f ^a ^r
+^y ^c ^o ^j
+^y ^b ^b ^i ^t
+^t ^s ^e ^l ^o ^o ^c
+^t ^f ^i ^w ^s ^r ^o ^l ^y ^a ^t
+^s ^r ^e ^g ^n ^e ^v ^a
+^s ^o ^t ^i ^r ^o ^d
+^s ^o ^l ^e ^p
+^s ^a ^g ^i ^m ^a
+^r ^o ^t ^c ^a ^r ^t
+^r ^o ^t ^a ^n ^i ^m ^r ^e ^t
+^r ^o ^i ^r ^e ^p ^u ^s
+^r ^o ^d ^o ^e ^t
+^r ^e ^p ^p ^u ^s
+^r ^e ^k ^c ^a ^p
+^r ^a ^b ^k ^a
+^p ^u ^s ^a ^w
+^p ^l ^p
+^o ^y ^o ^y ^o ^y
+^o ^t ^i ^r ^g ^e ^n
+^o ^t ^i ^r ^e ^v
+^o ^t ^i ^b ^o ^l
+^o ^t ^e ^e ^h ^c
+^o ^n ^i ^s ^e ^s ^a
+^o ^n ^i ^b ^m ^a ^b
+^o ^n ^a ^t
+^o ^m ^i ^n ^i ^m
+^o ^l ^u ^a ^p ^o ^a ^o ^j
+^o ^i ^n ^o ^m ^e ^d
+^o ^d ^r ^i ^e ^w
+^n ^o ^t ^n ^o ^t
+^n ^o ^s ^y ^l ^l ^a
+^n ^o ^i ^m ^a ^d
+^n ^m ^a
+^n ^i ^r ^a ^d
+^n ^h ^g ^u ^a ^v
+^n ^g ^i ^e ^r
+^n ^e ^m ^e ^l ^c
+^n ^e ^i ^t
+^n ^e ^i ^r ^a ^d
+^n ^e ^d ^i ^a ^k
+^n ^c ^m
+^n ^a ^v ^o ^j
+^n ^a ^t ^s ^i ^k ^a ^p
+^n ^a ^r ^a ^i ^c
+^n ^a ^k ^l ^o ^v
+^n ^a ^h ^r ^a ^f
+^m ^u ^t ^a ^t
+^m ^m ^a ^s
+^m ^a ^v
+^m ^a ^r ^a
+^m ^a ^h ^k ^c ^e ^b
+^l ^l ^o ^m
+^l ^l ^a ^b ^w ^o ^n ^s
+^l ^k ^j ^h
+^l ^e ^i ^u ^q ^e ^z ^e
+^k ^u ^t
+^k ^u ^n
+^k ^o ^o ^p ^s
+^k ^n ^i ^t
+^k ^c ^u ^p
+^k ^c ^o ^j
+^j ^j ^a
+^i ^y ^i ^y
+^i ^t ^t ^i ^k
+^i ^s ^a ^m
+^i ^p ^o ^p
+^i ^n ^n ^a ^y
+^i ^g ^u ^y
+^i ^f ^a ^r
+^i ^d ^b ^a
+^h ^s ^a ^k
+^h ^a ^y
+^g ^o ^d ^t ^a ^c
+^g ^n ^i ^t
+^g ^n ^i ^h ^c
+^g ^m ^m
+^g ^e ^s
+^g ^a ^k
+^e ^z ^a ^m
+^e ^y ^r
+^e ^u ^q ^u ^d
+^e ^t ^r ^o ^m
+^e ^r ^t ^s ^e
+^e ^r ^e ^h ^t ^i ^h
+^e ^o ^b
+^e ^n ^i ^l ^e
+^e ^m ^i ^x
+^e ^m ^i ^n ^i ^m
+^e ^l ^l ^e ^o ^n
+^e ^l ^g ^n ^a
+^e ^i ^t ^t ^a ^m
+^e ^i ^k ^o ^o ^w
+^e ^i ^k ^a ^j
+^e ^i ^f ^o ^s
+^e ^c ^n ^e ^r ^u ^a ^l
+^e ^a ^b
+^d ^r ^a ^u ^d ^e
+^d ^i ^l ^a ^w
+^d ^i ^a
+^d ^e ^t ^n ^a ^w
+^d ^a ^h ^a ^f
+^c ^i ^t ^s ^e ^j ^a ^m
+^b ^e ^b
+^a ^z ^z ^a ^h
+^a ^y ^a ^n ^a
+^a ^y ^a ^h
+^a ^v ^o ^i ^g
+^a ^t ^s ^o ^c ^a
+^a ^t ^a ^n ^i ^h
+^a ^r ^i ^e ^r ^e ^p
+^a ^r ^a ^k ^n ^a
+^a ^n ^y ^e ^r
+^a ^n ^n ^a ^j
+^a ^n ^i ^r ^a
+^a ^n ^e ^s ^a ^r ^t ^n ^o ^c
+^a ^m ^o ^m
+^a ^m ^b
+^a ^m ^a ^m ^o ^y
+^a ^l ^y ^a ^j
+^a ^k ^e ^j
+^a ^k ^e
+^a ^i ^r ^u ^f
+^a ^i ^n ^r ^a ^n
+^a ^i ^n ^e ^k
+^a ^g ^l ^o ^t
+^a ^g ^a ^d
+^a ^e ^r ^d
+^a ^e ^h
+^a ^d ^d
+^a ^c ^o ^j
+^a ^c ^c ^u ^p
+^a ^a ^s
+^a ^Z
+^a ]
+^N D2
+^N -1
+^J ^T
+^J $2
+^F ,3
+^D ^1
+^A $1 $2 $3
+^9 ^7 ^5 ^3 ^1 o50
+^6 ^4 ^2 o38
+^4 ^3 ^2 ^1 o45
+^2 ^2 ^1 o37
+^2 ^0 ^0 ^1 r
+^1 T1
+] ] ] ]
+[ i1o ^N
+[ .0
+K R5 i9C
+D8 ,8
+D7 o3y
+D6 o6m
+D4 o4X
+D3 $D
+D3 $2 $0 $0 $3
+D2 i3i
+D2 $2 $0 $0 $3
+D1 o3B
+D1 o1T
+D1 i2u
+D1 D2 o3F
+D1 D2 o3B
+D1 $1 $2 $3 $4 $5 $6
+@h ^a
+@8 i40
+@3 i03
+.0 $1
+-9 s09
+-7 o6b
+-6 o7a
+-5 c Z1
+-4 $1 $2 $3
+-3 o4e
+-3 '7 u
+-2 D3
+-2 '7
+-0 $1 $2 $3
++6 $o
++4 +5
++3 ^A
++3 ,4
++2 ^A
++1 t
++0 o4i
+*87 +8
+*76 o2r
+*76 o1l
+*75 o72
+*73 ^z
+*68 D6
+*56 o6b
+*54 -4
+*54 *67 ,8
+*41 D1
+*36 o4z
+*32 Z1
+*20 syt
+*13 i5u
+*06 o3m
+*05 ^r
+*04 Z1
+'9 o6m
+'9 Z1
+'6 o1l
+'6 *54
+$l $a
+$b sbf
+$a $r $i
+$_ $3 $2 $1
+$N $L
+$L r o7e
+$H l s2f
+$9 .7
+$9 $8 $9 $9
+$7 $7 $7 $8
+$7 $7 $2 $2
+$4 $5 $4 $6
+$4 $5 $1 $0
+$4 $4 $7 $7
+$3 o82
+$3 $2 $2 $4
+$3 $2 $1 $3 $2 $1
+$3 $2 $1 $1
+$3 $0 $1 $5
+$2 Z4
+$2 *68
+$2 $7 $1 $8
+$2 $6 $1 $3
+$2 $5 $3 $0
+$2 $5 $1 $3
+$2 $4 $4 $8
+$2 $3 $6 $6
+$2 $3 $5 $5
+$2 $3 $3 $3
+$2 $3 $2 $2
+$2 $2 $4 $6
+$2 $2 $4 $5
+$2 $1 $1 $5
+$2 $0 $1 $7
+$1 Y3
+$1 @s
+$1 $7 $7 $2
+$1 $6 $1 $9
+$1 $5 $5 $9
+$1 $5 $3 $6
+$1 $5 $2 $8
+$1 $4 $7 $0
+$1 $4 $5 $6
+$1 $2 $5 $5
+$1 $2 $3 $9 $8 $7
+$1 $1 $5 $0
+$1 $1 $3 $2
+$0 $9 $9 $9
+$0 $9 $8 $8
+$0 $6 $0 $0
+$0 $2 $9 $9
+$0 $1 $2 $3 $4
+$0 $0 $0 $2
+$)
+o69 -7
+o4S ]
+o4P o5E
+o3u
+o3V ]
+o3L
+o1Z D3
+o1Y
+o1K D3 ]
+o0a
+o0Z o3Z
+o0Z $1 $1
+o0Z $0 $0
+o0Y $2 $5
+o0X $1 $2 $3
+o0Q ]
+o0Q *64
+o0N o1G
+o0N Y2
+o0J $2 $0 $0 $1
+o0J $1 $2 $3 $4
+o0C ,6
+l ] $x
+l ] $G
+i8l i9i
+i72 i80 i90 oA2
+i72 i80 ,9 oA3
+i6i $o
+i6h i71
+i62 o70 i81 o93
+i62 [ i0G
+i5i i6t i7o
+i4n $o
+i44 i55 i66 o77
+i42 i50 i62 o70
+i42 i50 i60 o74
+i42 i50 i60 o73
+i42 i50 i60 i73
+i41 i59 i67 o76
+i41 i55 i61 o75
+i41 i52 i63 o70
+i41 i50 i62 o70
+i3e $e
+i35 i46 i57 o68
+i32 i40 i50 i62
+i2n ,9
+i2n $1 $2 $3
+i2i $1 $2 $3
+i2e ^A
+i2e $1 $2 $3
+i2d $1 $2 $3
+i1y D3
+i1o i2o
+i1n
+i1l $1 $2 $3
+i1i $i
+i0G
+c snj
+c ^7 ^0 ^9 ^2
+c $x $D
+c $9 $9 $5 $5
+c $9 $7 $9 $7
+c $9 $2 $9 $2
+c $9 $1 $1 $0
+c $9 $0 $0 $9
+c $8 $9 $9 $8
+c $8 $9 $8 $9
+c $8 $9 $0 $0
+c $8 $8 $6 $6
+c $8 $8 $0 $5
+c $8 $7 $8 $7
+c $8 $7 $0 $0
+c $8 $4 $5 $6
+c $8 $2 $0 $0
+c $8 $1 $8 $1
+c $8 $0 $1 $2
+c $8 $0 $0 $1
+c $7 $9 $8 $0
+c $7 $8 $7 $8
+c $7 $5 $1 $3
+c $6 $5 $7 $4
+c $6 $0 $1 $1
+c $5 $8 $9 $0
+c $5 $6 $9 $8
+c $5 $3 $2 $1
+c $5 $0 $2 $0
+c $4 $5 $1 $0
+c $4 $3 $3 $2
+c $4 $1 $0 $0
+c $4 $0 $5 $6
+c $3 $8 $1 $0
+c $3 $4 $5 $8
+c $3 $3 $1 $5
+c $3 $3 $0 $0
+c $3 $2 $5 $4
+c $3 $2 $4 $5
+c $3 $2 $2 $1
+c $3 $1 $2 $0
+c $3 $1 $1 $5
+c $3 $1 $0 $6
+c $3 $1 $0 $4
+c $3 $1 $0 $2
+c $3 $0 $5 $0
+c $3 $0 $0 $2
+c $2 $9 $2 $9
+c $2 $8 $1 $5
+c $2 $6 $6 $2
+c $2 $5 $4 $3
+c $2 $5 $1 $6
+c $2 $5 $0 $9
+c $2 $4 $6 $3
+c $2 $4 $4 $2
+c $2 $4 $1 $7
+c $2 $4 $0 $8
+c $2 $4 $0 $0
+c $2 $3 $7 $5
+c $2 $3 $3 $5
+c $2 $3 $3 $1
+c $2 $2 $6 $6
+c $2 $2 $5 $5
+c $2 $2 $1 $6
+c $2 $2 $1 $3
+c $2 $1 $6 $9
+c $2 $1 $3 $4
+c $2 $1 $1 $5
+c $2 $0 $2 $3
+c $2
+c $1 $8 $8 $1
+c $1 $8 $2 $4
+c $1 $7 $2 $4
+c $1 $7 $0 $6
+c $1 $6 $2 $6
+c $1 $6 $0 $8
+c $1 $6 $0 $4
+c $1 $6 $0 $3
+c $1 $5 $5 $5
+c $1 $5 $3 $0
+c $1 $5 $2 $8
+c $1 $5 $0 $8
+c $1 $5 $!
+c $1 $3 $5 $8
+c $1 $3 $1 $5
+c $1 $1 $5 $0
+c $1 $1 $3 $1
+c $1 $0 $4 $4
+c $0 $9 $3 $0
+c $0 $9 $2 $5
+c $0 $9 $2 $3
+c $0 $8 $2 $1
+c $0 $7 $3 $0
+c $0 $7 $2 $9
+c $0 $7 $2 $4
+c $0 $7 $1 $5
+c $0 $6 $2 $2
+c $0 $5 $3 $1
+c $0 $5 $3 $0
+c $0 $5 $2 $9
+c $0 $5 $0 $0
+c $0 $4 $2 $4
+c $0 $4 $2 $3
+c $0 $2 $1 $5
+c $0 $1 $5
+c $0 $0 $2 $8
+^y ^s ^s ^a ^l ^c
+^y ^p ^p ^u ^g
+^y ^n ^n ^i ^f
+^y ^l ^v ^o ^l
+^y ^e ^c ^a ^j
+^w ^s
+^w ^o ^e ^m ^w ^o ^e ^m
+^s ^w ^a ^q
+^s ^u ^g ^s ^u ^g
+^s ^o ^k ^o ^l
+^s ^i ^p ^o ^p
+^s ^e ^l ^b ^o ^r
+^s ^c ^i ^t ^s ^a ^n ^m ^y ^g
+^s ^a ^v ^i ^r
+^s ^a ^r ^u ^d ^n ^o ^h
+^r ^i ^s ^a ^y
+^r ^i ^h ^a ^t
+^r ^e ^s ^s ^a ^y
+^r ^e ^p ^m ^u ^h ^t
+^r ^e ^p ^e ^p
+^r ^e ^m ^a ^l ^f
+^r ^e ^l ^y ^a ^t
+^r ^e ^d ^a ^v ^h ^t ^r ^a ^d
+^p ^o ^i ^u
+^o ^t ^i ^s ^i ^u ^l
+^o ^t ^i ^l ^u ^j
+^o ^t ^i ^l ^u ^c
+^o ^t ^i ^g ^r ^o ^j
+^o ^s ^a ^y ^a ^p
+^o ^r ^r ^u ^h ^c
+^o ^n ^o ^f ^e ^l ^e ^t
+^o ^n ^i ^t ^n ^e ^l ^a ^v
+^o ^n ^a ^u ^j
+^o ^h ^c ^i ^m
+^o ^h ^c ^e ^h ^c
+^o ^g ^o ^g ^o ^g
+^o ^e ^d ^a ^t
+^o ^d ^a ^r ^o ^m
+^o ^c ^u ^l ^a ^m
+^o ^c ^e ^h ^c ^a ^p
+^o ^a ^h ^t
+^n ^o ^t ^a ^e ^k
+^n ^o ^s ^y ^a ^r ^g
+^n ^o ^s ^e ^m ^a ^j
+^n ^o ^j ^n ^o ^j
+^n ^i ^l ^a ^c
+^n ^e ^v ^o ^j
+^n ^e ^t ^l ^o ^c
+^n ^e ^e ^d
+^n ^a ^m ^x
+^n ^a ^m ^u ^r ^t
+^n ^a ^m ^n ^a ^m
+^n ^a ^m ^f ^l ^o ^w
+^n ^a ^l ^l ^i ^d
+^n ^a ^g ^n ^e ^s ^a ^r
+^m ^u ^a
+^m ^s ^e
+^m ^o ^m ^r ^u
+^m ^m ^a ^h
+^m ^e ^s ^o ^j
+^m ^a ^h ^l ^i
+^l ^r ^e
+^l ^r ^a ^h ^c
+^l ^p ^p
+^l ^o ^o ^c ^m ^i
+^l ^o ^l ^l ^o ^l
+^l ^l ^o ^h
+^l ^l ^e ^d ^n ^e ^w
+^l ^e ^t ^a ^p
+^l ^a ^t ^r ^a ^k
+^l ^a ^i ^n ^a ^d
+^l ^a ^b ^t ^e ^o ^v
+^j ^j ^c
+^i ^w ^i ^w
+^i ^r ^a ^j
+^i ^n ^a ^f
+^i ^l ^o ^y
+^i ^d ^o ^d
+^i ^d ^n ^a ^r
+^i ^d ^a ^d
+^i ^a ^r ^a ^s
+^h ^s ^o ^p
+^h ^s ^a ^y
+^h ^s ^a ^w
+^h ^l ^e
+^h ^e ^b
+^h ^e ^a ^v ^e ^n
+^h ^a ^l ^l ^u ^d ^b ^a
+^h ^a ^i ^m
+^g ^s ^s
+^g ^r ^o ^b ^y ^c
+^g ^n ^u ^t
+^g ^n ^u ^d
+^g ^n ^o ^y
+^g ^n ^o ^p ^g ^n ^i ^p
+^g ^n ^i ^v ^r ^i
+^g ^n ^e ^h ^s
+^f ^o ^s
+^f ^l ^o ^w ^e ^n ^o ^l
+^e ^u ^q ^r ^o ^p
+^e ^u ^n ^a ^m
+^e ^u ^j
+^e ^r ^i ^h ^p ^p ^a ^s
+^e ^r ^a ^k
+^e ^n ^i ^m ^s ^a ^y
+^e ^n ^e ^l ^e ^s
+^e ^n ^a ^l ^p
+^e ^l ^l ^e ^j
+^e ^i ^n ^a ^e ^b
+^e ^i ^d ^n ^a
+^e ^e ^l ^a
+^e ^d ^n ^a ^c
+^e ^c ^r ^a
+^e ^a ^r ^t
+^e ^a ^l
+^d ^n ^e ^e ^h ^t
+^d ^l ^i ^m
+^d ^e ^r ^d
+^d ^e ^e ^s
+^b ^u ^h ^c
+^b ^i ^k
+^a ^y ^k
+^a ^v ^a ^s
+^a ^v ^a ^n
+^a ^t ^o ^d
+^a ^t ^a ^t ^a ^b
+^a ^s ^e ^n ^a ^v
+^a ^s ^b
+^a ^r ^r ^a ^g
+^a ^r ^i ^l
+^a ^r ^e ^p
+^a ^r ^b ^m ^o ^s
+^a ^p ^s ^i ^h ^c
+^a ^n ^s
+^a ^n ^i ^u ^q ^a ^m
+^a ^n ^i ^r ^t
+^a ^n ^e ^c
+^a ^m ^k
+^a ^m ^i ^r
+^a ^l ^e ^i ^r ^a ^m
+^a ^i ^s ^a ^h ^a ^r
+^a ^i ^n ^a ^d
+^a ^i ^l ^a ^m
+^a ^h ^s ^i ^e ^k
+^a ^h ^c ^n ^o ^c
+^a ^e ^j
+^a ^d ^r ^a ^u ^d ^e
+^a ^d ^e ^r
+^a ^d ^a ^s
+^a ^c ^r ^o
+^a ^a ^b
+^S $2 $0 $0 $6
+^N D3
+^J $9
+^F ]
+^2 ^0 ^0 ^2 r
+^0 ^0 ^7 o32 r
+^0 ^0 ^3 o32 r
+K .8
+D9 o7g
+D9 -6
+D7 $o
+D5 i67
+D4 o4F
+D3 *56
+D2 o3B
+D2 $G
+D2 $2 $0 $0 $4
+D2 $2 $0 $0 $2
+D1 o2C
+D1 o2B D3
+D1 D2 o3M
+@h i6s D5
+-9 $7
+-8 $2
+-7 i7_ o7e
+-6 o78
+-6 i76
+-6 -6 -6 -6
+-5 -6
+-4 i4i
+-4 Z1
+-4 *54
+-3 -3 -3
+-3 *43
+-2 o3u
+-2 ,4
+-0 i2o
+-0 $2 $0 $0 $5
++7 o0S
++6 c ^M
++6 D7
++5 ,6
++4 D5
++0 $7
++0 $2 $0 $0 $5
+*B9 s29
+*86 +5
+*85
+*75 o1h
+*56 o2l
+*54 *71 '5
+*42 i3z
+*37 c
+*23 ]
+*17 Z2 D1
+*15 o1u
+*12 s34
+*05 ^y
+*05 [
+*05 K
+'B o9i
+'A o43
+'A T5
+'9 -4
+'8 ^t
+'6 [
+$i L6
+$e i5a
+$e $r $a
+$_ $9 $9 $9
+$G $1
+$F +7
+$9 $9 $9 $1
+$9 $0 $1 $1
+$8 *68
+$5 $5 $9 $9
+$5 $5 $6 $7
+$5 $5 $3 $3
+$4 $8 $1 $2
+$4 $5 $6 $0
+$4 $5 $2 $3
+$4 $4 $0 $4
+$3 snk
+$3 $5 $6 $7
+$3 $3 $4 $3
+$3 $3 $3 $4
+$3 $3 $1 $4
+$3 $2 $3 $3
+$2 -9
+$2 $8 $2 $0
+$2 $3 $3 $1
+$2 $1 $5 $4
+$2 $0 $2 $9
+$1 -4
+$1 -2
+$1 $8 $1 $7
+$1 $7 $3 $9
+$1 $7 $2 $4
+$1 $7 $0 $0
+$1 $6 $2 $2
+$1 $5 $5 $6
+$1 $5 $5 $2
+$1 $5 $3 $3
+$1 $5 $2 $6
+$1 $5 $1 $4
+$1 $4 $2 $2
+$1 $3 $3 $0
+$1 $2 $5 $7
+$1 $2 $1 $3 $1 $4
+$1 $1 $7 $3
+$0 $8 $9 $7
+$0 $2 $3 $4
+$0 $0 $2 $5
+$0 $0 $1 $7
+} c
+o7T
+o4X
+o4G ]
+o3C
+o2t +3
+o2W
+o1V
+o1J ]
+o1C D3
+o0n $1 $2 $3 $4
+o0Z $2 $2
+o0Z $1 $4
+o0Z $0 $6
+o0Y $5
+o0K o6K
+o0J $2 $0 $0 $3
+o0G o2D
+o0A .4
+l ] $z
+l $p $o $g $i
+k D2 ^k
+i7Q *43 z1
+i72 i80 i90 oA4
+i71 i82 o93
+i6i i7c i8a
+i50 R6 R4
+i4o +5
+i49 i50 i60 ,7
+i44 i54 i64 ,7
+i41 i50 i62 o79
+i3o i8s
+i32 i40 i50 ,6
+i2y -3
+i2k
+i2i +0
+i26
+i1u D3
+i1n i2a
+i1n *17
+i1g -0
+i1e *13
+i1a i2i i3n
+i1a +2
+i1R
+c $l $y
+c $_ $_
+c $9 $9 $7 $7
+c $9 $9 $1 $1
+c $9 $8 $2 $1
+c $9 $8 $1 $1
+c $9 $5 $9 $5
+c $9 $4 $0 $0
+c $9 $0 $9 $9
+c $9 $0 $1 $1
+c $8 $5 $1 $1
+c $8 $4 $8 $4
+c $7 $9 $1 $0
+c $7 $8 $7 $9
+c $7 $5 $1 $0
+c $6 $6 $0 $4
+c $6 $6 $0 $3
+c $6 $1 $9 $0
+c $6 $1 $2 $0
+c $6 $0 $0 $2
+c $5 $6 $1 $4
+c $5 $4 $5 $6
+c $5 $3 $6 $9
+c $5 $3 $5 $5
+c $5 $2 $5 $2
+c $5 $1 $0 $0
+c $5 $0 $0 $5
+c $5 $0 $0 $3
+c $4 $5 $1 $1
+c $4 $1 $5 $5
+c $4 $0 $3 $0
+c $4 $0 $0 $1
+c $3 $7 $3 $7
+c $3 $6 $7 $8
+c $3 $5 $3 $5
+c $3 $5 $2 $0
+c $3 $4 $4 $3
+c $3 $3 $4 $4
+c $3 $3 $1 $4
+c $3 $2 $2 $3
+c $3 $2 $1 $3
+c $3 $1 $5 $0
+c $3 $1 $3 $4
+c $3 $1 $2 $6
+c $2 $9 $0 $2
+c $2 $8 $2 $1
+c $2 $8 $2 $0
+c $2 $7 $8 $9
+c $2 $7 $0 $6
+c $2 $6 $2 $9
+c $2 $6 $2 $4
+c $2 $6 $0 $8
+c $2 $5 $4 $7
+c $2 $4 $8 $8
+c $2 $4 $2 $6
+c $2 $4 $0 $2
+c $2 $3 $6 $7
+c $2 $3 $6 $5
+c $2 $3 $4 $7
+c $2 $3 $1 $5
+c $1 $8 $9 $7
+c $1 $8 $0 $6
+c $1 $8 $0 $5
+c $1 $7 $2 $9
+c $1 $5 $4 $5
+c $1 $5 $3 $5
+c $1 $5 $3 $3
+c $1 $4 $5 $5
+c $1 $4 $4 $1
+c $1 $4 $0 $3
+c $1 $3 $7 $0
+c $1 $3 $3 $2
+c $1 $3 $2 $3
+c $1 $3 $2 $2
+c $1 $2 $4 $3
+c $1 $2 $3 $6
+c $1 $2 $2 $2
+c $1 $1 $7 $8
+c $1 $1 $5 $6
+c $1 $1 $4 $5
+c $1 $1 $4 $2
+c $1 $1 $4 $1
+c $1 $0 $5 $6
+c $0 $9 $1 $9
+c $0 $6 $1 $8
+c $0 $5 $1 $6
+c $0 $4 $3 $0
+c $0 $4 $1 $8
+c $0 $3 $3 $0
+c $0 $1 $5 $3
+c $0 $1 $2 $9
+c $0 $1 $1 $9
+c $0 $0 $3 $0
+c $0 $0 $0 $4
+^z ^n ^i ^k ^b ^e ^w
+^y ^o ^b ^e ^r ^i ^f
+^y ^e ^s ^r ^o ^h
+^y ^e ^l ^y ^a ^k
+^y ^b ^b ^a ^b
+^x ^d ^n ^x ^p
+^w ^q ^w ^q
+^w ^q ^s ^a ^x ^z
+^t ^r ^e ^b ^e ^h
+^t ^e ^f ^a ^j
+^s ^n ^e ^t ^t ^i ^k
+^s ^i ^r ^a ^f
+^s ^g ^s
+^s ^e ^k ^a ^c ^p ^u ^c
+^s ^a ^t ^u ^p
+^s ^a ^t ^e ^t
+^s ^a ^l ^l ^i ^s ^a ^c
+^r y1 E
+^r ^e ^t ^s ^o ^m
+^r ^e ^t ^l ^a ^v
+^r ^e ^p ^u ^d ^r ^e ^p ^u ^s
+^r ^e ^h ^s ^a ^d
+^r ^e ^g ^j ^i ^t
+^r ^e ^d ^n ^a ^l
+^r ^a ^e ^b ^r ^a ^l ^o ^p
+^p ^o ^p ^y ^l ^l ^o ^l
+^p ^i ^k ^d ^u ^m
+^o ^w ^t ^w ^e ^m
+^o ^t ^i ^r ^d ^e ^p
+^o ^t ^i ^l ^r ^a ^c
+^o ^r ^d ^i ^s ^i
+^o ^n ^a ^z ^o ^l
+^o ^l ^i ^m ^k
+^o ^i ^r ^a ^m ^o ^r
+^o ^a ^m ^i ^s
+^n ^u ^n
+^n ^u ^j ^n ^u ^j
+^n ^o ^s ^p ^m ^a ^s
+^n ^o ^s ^m ^e ^l ^c
+^n ^o ^i ^v ^a
+^n ^o ^h ^s
+^n ^o ^e ^m ^i ^s
+^n ^i ^v ^r ^e
+^n ^i ^e ^s ^s ^u ^h
+^n ^e ^r ^e ^k
+^n ^e ^k ^i ^h ^c
+^n ^e ^d ^l ^a
+^n ^b ^v ^c ^x ^z
+^n ^a ^y ^a ^d
+^n ^a ^w ^t
+^n ^a ^n ^e ^e ^k
+^n ^a ^m ^e ^l ^t ^t ^i ^l
+^n ^a ^i ^l ^i ^k
+^n ^a ^h ^t
+^n ^a ^h ^o ^y
+^n ^a ^g ^e ^r
+^n ^a ^g ^a ^e ^t
+^n ^a ^e
+^m ^u ^y ^m ^u ^y
+^m ^o ^j
+^m ^m ^m ^m
+^m ^m ^k
+^m ^a ^y ^a
+^m ^a ^u ^g
+^m ^a ^a
+^l ^l ^o ^p
+^l ^e ^u ^n ^a ^m ^n ^a ^u ^j
+^l ^e ^u ^n ^a ^m ^e ^s ^o ^j
+^l ^e ^s ^s ^u ^r
+^l ^e ^i ^k ^e ^z ^e
+^k ^n ^i ^m
+^k ^j ^k
+^k ^c ^a ^u ^q
+^i ^z ^i ^l
+^i ^v ^a ^s
+^i ^r ^i ^r
+^i ^o ^j
+^i ^n ^o ^d
+^i ^m ^i ^t
+^i ^m ^i ^h ^c
+^i ^l ^e ^r ^a
+^i ^k ^o ^o ^c
+^i ^k ^o ^k
+^i ^k ^k ^i ^m
+^i ^h ^s ^o ^m
+^i ^h ^k ^e ^m
+^i ^d ^h ^a ^m
+^h i2i
+^h ^s ^i ^f ^d ^l ^o ^g
+^h ^k ^a
+^h ^j ^h
+^h ^a ^g
+^g ^n ^o ^m
+^g ^n ^o ^j
+^g ^n ^i ^y ^a ^l ^p
+^e ^u ^q ^e ^p
+^e ^t ^i ^r ^p ^s
+^e ^s ^s ^o ^r ^c ^a ^l
+^e ^s ^o ^l
+^e ^r ^f ^l ^a
+^e ^r ^a ^l ^f
+^e ^p ^m ^o ^r
+^e ^p ^e ^h ^c
+^e ^o ^r
+^e ^o ^d
+^e ^n ^y ^a ^l
+^e ^n ^i ^t
+^e ^n ^i ^a ^m
+^e ^k ^r ^u ^b
+^e ^k ^i ^b ^t ^r ^i ^d
+^e ^i ^m ^o ^h
+^e ^i ^k ^o ^o ^s
+^e ^h ^c ^i ^m
+^e ^f ^f ^a ^r ^i ^g
+^e ^e ^y
+^e ^e ^l ^y ^a ^h
+^d ^r ^a ^o ^b ^e ^t ^a ^k ^s
+^d ^i ^a ^z
+^d ^a ^l ^a ^s
+^c ^i ^t ^s ^a ^t ^n ^a ^f
+^c ^i ^t ^o ^x ^e
+^c ^a ^g
+^b ^r ^e ^p ^u ^s
+^b ^i ^b ^a ^h
+^a ^z ^a ^g
+^a ^w ^a ^w
+^a ^t ^i ^u ^q ^i ^h ^c
+^a ^t ^i ^m
+^a ^r ^u ^c ^o ^l
+^a ^r ^g ^e ^n
+^a ^r ^a ^v ^e ^u ^g
+^a ^r ^a ^i ^t
+^a ^r .2
+^a ^n ^n ^a ^d
+^a ^n ^k
+^a ^n ^e ^j
+^a ^n ^a ^i ^k
+^a ^m ^s ^a ^t ^n ^a ^f
+^a ^m ^d
+^a ^l ^y ^a ^k ^a ^m
+^a ^k ^n ^o ^t
+^a ^k ^e ^m
+^a ^k ^a ^n
+^a ^i ^n ^a ^r
+^a ^h ^o ^m
+^a ^h ^n ^i ^r ^a ^l ^c
+^a ^g ^u ^t ^r ^o ^t
+^a ^e ^n
+^a ^e ^f
+^a ^e ^e ^r ^d ^n ^a
+^a ^d ^e ^d
+^a ^d ^a ^p ^s ^e
+^a ^c ^o ^r
+^a ^c ^a ^j
+^a ^b ^m ^i ^k
+^_ ^y ^x ^e ^s
+^M $5
+^L $2
+^J +1
+^J $3
+^I $1 $2
+^E $1 $2
+^B ,3
+^B $5
+^A $0 $9
+^A $0 $8
+^9 z1 u
+] ] l ] $y
+] ] ] $1
+Y2 o91 r
+D8 o4c
+D4 o4D
+D4 $2 $0 $0 $5
+D3 $1 $2 $3 $4 $5
+D1 o3M
+D1 o2T
+D1 o2S
+D1 o2F
+D1 o1P
+D1 D2 o3V
+D1 D2 o2H
+D1 D2 $G
+D1 $1 $2 $3 $1 $2 $3
+.0 z1
+.0 D3
+-8 K
+-6 s2w
+-6 Y2
+-4 ]
+-4 D5
+-4 *34
+-3 ,4
+-0 l .3
+-0 -2
+-0 -0 -0 -0
++7 ^o
++5 o7y
++5 o6u
++5 o6a
++5 o0N
++4 o5u
++2 E $4
++1 smd
++0 $5
+*78 T3
+*65 K
+*46 i5g
+*45 o2y
+*41 x13
+*32 ^I
+*24 D2
+*20 ^T
+*20 ^D
+*14 q '6
+*13 sxg y1
+*07 *24 T1
+*01 s81
+'A l
+'9 o5j
+'9 o2l
+'9 i6a
+'9 -6
+'6 Z1
+'5 i2l
+'5 ^F
+$o $1 $2 $3 $4 $5
+$f $e $e $d
+$e $o $n
+$c $u $r $r $y
+$X $1 $2 $3
+$R
+$N oAb E
+$N o8s siu
+$L t
+$G r
+$9 $1 $0 $0
+$8 $8 $3 $3
+$7 $8 $8 $9
+$7 $7 $1 $2
+$7 $1 $0 $0
+$6 $7 $8 $8
+$6 $5
+$5 i97
+$5 $9
+$5 $5 $5 $6
+$5 $4 $5 $6
+$4 $5 $6 $7 $8
+$4 $5 $1 $1
+$4 $3 $2 $2
+$4 $0 $0 $2
+$3 $6
+$3 $5 $4 $6
+$3 $4 $4 $3
+$3 $4 $1 $2
+$3 $3 $0 $1
+$3 $1 $2 $3
+$2 i88
+$2 R3
+$2 $7 $0 $0
+$2 $5 $6 $7
+$2 $5 $4 $7
+$2 $4 $7 $8
+$2 $4 $5 $7
+$2 $3 $2 $0
+$2 $0 $4 $5
+$1 o8d
+$1 DA
+$1 $8 $1 $3
+$1 $5 $1 $8
+$1 $5 $1 $7
+$1 $4 $6 $7
+$1 $4 $3 $4
+$1 $4 $3 $0
+$1 $3 $5 $1
+$1 $3 $3 $6
+$1 $2 $6 $7
+$1 $2 $6 $4
+$1 $2 $5 $9
+$1 $2 $5 $8
+$0 $9 $0 $0
+$0 $4 $0 $0
+$0 $1 $2
+$0 $0 $8 $8
+$0 $0 $2 $4
+$0 $0 $0 $8
+$! $! $! $! $!
+s^K Z5 E
+o47 ss7 $7
+o2U ]
+o2U
+o2O
+o1D ]
+o0s ^S
+o0r $1 $2 $3 $4 $5
+o0p $1 $2 $3 $4 $5
+o0p $1 $2 $3 $4
+o0c i1r
+o0Z $1 $5
+o0Y ]
+o0M i2K
+o0L o4A
+o0J o4R
+o0J $2 $0 $0 $6
+o0J $1 $2 $3 $4 $5
+l o52
+i72 i80 i90 oA3
+i4l ]
+i49 i50 i69 o70
+i42 i50 i60 o71
+i41 i53 i62 o74
+i41 i51 i62 i72 i83 ,9
+i40 i59 i68 o77
+i3w i4w ,5
+i3i $1 $2 $3
+i33 o40
+i31 i43 i55 i67 o79
+i2y
+i2v i3i i4d
+i2i i3n i4c
+i2a
+i2K o2w -7
+i1u y2
+i1a i2c i3o
+i1R l
+i1D
+i0e ^Z
+c o2n
+c o1m
+c d $1
+c $o $l
+c $9 $6 $5 $4
+c $9 $6 $0 $0
+c $9 $1 $9 $1
+c $8 $9 $0 $3
+c $8 $8 $9 $0
+c $8 $3 $1 $0
+c $7 $9 $0 $1
+c $7 $8 $9 $6
+c $7 $7 $6 $6
+c $7 $7 $1 $0
+c $7 $3 $1 $2
+c $7 $0 $1 $3
+c $6 $8 $9 $0
+c $6 $7 $6 $7
+c $6 $6 $9 $9
+c $6 $6 $5 $4
+c $6 $5 $8 $9
+c $6 $3 $1 $0
+c $6 $1 $6 $1
+c $6 $1 $1 $0
+c $6 $0 $5 $0
+c $5 $6 $9 $0
+c $5 $5 $8 $8
+c $5 $5 $3 $5
+c $5 $4 $5 $4
+c $5 $4 $3 $2
+c $5 $3 $6 $8
+c $5 $1 $1 $0
+c $4 $6 $1 $1
+c $4 $5 $8 $8
+c $4 $5 $6 $8
+c $4 $5 $6 $6
+c $4 $5 $6 $5
+c $4 $5 $0 $5
+c $4 $4 $3 $3
+c $4 $4 $2 $3
+c $4 $2 $1 $1
+c $4 $1 $1 $2
+c $4 $0 $6 $0
+c $4 $0 $4 $5
+c $3 $9 $0 $0
+c $3 $7 $8 $9
+c $3 $4 $5 $5
+c $3 $4 $2 $5
+c $3 $3 $7 $7
+c $3 $2 $8 $9
+c $3 $2 $3 $6
+c $3 $2 $1 $4
+c $3 $1 $3 $3
+c $2 $9 $8 $7
+c $2 $9 $0 $6
+c $2 $7 $0 $0
+c $2 $6 $9 $9
+c $2 $5 $7 $7
+c $2 $4 $1 $4
+c $2 $3 $8 $5
+c $2 $3 $2 $2
+c $2 $3 $2 $0
+c $2 $0 $0 $2 $!
+c $1 $8 $9 $9
+c $1 $8 $1 $3
+c $1 $8 $0 $7
+c $1 $8 $0 $2
+c $1 $7 $8 $8
+c $1 $7 $7 $7
+c $1 $7 $1 $3
+c $1 $7 $0 $9
+c $1 $7 $0 $8
+c $1 $6 $6 $6
+c $1 $6 $1 $9
+c $1 $5 $1 $9
+c $1 $4 $6 $3
+c $1 $4 $0 $1
+c $1 $3 $4 $6
+c $1 $3 $2 $7
+c $1 $2 $7 $5
+c $1 $1 $3 $4
+c $1 $0 $5 $2
+c $0 $9 $2 $6
+c $0 $7 $2 $2
+c $0 $7 $1 $8
+c $0 $7 $1 $6
+c $0 $7 $0 $0
+c $0 $4 $0 $0
+c $0 $2 $2 $4
+c $0 $2 $0 $0
+c $0 $1 $9 $9
+c $0 $1 $4
+c $0 $1 $1 $6
+c $0 $1 $1 $5
+c $0 $0 $9 $0
+c $0 $0 $0 $2
+^z ^i ^r ^a ^f
+^y ^x ^x ^o ^f
+^y ^s ^s ^a ^k
+^y ^o ^b ^t ^a ^b
+^y ^o ^b ^m ^o ^t
+^y ^n ^n ^o ^t
+^y ^l ^a ^h ^t ^a ^n
+^x ^c ^i ^n ^o ^s
+^t ^s ^a ^n ^m ^y ^g
+^s ^y ^b ^a ^b
+^s ^u ^g ^a ^b
+^s ^r ^e ^y ^a ^l ^p
+^s ^o ^r ^r ^e ^p
+^s ^o ^i ^c ^a ^l ^a ^p
+^s ^i ^u ^q ^i ^h ^c
+^s ^i ^k ^i ^h ^c
+^s ^e ^l ^k ^r ^a ^p ^s
+^s ^e ^l ^b ^b ^i ^n
+^s ^e ^d ^e ^r ^a ^p
+^r ^e ^t ^s ^a ^m ^e ^h ^t
+^r ^e ^p ^p ^o ^p
+^r ^e ^g ^r ^u ^b ^m ^a ^h
+^r ^e ^f ^f ^e ^j
+^r ^e ^d ^i ^a ^h
+^q ^i ^r ^a ^t
+^p ^u ^z ^z ^a ^w
+^p ^u ^c ^r ^e ^t ^t ^u ^b
+^o ^t ^i ^l ^e ^s ^o ^j
+^o ^r ^o ^t ^o ^t
+^o ^o ^k ^o ^o ^k
+^o ^n ^i ^u ^g ^n ^i ^p
+^o ^n ^i ^n ^i ^m
+^o ^l ^l ^i ^w
+^o ^l ^l ^i ^r ^u ^m
+^o ^i ^l ^e ^r ^u ^a
+^o ^h ^c ^u ^m ^o ^m ^a ^e ^t
+^o ^h ^c ^a ^m ^a ^c
+^o ^d ^l ^a ^b
+^o ^d ^a ^d ^l ^o ^s
+^o ^d ^a ^c ^r ^e ^m
+^o $1 $2 $3
+^n ^y ^v ^e ^d
+^n ^y ^r ^u ^a ^l
+^n ^y ^l ^t ^i ^a ^c
+^n ^o ^t ^r ^y ^a
+^n ^o ^t ^e ^l ^e ^k ^s
+^n ^o ^m ^e ^a ^r ^o ^d
+^n ^o ^i ^s
+^n ^o ^b ^m ^o ^b
+^n ^i ^v ^e ^l
+^n ^e ^t ^s ^i ^r ^t
+^n ^e ^r ^a
+^n ^e ^g ^r ^u ^j
+^n ^a ^t ^a ^n ^o ^h ^j
+^n ^a ^t ^a ^l ^z
+^n ^a ^m ^c
+^n ^a ^i ^x
+^n ^a ^f ^r ^i
+^m ^y ^a
+^m ^h ^o
+^l ^p ^a
+^l ^i ^a ^j
+^l ^e ^t ^r ^a ^c
+^l ^e ^t ^a ^c ^l ^a
+^l ^e ^k ^i ^a ^m
+^l ^e ^i ^n ^a ^h ^t ^a ^n
+^l ^e ^d ^n ^e ^w
+^l ^e ^a ^j
+^k ^r ^b
+^k ^e ^n
+^k ^c ^u ^t
+^k ^a ^e ^w
+^j ^c ^j
+^j ^a ^s
+^i ^x ^i ^p
+^i ^t ^o ^t
+^i ^m ^u ^k ^a ^t
+^i ^m ^a ^g ^i ^r ^o
+^i ^l ^u ^y
+^i ^l ^s ^e ^l
+^i ^l ^a ^p
+^i ^h ^c ^u ^p
+^i ^h ^c ^u ^h ^c
+^i ^h ^c ^a ^c
+^i ^f ^e ^t ^s
+^i ^c ^i ^n
+^i ^a ^l ^o ^k ^i ^n
+^h ^s ^k
+^h ^e ^s
+^h ^a ^r ^o ^n
+^g ^r ^b
+^g ^n ^o ^t
+^g ^n ^e ^b
+^g ^e ^k
+^f ^i ^l ^a
+^e ^z ^e ^e ^r ^b
+^e ^s ^s ^i ^n ^e ^d
+^e ^s ^r ^e ^v ^i ^n ^u
+^e ^r ^r ^i ^u ^g ^a
+^e ^n ^i ^v
+^e ^j ^a
+^e ^i ^x ^o ^r
+^e ^i ^v ^a ^d
+^e ^i ^t
+^e ^i ^n ^a ^j
+^e ^i ^l ^y ^r
+^e ^h ^s ^a
+^e ^e ^l ^y ^a ^b
+^e ^d ^a ^n ^o ^m ^e ^l
+^e ^b ^e ^r
+^d ^r ^o ^l ^k ^r ^a ^d
+^d ^n ^a ^m ^r ^a
+^d ^i ^m ^a ^h
+^d ^e ^m ^m ^a ^h ^u ^m
+^d ^e ^l ^a ^h ^k
+^d ^a ^u ^q ^s
+^c ^i ^n ^o ^s ^r ^e ^p ^u ^s
+^b ^m ^l
+^b ^e ^k
+^b ^b ^a ^a
+^b ^a ^p
+^a ^z ^e ^m
+^a ^y ^a ^r
+^a ^y ^a ^p ^a ^p
+^a ^t ^i ^r ^o ^m
+^a ^t ^i ^p
+^a ^s ^o ^c
+^a ^r ^e ^k
+^a ^r ^d ^e ^i ^p
+^a ^p ^o ^s
+^a ^p ^o ^o ^k
+^a ^n ^r ^e ^b
+^a ^n ^i ^z
+^a ^n ^e ^z
+^a ^n ^e ^b
+^a ^n ^a ^z ^n ^a ^m
+^a ^n ^a ^i ^v ^i ^v
+^a ^m ^u ^y
+^a ^m ^i ^s
+^a ^m ^e ^h ^c
+^a ^m ^a ^p
+^a ^l ^l ^o ^h
+^a ^l ^i ^a ^k
+^a ^l ^a ^j
+^a ^k ^c ^a ^j
+^a ^i ^j ^e ^m
+^a ^h ^s ^y ^a
+^a ^h ^n ^i ^l ^o ^b
+^a ^h ^a ^t
+^a ^g ^u ^s
+^a ^g ^o ^j
+^a ^f ^f
+^a ^d ^s
+^a ^c ^o ^m
+^a ^c ^e ^s ^n ^o ^f
+^a ^b ^o ^l
+^a ^b ^b
+^_ ^s ^i ^u ^l
+^_ ^e ^u ^l ^b
+^_ ^d ^i ^v ^a ^d
+^_ ^A
+^N
+^J ,3
+^J $7
+^E ,2
+^A o1h
+^A ]
+^A $s
+^A $4
+^2 ^0 ^0 ^3 r
+^1 ^2 ^3 ^4 ^5 r
+^0 ^9 ^1 o37
+^0 ^1 ^4 o32 r
+[ k c
+TC
+T0 T2 T3 T4
+T0 $x
+E *85 Z4
+D7 sbp
+D6 sng
+D5 o5X
+D5 .5
+D4 o4J
+D4 o4B
+D1 o2X
+D1 o2J
+D1 i2o
+D1 $2 $3 $4 $5
+D1 $1 $2 $3 $4 $5 $6 $7 $8 $9
+-6 o75
+-5 i61
+-5 $o
+-3 o0W
+-2 ^S
+-2 $1 $2 $3
+-1 D2
++7 o68
++2 $1 $2 $3
++1 i1i
++0 i4a
+*78 +6
+*75 L5
+*67 i65
+*64 i5f
+*57 o3e
+*54 o0K
+*45 ]
+*40 *23 y2
+*36 o0B
+*34 ^M
+*32 Z1 E
+*25 ^2
+*16 o5s
+*13 sau
+*05 '5
+'A D1
+'7 srv
+'7 o3g
+'7 D4
+'6 s0g
+'2 p3
+$k $1 $2 $3 $4
+$e i4r
+$d @p
+$c $i $t $y
+$a $y $a $l $a
+$N r
+$E
+$C r
+$@ $2 $0 $0 $5
+$9 $9 $1 $2
+$9 $1 $1 $2
+$9 $0 $0 $8
+$8 $8 $0 $2
+$5 o0A
+$5 -9 *89
+$5 $6 $5 $4
+$5 $6 $2 $3
+$4 iA3
+$4 $8 $0 $0
+$4 $5 $6 $1
+$4 $2 $3 $5
+$3 DA
+$3 $8 $9 $0
+$3 $7 $7 $7
+$3 $6 $5 $4
+$3 $3 $0 $3
+$3 $1 $9 $9
+$3 $1 $3 $2
+$3 $0 $2 $1
+$2 $5 $2 $7
+$2 $3 $6 $7
+$2 $3 $6 $5
+$2 $3 $4 $9
+$2 $3 $4 $3
+$2 $0 $2 $8
+$2 $0 $0 $6 $!
+$1 $6 $6 $6
+$1 $5 $3 $4
+$1 $5 $1 $3
+$1 $4 $2 $4
+$1 $3 $5 $2
+$1 $2 $1 $2 $3
+$1 $1 $4 $5
+$0 $0 $5 $6
+$0 $0 $3 $3
+} +0
+o61 i72 i83 i94 sS5 $6
+o45 c
+o2R
+o2O ]
+o2M
+o2B
+o1U
+o1C
+o0l $1 $2 $3 $4 $5
+o0Z o4Z
+o0Z ,2
+o0Z $0 $4
+o0Y o4Y
+o0Y $2 $1
+o0Y $1 $3
+o0S i1K
+o0M i2R
+o0D o2R
+l ] $o
+i9E
+i72 i80 ,9 oA5
+i6l i7d
+i61 i72 i83 i94
+i57 $7
+i51 i62 i73 i84 i95 iA6 oB7
+i51 i62 i73 i84 i95
+i4a D2
+i4B
+i45 i55 i66 ,7
+i45 i55 i65 ,7
+i42 i53 i62 o73
+i42 i50 i60 ,7
+i41 i59 i67 o75
+i41 i59 i67 o71
+i41 i59 i60 o77
+i41 i59 i60 o75
+i41 i52 i63 i74 i85
+i41 i52 i62 o77
+i40 i53 i60 o73
+i40 i50 i60 ,7
+i3s
+i3l $1 $2 $3
+i3e D5
+i3a D5
+i3a *35
+i3S
+i34 i45 i56 i67 o78
+i31 i42 i53 i64 o75
+i2k *75
+i2c i31 i42 o53
+i1o i2l i3o
+i1o i2c i3o
+i1c i3e
+i1O
+i1H
+i0T ^j k
+i0O i1c i2t
+i0J i1u i2n
+c o6o
+c ^x $x
+c T5
+c *98 ,8
+c $i $x
+c $9 $9 $6 $6
+c $9 $9 $0 $9
+c $9 $1 $1 $2
+c $9 $1 $1 $1
+c $9 $0 $5 $0
+c $9 $0 $1 $0
+c $9 $0 $0 $7
+c $8 $9 $2 $2
+c $8 $9 $0 $2
+c $8 $8 $5 $5
+c $8 $1 $8 $8
+c $8 $1 $0 $0
+c $8 $0 $0 $9
+c $7 $8 $6 $1
+c $7 $8 $0 $1
+c $7 $7 $2 $2
+c $7 $4 $2 $3
+c $7 $4 $0 $0
+c $7 $2 $7 $2
+c $6 $9 $9 $9
+c $6 $9 $8 $7
+c $6 $7 $8 $8
+c $6 $7 $7 $6
+c $6 $6 $7 $8
+c $6 $0 $6 $1
+c $5 $9 $0 $1
+c $5 $8 $6 $7
+c $5 $8 $2 $2
+c $5 $8 $1 $0
+c $5 $6 $2 $3
+c $5 $6 $1 $0
+c $5 $5 $1 $2
+c $5 $1 $3 $5
+c $4 $8 $9 $6
+c $4 $8 $9 $0
+c $4 $7 $5 $6
+c $4 $7 $1 $0
+c $4 $6 $5 $7
+c $4 $6 $5 $5
+c $4 $5 $5 $4
+c $4 $4 $1 $2
+c $4 $4 $0 $1
+c $4 $1 $5 $0
+c $4 $1 $3 $2
+c $4 $1 $2 $2
+c $4 $0 $9 $0
+c $4 $0 $5 $5
+c $3 $4 $6 $7
+c $3 $3 $0 $3
+c $3 $2 $0 $5
+c $3 $1 $1 $8
+c $2 $7 $1 $3
+c $2 $6 $7 $7
+c $2 $6 $7 $1
+c $2 $6 $2 $8
+c $2 $5 $4 $9
+c $2 $5 $1 $8
+c $2 $5 $1 $3
+c $2 $4 $9 $8
+c $2 $4 $4 $8
+c $2 $4 $2 $1
+c $2 $3 $9 $0
+c $2 $3 $2 $8
+c $2 $3 $1 $7
+c $2 $2 $2 $4
+c $2 $1 $9 $9
+c $2 $0 $2 $9
+c $1 $8 $8 $8
+c $1 $8 $2 $2
+c $1 $8 $1 $4
+c $1 $7 $3 $3
+c $1 $5 $8 $2
+c $1 $5 $4 $6
+c $1 $5 $2 $3
+c $1 $5 $1 $3
+c $1 $4 $9 $9
+c $1 $4 $7 $8
+c $1 $4 $3 $2
+c $1 $3 $4 $4
+c $1 $3 $3 $0
+c $1 $3 $2 $6
+c $1 $2 $5 $7
+c $1 $2 $4 $6
+c $0 $8 $2 $6
+c $0 $7 $2 $6
+c $0 $3 $1 $7
+c $0 $2 $3 $3
+c $0 $1 $9 $8
+c $0 $1 $5 $6
+^z ^g ^i ^m
+^y ^r ^u ^a ^m ^a
+^y ^p ^e ^e ^h ^s
+^y ^o ^b ^t ^s ^a ^e ^b
+^y ^a ^h ^j
+^y ^a ^d ^y ^a ^p
+^x ^n ^i ^w
+^x ^a ^m ^x ^a ^m
+^u ^u ^u
+^u ^i ^g ^r ^e ^s
+^t ^o ^l ^e ^c ^o
+^s ^t ^e ^e ^w ^s
+^s ^s ^o ^b ^a ^d
+^s ^r ^e ^n ^i ^m
+^s ^r ^e ^k ^a ^j
+^s ^o ^n ^a ^m ^r ^e ^h
+^s ^e ^i ^p ^p ^u ^p
+^s ^e ^i ^n ^n ^u ^b
+^s ^a ^i ^s ^o ^j
+^s ^a ^g ^e ^l ^l ^i ^v
+^r ^e ^t ^s ^i ^g ^e ^r
+^r ^e ^h ^s ^u ^r ^c
+^r ^e ^d ^a ^e ^r
+^r ^a ^t ^s ^r ^e ^p ^u ^s
+^r ^a ^e ^b ^a ^d ^n ^a ^p
+^o ^x ^e ^l ^a
+^o ^t ^o ^r ^a ^k ^a ^k
+^o ^t ^i ^n ^i ^h ^c
+^o ^t ^i ^h ^c ^a ^c
+^o ^p ^a ^u ^g
+^o ^o ^g ^o ^o ^g
+^o ^m ^o ^l ^a ^p
+^o ^l ^i ^r ^d ^o ^c ^o ^c
+^o ^l ^i ^h ^c
+^o ^i ^r ^u ^a ^s ^o ^n ^i ^d
+^o ^i ^r ^o ^s ^o
+^o ^h ^c ^i ^p
+^o ^g ^e ^i ^d ^n ^a ^u ^j
+^o ^d ^r ^a ^c ^c ^i ^r
+^n ^y ^l ^t ^a ^k
+^n ^o ^t ^n ^e ^r ^t
+^n ^o ^o ^j
+^n ^o ^i ^p ^r ^o ^c ^s ^e
+^n ^o ^e ^p ^m ^a ^c
+^n ^o ^e ^d
+^n ^i ^r ^o ^l ^f
+^n ^i ^l ^o ^p
+^n ^e ^r ^f ^e
+^n ^e ^l ^y ^a ^j
+^n ^e ^l ^a ^k
+^n ^a ^z ^a ^m ^a ^r
+^n ^a ^w ^k
+^n ^a ^m ^s ^s ^o ^b
+^n ^a ^m ^m ^e
+^n ^a ^i ^l ^l ^i ^k
+^m ^u ^b ^m ^u ^b
+^m ^e ^e ^r ^a ^k
+^m ^d ^t
+^m ^b ^b
+^m ^a ^n ^t ^e ^i ^v
+^l ^r ^i ^g ^d ^a ^b
+^l ^r ^a ^m
+^l ^l ^e ^r ^y ^t
+^l ^e ^o ^r
+^l ^e ^h ^c ^t ^i ^m
+^l ^e ^a ^s ^i ^m
+^l ^a ^v ^o ^d ^n ^a ^s
+^k ^s ^o
+^k ^n ^k
+^k ^n ^i ^k
+^k ^k ^k ^k
+^j ^d ^d
+^i ^s ^o ^y
+^i ^p ^u ^p
+^i ^n ^o ^n
+^i ^n ^i ^t
+^i ^n ^a ^v ^o ^i ^g
+^i ^n ^a ^u ^j
+^i ^l ^r ^a ^k
+^i ^l ^e ^l
+^h ^d ^k
+^h ^a ^e ^y ^h ^o
+^g ^o ^o ^b
+^g ^n ^i ^c ^u ^k
+^g ^n ^a ^o ^h
+^g ^n ^a ^j
+^f ^l ^o ^w ^e ^r ^e ^w
+^e ^z ^e ^z
+^e ^w ^q ^e ^w ^q
+^e ^u ^q ^i ^u ^q
+^e ^t ^n ^a ^m ^a ^i ^d
+^e ^r ^e ^r
+^e ^o ^l ^h ^k
+^e ^n ^o ^l ^c ^y ^c
+^e ^l ^i ^t ^p ^e ^r
+^e ^l ^e ^s
+^e ^i ^m ^m ^o ^t
+^e ^i ^l ^l ^i ^l
+^e ^i ^l ^l ^e ^n
+^e ^i ^k ^o ^o ^r
+^e ^i ^b ^a ^g
+^e ^d ^y ^a ^j
+^e ^d ^i ^t ^l ^l ^o ^r
+^e ^c ^i ^m
+^e ^a ^n
+^e ^a ^f
+^d ^n ^o ^p
+^d ^e ^b ^o
+^d ^d ^u ^j
+^c ^a ^s ^i
+^b ^b ^o ^b
+^a ^y ^n ^a ^s
+^a ^y ^l ^a
+^a ^v ^a ^v
+^a ^t ^r ^e ^u ^p
+^a ^t ^i ^s ^o ^r
+^a ^t ^e ^t
+^a ^s ^y
+^a ^r ^h ^a ^z
+^a ^r ^e ^r ^r ^e ^h
+^a ^r ^d ^n ^a
+^a ^r ^a ^m ^a
+^a ^r ^a ^j
+^a ^p ^o ^p
+^a ^n ^n ^e ^r ^b
+^a ^n ^n ^a ^v ^a ^s
+^a ^n ^n ^a ^l ^a
+^a ^n ^i ^v
+^a ^n ^a ^x ^o ^r
+^a ^n ^a ^h ^o ^j
+^a ^m ^o ^j
+^a ^l ^l ^i ^d ^r ^a
+^a ^l ^i ^g
+^a ^l ^i ^e ^k
+^a ^k ^j
+^a ^k ^c ^i ^r ^e
+^a ^j ^a ^j ^a ^j
+^a ^h ^t ^a ^n
+^a ^h ^n ^i ^l ^a ^g
+^a ^h ^c ^i ^h ^c
+^a ^d ^o ^c
+^a ^c ^a ^b
+^a ^b ^a ^t
+^a ^b ^a ^h ^r ^e ^m
+^a ^a ^d
+^D $2
+^B .3
+^3 ^2 ^1 o34 r
+^2 ^1 T2
+Y2 $1
+L6 o2g
+D5 o5D
+D5 ,5
+D4 o4V
+D4 o4C
+D3 o3I
+D2 .4
+D2 $1 $2 $3 $4 $5 $6
+D1 o1V
+C s5P D0
+@a o1g
+.0 ^y
+.0 D2
+.0 $1 $2 $3
+-9 oA3
+-8 Z1 ,7
+-6 soi
+-6 o3l
+-5 [
+-4 o52
+-3 $1 $2 $3
+-2 T3
+-0 i3i
++B c
++8 +8 +8
++5 i51
++5 ^K
++5 Z1
++5 -4
++4 i47
++4 ]
++2 D4
++1 D2
++1 *04
++1 $1 $2 $3
++0 $3 $2 $1
+*BA D9
+*87 o81
+*75 o2n
+*69 o67
+*68 o6r
+*60 o0C
+*41
+*31 sns T6
+*31 r
+*27 o2n
+*12 ^H
+*06 o4k
+'B c $7
+'A t
+'5 o0d
+'5 o0b
+'4 $m
+$v .7
+$o @1
+$m $1 $2 $3 $4
+$l
+$e o0F
+$e Z3
+$c $l $a $s $h
+$a ssj
+$_ $2 $0 $0 $4
+$9 $9 $9 $9 $9 $9
+$9 $9 $8 $7
+$9 $3 $2 $1
+$9 $0 $9 $9
+$8 Z1
+$8 $8 $0 $4
+$6 $8 $1 $0
+$5 $4 $2 $3
+$5 $1 $2 $3
+$4 $5 $6 $6
+$4 $3 $3 $4
+$3 $2 $1 $3
+$2 $8 $2 $1
+$2 $8 $0 $0
+$2 $5 $4 $5
+$2 $5 $4 $3
+$2 $4 $6 $8 $1 $0
+$2 $4 $6 $7
+$2 $4 $5 $5
+$2 $4 $1 $5
+$2 $3 $4 $7
+$2 $3 $3 $5
+$2 $3 $2 $9
+$2 $2 $2 $1
+$2 $0 $9 $8
+$1 T6 $5
+$1 $6 $7 $8
+$1 $5 $6 $7
+$1 $3 $5 $4
+$1 $2 $6 $6
+$1 $1 $5 $7
+$1 $1 $4 $1
+$1 $1 $3 $1
+$1 $0 $4 $4
+$0 sGk .4
+$0 o67
+$0 T3 $8
+$0 *85
+$0 $0 $2 $0
+$%
+{ [
+so0 u $1
+r c
+oAs
+o9x
+o4T o5H
+o2Y ]
+o2N
+o2C ]
+o1Z
+o1W ]
+o1R D0
+o0r $2 $0 $0 $4
+o0r $2 $0 $0 $2
+o0n $2 $0 $0 $3
+o0Z o2Z
+o0Y $1 $1
+o0Y $0 $5
+o0T ,5
+o0K o5C
+o0K o5B
+o0K $2 $0 $0 $2
+o0K $2 $0 $0 $1
+o0( o6)
+l sys
+l o0c
+l ] $t
+l $r
+i8r i9o
+i8l i9e
+i82 i90 iA0 oB4
+i7t i8y
+i7t ]
+i6r i71
+i62 i70 i80 o92
+i5r i6i i7a
+i5Z c
+i5T
+i51 i62 i73 o84
+i4a i6a i5r
+i4_ i51 o63
+i4_ i51 o62
+i4P
+i49 i58 i67 o76
+i48 i58 i68 ,7
+i47 i58 i69 o70
+i41 i59 i69 ,7
+i41 i59 i67 o74
+i41 i51 i62 ,7
+i40 i59 i60 o79
+i3i -4
+i31 i42 i53 i64 i75 i86 i97 iA8 oB9
+i2o i3o
+i1o i2k i3o
+i1a i2y i3l
+i1a i2u i3l
+i1a i2m i3s
+i0P i0O
+i0H z1 E
+d t
+c seu
+c o2_
+c i6R
+c ^5 ^0 ^9 ^2
+c ^0 ^8 ^0 ^1
+c +A $1
+c $9 $8 $9 $9
+c $9 $8 $0 $1
+c $9 $3 $3 $9
+c $9 $3 $0 $0
+c $9 $1 $0 $4
+c $8 $8 $7 $6
+c $8 $8 $0 $1
+c $8 $7 $7 $1
+c $7 $8 $9 $1
+c $7 $7 $9 $9
+c $7 $3 $1 $0
+c $7 $0 $0 $1
+c $6 $8 $6 $9
+c $6 $7 $8 $7
+c $6 $5 $8 $7
+c $5 $9 $9 $9
+c $5 $7 $6 $8
+c $5 $7 $1 $2
+c $5 $6 $1 $3
+c $5 $4 $3 $1
+c $5 $4 $2 $0
+c $5 $0 $0 $9
+c $4 $5 $2 $1
+c $4 $4 $3 $2
+c $4 $4 $2 $4
+c $4 $4 $2 $1
+c $4 $4 $1 $1
+c $4 $4 $0 $4
+c $4 $3 $9 $9
+c $4 $2 $3 $5
+c $4 $1 $0 $1
+c $4 $0 $1 $1
+c $3 $8 $3 $8
+c $3 $7 $0 $0
+c $3 $6 $0 $1
+c $3 $5 $2 $5
+c $3 $4 $5 $4
+c $3 $4 $1 $2
+c $3 $3 $5 $5
+c $3 $3 $2 $2
+c $3 $2 $3 $4
+c $3 $2 $1 $9
+c $3 $0 $9 $9
+c $3 $0 $9 $8
+c $2 $9 $1 $5
+c $2 $9 $0 $0
+c $2 $8 $2 $2
+c $2 $7 $7 $2
+c $2 $7 $1 $4
+c $2 $5 $4 $6
+c $2 $5 $2 $7
+c $2 $4 $3 $2
+c $2 $4 $3 $1
+c $2 $4 $2 $7
+c $2 $4 $1 $6
+c $2 $3 $5 $1
+c $2 $2 $3 $2
+c $2 $2 $2 $1
+c $2 $2 $1 $4
+c $2 $1 $2 $6
+c $1 $8 $7 $6
+c $1 $8 $1 $7
+c $1 $7 $4 $9
+c $1 $7 $2 $7
+c $1 $6 $7 $8
+c $1 $5 $3 $1
+c $1 $5 $1 $4
+c $1 $4 $2 $4
+c $1 $3 $6 $0
+c $1 $3 $5 $6
+c $1 $3 $4 $7
+c $1 $2 $6 $7
+c $1 $2 $6 $4
+c $1 $2 $4 $2
+c $1 $2 $3 $7
+c $1 $1 $3 $5
+c $0 $9 $2 $1
+c $0 $7 $9 $8
+c $0 $6 $2 $9
+c $0 $6 $2 $7
+c $0 $6 $1 $4
+c $0 $3 $1 $4
+c $0 $1 $3 $2
+c $0 $0 $0 $9
+c $0 $0 $0 $6
+c $0 $0 $0 $5
+^z ^e ^d ^n ^e ^l ^e ^m
+^y ^o ^l ^p
+^y ^k ^z ^i ^r
+^y ^e ^v ^e ^t ^s
+^y ^d ^i ^p ^s
+^t ^e ^p ^p ^o ^p
+^t ^a ^h ^r ^e ^f
+^s ^t ^u ^n ^a ^e ^p
+^s ^e ^s ^o ^j
+^s ^e ^l ^a ^s ^o ^r
+^s ^a ^k ^a ^l ^a ^m
+^r ^o ^d ^a ^z ^a ^c
+^r ^i ^a ^d ^a
+^r ^e ^t ^n ^o ^m
+^r ^e ^s ^s ^a ^n
+^r ^e ^k ^y ^r
+^r ^e ^e ^b ^t ^o ^o ^r
+^r ^a ^m ^r ^a ^m
+^r ^a ^h ^z ^a
+^r ^a ^c ^e ^c ^a ^r
+^q ^q ^q ^q
+^p ^o ^p ^p ^o ^p
+^p ^o ^h ^c ^k ^r ^o ^p
+^o ^n ^i ^p ^i ^l ^i ^f
+^o ^n ^e ^n ^e ^v
+^o ^n ^a ^h ^c
+^o ^i ^l ^e ^g ^o ^r
+^o ^h ^c ^u ^c
+^o ^c ^o ^l ^l ^e
+^n ^u ^r ^e ^m ^o ^h
+^n ^o ^z ^e ^b ^a ^c
+^n ^o ^s ^n ^a
+^n ^o ^e ^k
+^n ^o ^e ^g ^n ^u ^d
+^n ^o ^c ^l ^a
+^n ^n ^y ^r ^b
+^n ^n ^a ^y ^r
+^n ^i ^s ^a ^s ^s ^a
+^n ^i ^o ^e
+^n ^e ^e ^k
+^n ^e ^d ^n ^a ^l
+^n ^a ^r ^m ^a ^k
+^n ^a ^r ^a ^s
+^n ^a ^m ^y ^a ^r
+^n ^a ^l ^p ^a ^k
+^n ^a ^h ^s ^o ^r
+^n ^a ^a
+^m ^r ^a ^h
+^m ^i ^s ^a
+^l ^e ^z ^n ^e ^d
+^l ^e ^o ^y
+^l ^a ^n ^o ^r
+^l ^a ^m ^r ^o ^n
+^k ^o ^y
+^k ^n ^a ^u ^j
+^k ^e ^j
+^k ^c ^o ^l ^r ^e ^h ^s
+^k ^c ^i ^n ^i ^m ^o ^d
+^i ^w ^a ^k
+^i ^u ^t
+^i ^r ^u ^z
+^i ^r ^a ^h ^s
+^i ^n ^o ^y
+^i ^m ^o ^m
+^i ^l ^l ^o ^p
+^i ^e ^j
+^i ^d ^r ^o ^g
+^i ^a ^s ^i
+^h ^t ^o ^o ^t
+^h ^t ^e ^z ^i ^l
+^h ^s ^o ^g
+^h ^s ^i ^n ^a
+^h ^n ^a ^h ^t
+^h ^a ^y ^m
+^h ^a ^y ^i ^l ^a
+^h ^a ^y ^a
+^h ^a ^l ^a ^s
+^g ^n ^a ^t ^n ^i ^b
+^g ^n ^a ^p
+^g ^a ^a
+^f ^e ^k
+^f ^a ^t
+^e ^t ^a ^p
+^e ^r ^o ^d ^o ^e ^h ^t
+^e ^r ^a ^p
+^e ^o ^l
+^e ^n ^y ^a ^p
+^e ^n ^i ^m ^z ^a ^j
+^e ^m ^i ^j
+^e ^l ^t
+^e ^l ^s
+^e ^k ^a ^k
+^e ^i ^p ^o ^o ^p
+^e ^i ^k ^c ^a ^l ^b
+^e ^f ^l ^o ^w
+^e ^e ^r ^d ^n ^a
+^e ^e ^k ^i ^m
+^e ^e ^b ^e ^l ^b ^m ^u ^b
+^e ^c ^n ^e ^r ^a ^l ^c
+^e ^c ^n ^e ^i ^c ^s
+^e ^c ^m
+^d ^r ^e ^w
+^d ^r ^e ^t
+^d ^i ^v ^i ^e ^d
+^d ^e ^e ^a ^s
+^d ^d ^u ^b
+^d ^d ^s
+^d ^a ^d ^m ^u ^m
+^c ^s ^o
+^c ^n ^e
+^b ^v ^c ^x ^z
+^b ^u ^j
+^a ^y ^i ^l ^a
+^a ^y ^i
+^a ^y ^a ^t
+^a ^t ^s ^o ^k
+^a ^t ^i ^p ^e ^p
+^a ^t ^a ^p ^a ^z
+^a ^s ^k
+^a ^s ^d ^f
+^a ^r ^t ^u ^p
+^a ^r ^r ^a ^p
+^a ^r ^i ^a
+^a ^p ^a ^h ^c
+^a ^n ^o ^r
+^a ^n ^i ^a
+^a ^n ^e ^k
+^a ^n ^e ^e ^l
+^a ^n ^a ^v ^o ^i ^g
+^a ^l ^y ^a ^t
+^a ^l ^o ^z
+^a ^l ^e ^a ^k ^i ^m
+^a ^k ^u ^p
+^a ^k ^m
+^a ^j ^n ^a ^m ^e ^n
+^a ^i ^s ^e ^n ^o ^d ^n ^i
+^a ^h ^c ^a ^p
+^a ^g ^l ^u ^p
+^a ^d ^i ^m ^o ^c
+^a ^d ^i ^d
+^a ^c ^n ^a ^u ^j
+^a ^a ^l ^a
+^_ ^s ^o ^l ^r ^a ^c
+^_ ^m ^a ^s
+^L *15
+^I $1 $3
+^I $1 $2 $3
+^D o1J
+^D ^X
+^C i72
+^B $7
+^A ,5
+^A $2 $3
+^A $1 $0
+^9 ^9 ^9 ^1
+^1 ^2 ^3 ^4 D5 r
+^0 ^0 ^1 ^1
+^0 C ^3
+^( $)
+] {
+] *41
+[ *53
+L0 +0 ,1
+K s6u
+E T6 .2
+E T3
+DC
+D8 ]
+D8 $b
+D7 i4y
+D4 o4P
+D3 .3
+D3 -3
+D2 o3C
+D1 o2V
+D1 o2A
+D1 i2a
+D0 o3p
+@a T0
+.0 {
+.0 i1k
+-8 .7
+-7 i77
+-5 s20
+-5 i55
+-4 o5i
+-1 $1 $2 $3
+-0 i1r
+-0 *05 D0
++7 i34
++6 slg
++6 +6 +6
++6 '9
++4 ,5
++3 stg
++3 snz
++3 i4e
++2 o3u
++1 $2 $0 $0 $2
++0 y2
++0 i1l
++0 Z2
++0 D2
++0 $2 $0 $0 $1
+*76 +6
+*68 o4i oAJ
+*68 o0k
+*63 o3q
+*57 c D6
+*56 ^a
+*54 o4z
+*36 c
+*34 $y
+*28 c
+*26 D2 Z2
+*10 { c
+'B t
+'B o9u
+'B $e
+'8 o2t D1
+'7 o1n
+'7 ^C
+'6 c
+'5 i3e
+'2 +0 p4
+$n $1 $2 $3 $4
+$j $1
+$e $0 $2
+$_ $3 $3 $3
+$_ $1 $2 $3 $4 $5
+$R $O
+$8 $9 $0 $1
+$7 $2
+$6 $7 $8 $0
+$6 $3
+$5 $6 $2 $1
+$5 $5 $1 $2
+$5 $0 $0 $2
+$4 $5 $6 $5
+$4 $4 $5 $6
+$4 $4 $3 $4
+$4 $3 $2 $5
+$3 $4 $5 $6 $7
+$2 $8 $9 $9
+$2 $3 $4 $6
+$1 R3
+$1 $5 $4 $3
+$1 $5 $2 $7
+$1 $4 $2 $6
+$1 $2 $3 $4 $5 $6 $7 $8 $9
+$1 $1 $4 $2
+$0 o63
+$0 $5 $0 $0
+$0 $3 $4 $5
+$0 $2 $0 $0
+$0 $1 $9 $9
+u i6s
+o8S
+o3T o4H
+o1K ]
+o1E ]
+o0t $1 $2 $3 $4 $5
+o0c scq
+o0Z $2 $4
+o0Z $0 $3
+o0Y $2 $8
+o0Y $0 $3
+o0V $1 $2 $3 $4
+o0K $2 $0 $0 $4
+o0D
+o0C o4A
+l ^w ^e ^n
+l ] $D
+i8a i9l
+i82 o90 iA0 oB2
+i7o i8p
+i7i i8o
+i6q
+i6f
+i6T o7H
+i5P
+i5@
+i52 $2
+i4i .5
+i47 i57 i67 ,7
+i42 i55 i62 o75
+i42 i54 i62 o74
+i42 .5
+i3t
+i3N
+i2y +0
+i2m $1 $2 $3
+i2i -3
+i2E l
+i2E
+i1y ^s
+i1e i2m i3o
+i0d
+c o1G
+c ^6 ^0 ^9 ^2
+c $9 $9 $1 $3
+c $9 $6 $7 $8
+c $9 $2 $3 $4
+c $9 $2 $2 $3
+c $9 $2 $0 $2
+c $9 $0 $1 $5
+c $9 $0 $0 $8
+c $8 $8 $1 $1
+c $8 $4 $1 $2
+c $8 $3 $8 $3
+c $8 $3 $0 $1
+c $8 $1 $2 $2
+c $7 $8 $8 $8
+c $7 $8 $6 $5
+c $7 $8 $1 $1
+c $7 $7 $9 $0
+c $7 $7 $1 $2
+c $7 $6 $8 $9
+c $7 $2 $1 $0
+c $7 $1 $0 $0
+c $6 $9 $0 $3
+c $6 $8 $6 $8
+c $6 $7 $0 $0
+c $6 $6 $5 $5
+c $6 $6 $2 $1
+c $6 $5 $4 $0
+c $6 $5 $0 $3
+c $6 $0 $0 $7
+c $6 $0 $0 $6
+c $5 $8 $2 $6
+c $5 $7 $9 $0
+c $5 $7 $5 $7
+c $5 $6 $7 $7
+c $5 $5 $3 $3
+c $5 $4 $6 $8
+c $5 $2 $3 $6
+c $5 $1 $1 $2
+c $5 $0 $1 $2
+c $5 $0 $0 $7
+c $5 $0 $0 $2
+c $4 $6 $8 $0
+c $4 $5 $8 $0
+c $4 $5 $7 $6
+c $4 $5 $6 $0
+c $4 $4 $7 $7
+c $4 $4 $5 $6
+c $4 $3 $2 $5
+c $4 $0 $0 $2
+c $3 $8 $3 $9
+c $3 $7 $9 $8
+c $3 $5 $4 $6
+c $3 $5 $3 $4
+c $3 $4 $5 $7
+c $3 $4 $1 $0
+c $3 $3 $0 $6
+c $3 $2 $4 $4
+c $3 $1 $3 $2
+c $3 $1 $2 $2
+c $2 $9 $8 $8
+c $2 $9 $2 $0
+c $2 $8 $3 $7
+c $2 $7 $2 $5
+c $2 $7 $0 $2
+c $2 $6 $1 $3
+c $2 $5 $6 $0
+c $2 $5 $3 $0
+c $2 $4 $7 $8
+c $2 $4 $6 $5
+c $2 $3 $7 $8
+c $2 $3 $7 $6
+c $2 $2 $7 $7
+c $2 $2 $4 $4
+c $2 $1 $5 $4
+c $2 $1 $5 $0
+c $2 $1 $3 $0
+c $2 $1 $1 $4
+c $1 $8 $0 $3
+c $1 $7 $2 $6
+c $1 $5 $9 $0
+c $1 $5 $6 $7
+c $1 $5 $2 $2
+c $1 $4 $7 $7
+c $1 $4 $7 $0
+c $1 $4 $3 $8
+c $1 $4 $3 $5
+c $1 $4 $2 $7
+c $1 $4 $2 $6
+c $1 $3 $6 $7
+c $1 $3 $4 $3
+c $1 $3 $3 $4
+c $1 $2 $8 $4
+c $1 $2 $6 $6
+c $1 $2 $5 $9
+c $1 $2 $4 $8
+c $1 $1 $5 $7
+c $1 $1 $4 $0
+c $0 $8 $1 $4
+c $0 $5 $2 $7
+c $0 $1 $4 $5
+c $0 $0 $8 $9
+c $0 $0 $7 $7
+c $0 $0 $6 $8
+c $0 $0 $0 $3
+^y ^u ^p
+^y ^o ^b ^y ^n ^n ^e ^b
+^y ^n ^a ^v ^o ^j
+^y ^h ^c ^a ^z
+^y ^e ^r ^y ^e ^r
+^y ^e ^l ^s ^n ^i ^a
+^y ^a ^n ^o ^d ^a
+^x ^z ^x ^z
+^w ^z ^a ^q
+^w ^w ^w ^w
+^u ^h ^c ^a ^c ^i ^p
+^t ^a ^c ^a ^c
+^s ^y ^t ^t ^i ^k
+^s ^o ^d ^e ^d
+^s ^i ^v ^a ^j
+^s ^e ^x ^o ^f
+^s ^e ^l ^g ^g ^i ^g
+^r ^i ^h ^a ^z
+^r ^e ^y ^a ^l ^s ^n ^o ^g ^a ^r ^d
+^r ^e ^p ^o ^o ^p
+^r ^e ^p ^e ^e ^r ^c
+^r ^e ^d ^a ^b
+^r ^a ^l ^u ^p ^o ^p
+^p ^o ^c ^o ^b ^o ^r
+^o ^y ^i ^y
+^o ^t ^i ^x ^e ^l ^a
+^o ^t ^i ^x ^a ^m
+^o ^t ^i ^l ^e ^u ^g ^i ^m
+^o ^t ^i ^h ^c ^u ^l
+^o ^t ^a ^p ^a ^z
+^o ^r ^r ^a ^v ^a ^n
+^o ^r ^g ^e ^n ^l ^e
+^o ^r ^e ^n ^i ^d
+^o ^l ^l ^i ^j ^u ^r ^t
+^o ^j ^e ^r ^t
+^o ^i ^r ^e ^t ^s ^i ^m
+^o ^i ^l ^u ^a ^r ^b
+^o ^h ^c ^o ^p
+^o ^h ^c ^i ^n
+^o ^e ^l ^o ^e ^l
+^o ^d ^a ^r ^o ^d
+^n ^u ^b ^n ^u ^b
+^n ^o ^v ^a ^j
+^n ^o ^t ^x ^a ^r ^b
+^n ^o ^s ^y ^l ^a
+^n ^n ^n
+^n ^i ^v ^l ^a ^k
+^n ^i ^s ^a ^y
+^n ^i ^m ^s ^o ^c
+^n ^i ^a ^s ^s ^u ^h
+^n ^e ^p ^p ^i ^k
+^n ^e ^k ^n ^e ^k
+^n ^e ^d ^r ^a ^a ^p
+^n ^a ^y ^i ^a ^s
+^n ^a ^m ^y ^a
+^n ^a ^m ^l ^a ^s
+^n ^a ^g ^u ^k ^a ^b
+^n ^a ^d ^y ^a
+^m ^x ^e ^l ^a
+^m ^a ^z ^a
+^m ^a ^s ^m ^a ^s
+^l ^r ^u ^g
+^l ^o ^c ^i ^a ^m
+^l ^e ^g ^n ^a ^r
+^l ^e ^a ^k
+^l ^e ^a ^c ^i ^m
+^l ^a ^u ^c ^s ^a ^p
+^l ^a ^i ^c ^i ^f ^f ^o
+^k ^n ^u ^h
+^k ^m ^m
+^k ^j ^k ^j
+^k ^a ^a
+^j ^s ^j
+^i ^u ^p
+^i ^s ^e ^y
+^i ^r ^o ^s ^a ^s
+^i ^r ^e ^n
+^i ^r ^a ^y
+^i ^r ^a ^n
+^i ^n ^a ^l ^a
+^i ^n ^a ^b
+^i ^l ^o ^n
+^i ^l ^e ^y ^a ^n
+^i ^h ^c ^o ^c
+^i ^h ^c ^a ^h ^c
+^i ^g ^r ^e ^s
+^h ^s ^s
+^h ^e ^r ^i ^j
+^h ^c ^a ^p
+^h ^a ^i ^s ^i
+^g ^u ^b ^e ^v ^o ^l
+^g ^n ^o ^d ^g ^n ^i ^d
+^g ^n ^i ^n
+^g ^n ^i ^l ^t ^s ^e ^r ^w
+^g ^n ^i ^d ^a ^e ^r
+^g ^n ^a ^v
+^g ^b ^b
+^g ^a ^z ^g ^i ^z
+^f ^n ^a
+^f ^e ^s ^u ^o ^y
+^e ^y ^e ^k ^w ^a ^h
+^e ^y ^a ^k
+^e ^s ^n ^a ^u ^j
+^e ^r ^b ^u ^t ^c ^o
+^e ^n ^i ^a ^r
+^e ^m ^i ^m
+^e ^m ^e ^v ^o ^l ^i
+^e ^i ^t ^a ^c
+^e ^i ^n ^a ^l
+^e ^i ^g
+^e ^i ^d ^a
+^e ^f ^f ^o ^c
+^e ^f ^a ^t ^n ^a ^s
+^e ^c ^r ^a ^b
+^e ^c ^i ^v
+^d ^u ^o ^m ^h ^a ^m
+^d ^s ^s
+^d ^r ^o ^o ^w ^t ^h ^c ^a ^w
+^d ^k ^a
+^d ^i ^n
+^d ^e ^a
+^d ^a ^m ^a
+^d ^a ^a
+^c ^n ^a ^u ^j
+^c ^i ^n ^a ^t ^i ^t
+^c ^d ^i ^v ^a ^d
+^c ^c ^c ^c
+^a ^z ^o ^l
+^a ^y ^u ^k
+^a ^y ^i ^k
+^a ^y ^a ^d
+^a ^v ^a ^h ^c
+^a ^t ^a ^h ^c
+^a ^s ^u ^l ^e ^p
+^a ^s ^o ^s
+^a ^r ^o ^t
+^a ^n ^a ^z
+^a ^n ^a ^y ^a ^d
+^a ^n ^a ^i ^t
+^a ^m ^o ^l
+^a ^m ^n ^a ^u ^j
+^a ^l ^i ^n
+^a ^l ^a ^m ^e ^t ^a ^u ^g
+^a ^k ^e ^b
+^a ^j ^n ^a ^r ^a ^n
+^a ^j ^j
+^a ^h ^s ^i ^r ^t
+^a ^h ^j
+^a ^g ^o ^k
+^a ^f ^a ^t ^s ^o ^m
+^a ^d ^r ^o ^j
+^a ^c ^i ^r ^a ^m
+^a ^c ^i ^n ^a ^d
+^a ^a ^c
+^M ,2
+^B .2
+^B ,2
+^A T5
+^A ,3
+^A $2 $1
+^A $0 $6
+^<
+^7 ^1 T2
+^2 ^0 ^0 ^4 r
+^0 ^0 ^5 o32 r
+^0 ^0 ^1 o32 r
+^- D2
+] ] l ] $o
+] ] ] ] ] c
+Y2 Y4 Y2
+DA oAa
+D5 scv
+D5 o5P
+D5 o5M
+D5 ,3 stm
+D3 o3W
+D1 o3F
+D1 o1J D3
+D1 D3 o3P
+@k c o3L
+.0 r
+-9 ]
+-8 o3b
+-7 o55
+-7 i59
+-5 o6a
+-5 Z2
+-4 o5a
+-4 -4 -4 -4
+-4 $o
+-3 -3 -3 -3
+-2 $2 $0 $0 $2
+-0 -2 ^B
++6 Y2 .2
++5 i53
++4 o5a
++4 c
++4 *76 *6B
++1 i1u
++1 D2 D3
++0 i16
++0 '5
+*A8 s0x
+*83 Z1 .5
+*78 D4
+*76 o5t
+*75 r
+*74 i57
+*71 c
+*57 o0C
+*56 o69
+*56 +6
+*27 i55
+*06 $6 '5
+*05 Z1
+*02 R4
+'B D3
+'A +7
+'9 o2z
+'9 i6e
+'9 i46
+'9 ^k
+'8 t
+'8 $y
+'6 stb
+$i $1 $2 $3 $4
+$e $1 $2 $3 $4
+$d $a $y
+$b u
+$_ $2 $0 $0 $2
+$B
+$8 $8 $8 $8 $8 $8
+$7 $7 $3 $3
+$7 $1 $2 $3
+$5 $7
+$5 $6 $7 $9
+$5 $6 $6 $7
+$5 $6 $1 $2
+$5 $3
+$5 $0 $0 $3
+$4 sdr
+$4 ^M
+$4 *86
+$4 $8 $9 $0
+$4 $4 $9 $9
+$4 $0 $0 $1
+$3 $9 $8 $7
+$3 $4 $4 $5
+$2 $9 $9 $9
+$2 $9 $1 $4
+$2 $8 $2 $2
+$2 $8
+$2 $5 $4 $8
+$2 $2 $5 $6
+$1 Y2
+$1 $7 $1 $3
+$1 $7
+$1 $4 $4 $5
+$0 Z3 D5
+$0 $4 $5 $6
+$0 $0 $6 $6
+$/ s/X @8
+} i0W
+{ i5k
+t Y4 Y4
+o6]
+o60
+o3U
+o2Z ]
+o1C ]
+o0Z $0 $2
+o0Y i1T
+o0Y $2 $4
+o0Y $1 $4
+o0K o4J
+o0J $2 $0 $0 $2
+o0E o1J
+l o63
+l i6i
+l ^r ^e ^p ^u ^s
+l $p
+l $m $e
+k D2
+i8c i9h
+i7p i8e
+i7o ]
+i72 i80 ,9 oA2
+i6Z
+i69 +7
+i5Y
+i4s i52 i60
+i4_ ss1 $2 $3
+i42 i54 i66 o78
+i42 i52 i62 ,7
+i42 i50 i61 o74
+i42 i50 i61 o73
+i42 i50 i61
+i42 i50 i60 o72
+i41 i59 i67 o72
+i3m .4
+i3a i42 o50
+i32 i40 i50 o64
+i31 i42 i53 i64 i75 o86
+i1o i2a
+i1o $1 $2 $3
+i1e ^E
+i1e $1 $2 $3
+c $e $x
+c $d $u $d $e
+c $9 $9 $0 $1
+c $9 $0 $2 $2
+c $8 $9 $1 $2
+c $8 $5 $1 $0
+c $8 $1 $9 $0
+c $7 $9 $7 $9
+c $7 $7 $3 $3
+c $7 $5 $5 $5
+c $7 $5 $4 $3
+c $7 $2 $2 $1
+c $7 $0 $9 $8
+c $7 $0 $2 $1
+c $6 $6 $7 $6
+c $6 $5 $6 $6
+c $6 $5 $1 $2
+c $6 $2 $0 $0
+c $6 $0 $0 $1
+c $5 $6 $7 $6
+c $5 $6 $7 $4
+c $5 $6 $6 $5
+c $5 $6 $5 $4
+c $5 $6 $4 $7
+c $5 $5 $5 $6
+c $5 $5 $3 $2
+c $5 $5 $2 $2
+c $5 $4 $6 $7
+c $5 $0 $9 $0
+c $5 $0 $7 $0
+c $4 $9 $4 $9
+c $4 $8 $0 $4
+c $4 $6 $8 $7
+c $4 $5 $5 $6
+c $4 $5 $4 $3
+c $4 $5 $2 $6
+c $4 $4 $4 $5
+c $4 $3 $4 $5
+c $4 $2 $1 $3
+c $4 $1 $7 $2
+c $4 $0 $1 $2
+c $3 $9 $3 $9
+c $3 $7 $7 $7
+c $3 $5 $6 $1
+c $3 $5 $1 $9
+c $3 $4 $6 $5
+c $3 $4 $4 $7
+c $3 $4 $2 $6
+c $3 $2 $6 $5
+c $3 $2 $3 $1
+c $3 $2 $1 $5
+c $3 $1 $1 $7
+c $3 $1 $1 $1
+c $3 $0 $4 $0
+c $2 $7 $2 $9
+c $2 $5 $5 $8
+c $2 $5 $5 $4
+c $2 $5 $1 $4
+c $2 $1 $5 $5
+c $2 $1 $4 $3
+c $1 $8 $6 $2
+c $1 $7 $9 $9
+c $1 $7 $3 $0
+c $1 $7 $2 $8
+c $1 $5 $3 $6
+c $1 $5 $3 $2
+c $1 $3 $5 $4
+c $1 $3 $3 $9
+c $1 $3 $1 $9
+c $1 $2 $3 $4 $5 $6 $7 $8
+c $1 $1 $6 $6
+c $1 $1 $5 $4
+c $1 $1 $4 $8
+c $1 $1 $4 $3
+c $0 $9 $9 $8
+c $0 $9 $2 $2
+c $0 $9 $1 $5
+c $0 $8 $2 $9
+c $0 $7 $2 $7
+c $0 $5 $6 $7
+c $0 $3 $4 $5
+c $0 $2 $2 $2
+c $0 $1 $5 $0
+c $0 $1 $3 $5
+c $0 $0 $9 $8
+^y ^u ^g ^t ^o ^h
+^y ^o ^b ^y ^o ^b
+^y ^n ^n ^e ^g
+^s ^w ^o ^b ^n ^i ^a ^r
+^s ^s ^i ^u ^l
+^s ^s ^a ^a
+^r ^i ^m ^a ^j
+^r ^e ^f ^o ^t ^s ^i ^r ^c
+^r ^a ^u ^n ^a
+^o ^t ^i ^t ^e ^b
+^o ^t ^i ^l ^a ^p
+^o ^t ^i ^k ^o ^l
+^o ^s ^o ^m ^r ^e ^h
+^o ^r ^e ^h ^r ^e ^p ^u ^s
+^o ^r ^a ^n ^e ^g
+^o ^o ^c ^o ^o ^c
+^o ^l ^l ^i ^r ^r ^a ^c
+^o ^l ^e ^n ^a ^c
+^o ^j ^e ^d ^n ^e ^p
+^o ^d ^a ^r ^a ^v ^l ^a
+^o ^d ^a ^n ^o ^d ^l ^a ^m
+^n ^y ^r ^m ^a ^k
+^n ^y ^r ^m ^a ^c
+^n ^o ^s ^r ^e ^t ^e ^p
+^n ^o ^s ^l ^i ^n ^e ^d
+^n ^o ^r ^e ^m ^a ^k
+^n ^o ^n ^n ^a ^i ^h ^r
+^n ^o ^m ^a ^j
+^n ^o ^i ^m ^a ^c
+^n ^i ^u ^g ^n ^i ^p
+^n ^i ^s ^s ^a ^y
+^n ^i ^l ^e ^s ^o ^j
+^n ^e ^t ^o ^g
+^n ^a ^x ^e ^l ^a
+^n ^a ^v ^l ^a ^g
+^n ^a ^t ^a ^t
+^n ^a ^m ^y ^e ^n ^o ^m
+^n ^a ^m ^o ^g ^e ^l
+^n ^a ^m ^d ^e ^r
+^n ^a ^l ^y ^r
+^n ^a ^l ^h ^c ^a ^l
+^n ^a ^l ^a ^t
+^n ^a ^i ^h ^t ^s ^i ^r ^c
+^n ^a ^e ^b ^y ^l ^l ^e ^j
+^m ^o ^b ^m ^i ^c
+^l ^o ^l ^o ^l
+^l ^i ^m ^a ^y
+^l ^e ^a ^n ^a ^t ^a ^n
+^l ^a ^n ^r ^e ^b
+^l ^a ^n ^o ^i ^c ^a ^n
+^k ^o ^o ^p
+^k ^o ^o ^k
+^k ^n ^u ^p ^m ^c
+^k ^e ^l ^a ^d
+^k ^d ^k
+^j ^m ^k
+^i ^r ^u ^s
+^i ^r ^m
+^i ^n ^e ^r
+^i ^n ^a ^l ^i ^e ^l
+^i ^g ^r ^o ^i ^g
+^i ^d ^l ^o ^g
+^i ^a ^p ^e ^a ^m
+^i ^a ^k ^i ^a ^k
+^h ^a ^y ^n
+^g ^o ^d ^c
+^g ^n ^i ^g
+^g ^n ^a ^r ^o
+^f ^i ^a ^s
+^f ^a ^r ^h ^s ^a
+^e ^y ^e ^y
+^e ^y ^a ^m
+^e ^s ^t ^n ^o ^m
+^e ^p ^o ^l
+^e ^n ^y ^a ^r
+^e ^m ^i ^l ^s
+^e ^m T2
+^e ^l ^o ^h ^t ^t ^u ^b
+^e ^l ^o ^h ^c
+^e ^l ^i ^l
+^e ^k ^c ^a ^j
+^e ^i ^z ^n ^e ^k ^c ^m
+^e ^i ^x ^a ^m
+^e ^i ^w ^e ^t ^s
+^e ^i ^p ^e ^k ^i ^l ^i
+^e ^i ^m ^m ^e
+^e ^i ^l ^a
+^e ^i ^f ^l ^o ^w
+^e ^e ^w ^e ^e ^p
+^e ^e ^v ^e ^e
+^e ^e ^l ^i ^a ^h
+^e ^c ^y ^a ^j
+^d ^n ^o ^m ^h ^c ^i ^r
+^d ^l ^a ^w ^s ^o
+^d ^e ^r ^r ^a ^j
+^d ^e ^k
+^c ^k ^k
+^a ^z ^n ^a ^i ^l ^a
+^a ^y ^i ^e ^s
+^a ^y ^a ^l
+^a ^t ^i ^n ^u ^l
+^a ^t ^i ^f ^a ^r
+^a ^n ^i ^a ^l ^a
+^a ^n ^a ^t
+^a ^m ^h
+^a ^m T2
+^a ^l ^l ^i ^w
+^a ^l ^i ^p
+^a ^l ^e ^v
+^a ^l ^a ^w
+^a ^k ^i ^a
+^a ^j ^n ^o ^p ^s ^e ^b ^o ^b
+^a ^i ^t ^s ^e ^b
+^a ^i ^l ^a ^d
+^a ^g ^j
+^a ^e ^h ^c
+^a ^c ^i ^s ^e ^j
+^X ^x
+^K $1 $2 $3
+^J $0 $1
+^B $2
+^A i4A
+^A .3
+^7 ^0 T2
+^4 r c
+^3 ^2 ^2 ^1 ^1 o53
+^2 ^3 ^4 ^5 ^6 o51 r
+^2 ^3 ^4 ^5 ^6 ^7 ^8 ^9 o81 r
+^2 ^2 ^2 o32
+^2 ^0 ^0 ^5 r
+] ] ] ] ] ]
+] -2
+L6
+D8 o2d
+D5 T0
+D3 o3U
+D3 o3H
+D3 i4i
+D3 $O
+D2 o3K
+D2 i3e
+D2 $D
+D1 o3T
+D1 o2W
+D1 o2V ]
+D1 o2B
+D1 o1D
+D1 D2 o3G
+D1 D2 o2J
+D1 $2 $0 $0 $4
+@v Z1 $p
+@7 i42
+-9 i90
+-7 i4x
+-7 E $5
+-7 -7
+-7 -3 Z1
+-6 i62
+-5 o6i
+-4 -5
+-2 o3a
+-2 *10
++A ^5 c
++9 o0l
++8 o4l
++8 ,9
++7 o0K
++5 o6o
++5 Z2
++4 @a
++2 $2 $0 $0 $2
++1 ^J
+*87 o7i
+*86 o30
+*68 *97
+*67 sf. s12
+*63
+*57 D8
+*56 -6
+*56 '7
+*51 o0C
+*47 o5w
+*35 Y2
+*31 o1u
+*20 sri
+*06 o2y
+*02 scl
+*01 soi
+'B c $0
+'9 i48
+'9 ^e @c
+'9 D2
+'6 o3e
+'6 $i
+'5 o21
+'5 Z4
+'5 +4
+'4 ^d
+$l $1 $2 $3 $4
+$i $a $n
+$e $0 $3
+$F t
+$D T5 T0
+$A {
+$9 $0 $8 $7
+$8 $4 $5 $6
+$6 @o
+$5 $5 $6 $1
+$4 .7
+$4 $6 $8 $0
+$4 $6 $7 $8
+$4 $5 $6 $2
+$3 $7 $8 $9
+$3 $4 $2 $5
+$3 $4
+$3 $3 $3 $3 $3 $3
+$3 $0 $0 $2
+$2 $6
+$2 $5 $3 $5
+$2 $3 $4 $8
+$2 $0 $2 $0 $2 $0
+$2 $0 $1 $3
+$2 $0 $0 $6
+$1 $7 $7 $7
+$1 $6 $9 $9
+$1 $5 $9 $9
+$1 $5 $5 $5
+$1 $3 $4 $3
+$1 $3 $3 $2
+$1 $2 d ] ]
+$1 $2 $4 $6
+$1 $2 $3 $4 $1
+$1 $1 $5 $6
+$1 $1 $4 $3
+$1 $1 $4 $0
+$0 $9 $9 $8
+$0 $9 $8 $7 $6 $5
+$0 $9
+$0 $7 $9 $9
+$0 $0 $0 $5
+u $x $X ^x ^X
+snN
+r -7 $m
+o1o ssE u
+o1J D3 ]
+o0r $2 $0 $0 $3
+o0Z ,5
+o0W +1
+o0K $1 $2 $3 $4 $5
+o0B o4A
+l o4a
+l i2m
+l ] $s
+l $u $s
+l $m $a $n
+k ^t
+i70
+i6u i7i
+i6q $w
+i67 +7
+i61 i72 i83 i94 iA5
+i61 ^t
+i6.
+i5y i61 i72
+i4_ i52 o61
+i44 i55 i64 o75
+i43 i54 i63 o74
+i43 i50 i60 ,7
+i41 i59 i60 o73
+i3o i41 o52
+i3a R0 L0
+i31 i42 i53 i64 i75 i86 o97
+i2i D4
+i1w
+i1o i2b i3o
+i1k
+i1e R0 L0
+i1a R0 L0
+i0s i2m i1a
+c o0r
+c i3a
+c ^9 ^0 ^9 ^2
+c ^6 ^1 ^0 ^2
+c $t $y
+c $9 $9 $9 $8
+c $9 $9 $1 $9
+c $9 $9 $1 $2
+c $9 $9 $0 $2
+c $9 $1 $0 $2
+c $8 $2 $2 $0
+c $8 $2 $1 $2
+c $7 $8 $9 $9
+c $7 $8 $8 $9
+c $7 $8 $8 $5
+c $7 $8 $1 $0
+c $7 $8 $0 $9
+c $7 $8 $0 $0
+c $7 $3 $4 $5
+c $6 $7 $7 $7
+c $6 $3 $4 $5
+c $6 $1 $3 $2
+c $5 $6 $0 $3
+c $5 $5 $9 $9
+c $5 $5 $2 $3
+c $5 $4 $3 $4
+c $5 $4 $3 $3
+c $5 $2 $0 $2
+c $5 $1 $1 $1
+c $5 $0 $5 $5
+c $4 $7 $6 $5
+c $4 $7 $0 $5
+c $4 $6 $1 $0
+c $4 $5 $6 $3
+c $4 $5 $5 $1
+c $4 $5 $3 $2
+c $4 $5 $0 $9
+c $4 $4 $3 $4
+c $4 $3 $5 $6
+c $4 $2 $4 $5
+c $4 $2 $3 $1
+c $3 $8 $0 $0
+c $3 $3 $1 $1
+c $2 $9 $2 $2
+c $2 $9 $1 $7
+c $2 $9 $1 $4
+c $2 $5 $6 $4
+c $2 $5 $5 $0
+c $2 $5 $2 $8
+c $2 $5 $2 $3
+c $2 $5 $1 $5
+c $2 $4 $5 $2
+c $2 $4 $4 $4
+c $2 $4 $2 $3
+c $2 $4 $1 $5
+c $2 $3 $4 $8
+c $2 $3 $4 $0
+c $2 $3 $2 $9
+c $2 $2 $8 $8
+c $2 $2 $4 $5
+c $2 $2 $3 $8
+c $2 $0 $5 $6
+c $1 $8 $7 $2
+c $1 $8 $2 $5
+c $1 $8 $2 $1
+c $1 $6 $2 $3
+c $1 $6 $1 $5
+c $1 $4 $9 $8
+c $1 $3 $5 $2
+c $1 $3 $4 $5
+c $1 $2 $9 $8
+c $1 $2 $4 $4
+c $1 $2 $3 $@
+c $1 $0 $7 $6
+c $0 $8 $9 $7
+c $0 $2 $3 $4
+c $0 $0 $4 $5
+c $0 $0 $4 $3
+^z ^z ^z ^z ^z
+^y ^o ^b ^r ^e ^p ^u ^s
+^y ^m ^o ^m
+^x ^X ^x $x $X $x
+^s ^o ^t ^i ^t ^a ^g
+^s ^o ^d ^a ^y ^a ^r
+^s ^n ^a ^x ^e ^t
+^s ^i ^n ^a ^u ^j
+^s ^e ^o ^t ^a ^t ^o ^p
+^s ^e ^n ^o ^g ^a ^r ^d
+^s ^a ^r ^d ^s ^e
+^s ^a ^l ^o ^k ^c ^i ^n
+^s ^a ^h ^c ^n ^a ^m
+^r ^e ^t ^a ^n
+^r ^e ^d ^n ^a ^m ^r ^a ^h ^c
+^r ^a ^m ^s ^o
+^r ^a ^c ^r ^a ^c
+^p ^x ^e ^l ^a
+^p ^o ^l ^p ^o ^l
+^o ^z ^i ^r ^o ^h ^c
+^o ^y ^y ^u ^t
+^o ^t ^i ^r ^a ^m
+^o ^t ^i ^m ^e ^m
+^o ^r ^e ^t ^n ^o ^m
+^o ^m ^i ^n ^o ^n ^a
+^o ^m ^e ^r ^t ^x ^e
+^o ^l ^l ^i ^k ^o ^l
+^o ^l ^e ^i ^n ^a ^d
+^o ^h ^o ^h ^o ^h
+^o ^f ^u ^t ^i ^p
+^o ^d ^r ^u ^z
+^o ^d ^n ^o ^w ^k ^e ^a ^t
+^o ^d ^e ^r ^f ^l ^i ^w
+^n ^y ^d ^a ^j
+^n ^o ^s ^n ^e ^j
+^n ^o ^r ^e ^d ^l ^a ^c
+^n ^o ^r ^a ^j
+^n ^o ^o ^n
+^n ^o ^d ^a ^j
+^n ^i ^k ^l ^e
+^n ^a ^y ^n ^a ^y
+^n ^a ^t ^n ^a ^t
+^n ^a ^s ^h ^i
+^n ^a ^m ^t ^t ^a ^m
+^n ^a ^m ^t ^n ^a
+^n ^a ^m ^k
+^n ^a ^j ^a ^b
+^n ^a ^i ^r ^a ^d
+^m ^r ^e ^p ^u ^s
+^m ^o ^p ^m ^o ^p
+^m ^o ^o
+^m ^m ^t
+^l ^e ^i ^n
+^l ^a ^v ^i ^v ^r ^u ^s
+^l ^a ^d ^n ^e ^k
+^k ^k ^j
+^k ^c ^i ^t
+^i ^u ^g ^n ^i ^p
+^i ^r ^b ^i ^r ^b
+^i ^k ^u ^p
+^i ^k ^n ^o ^m
+^i ^i ^r ^a ^m
+^i ^h ^r
+^h ^t ^e ^b ^z ^i ^l
+^h ^b ^a
+^g ^o ^h ^e ^g ^d ^e ^h
+^g ^n ^o
+^g ^n ^e ^l
+^g ^n ^a ^r
+^f ^o ^o ^w
+^e ^s ^j
+^e ^r ^o ^n
+^e ^n ^y ^a ^h ^s
+^e ^n ^i ^a ^l
+^e ^n ^e ^v
+^e ^n ^a ^t
+^e ^n ^a ^n ^a ^s
+^e ^m ^s ^i
+^e ^m ^o ^g
+^e ^l ^l ^a ^w
+^e ^l ^c ^i ^n ^o ^i ^b
+^e ^h ^j
+^e ^h ^c ^e ^h ^c
+^e ^f ^i ^l ^g ^u ^h ^t
+^e ^d ^o ^c ^s ^s ^a ^p
+^e ^c ^o ^j
+^e ^c ^n ^o ^p
+^e ^c ^n ^e ^d ^a ^c
+^e ^c ^h ^a ^b ^r ^e ^n ^e ^f
+^e ^b ^o ^r
+^d ^x ^e ^l ^a
+^d ^u ^b ^e ^s ^o ^r
+^d ^r ^e ^i ^w
+^d ^o ^g ^e ^v ^o ^l ^i
+^d ^i ^k ^l ^o ^o ^c
+^b ^u ^a
+^b ^o ^b ^y ^l ^l ^i ^b
+^a ^z ^i ^m
+^a ^z ^a ^n
+^a ^y ^h ^a ^y
+^a ^y ^d
+^a ^v ^e ^r
+^a ^u ^l ^l ^i ^k
+^a ^u ^h ^c
+^a ^t ^i ^s ^o
+^a ^t ^i ^l ^l ^e ^r ^t ^s ^e
+^a ^t ^e ^l ^l ^a ^g
+^a ^s ^i ^n
+^a ^r ^o ^d ^i ^s ^i
+^a ^r ^d ^n ^e ^m ^l ^a
+^a ^n ^u ^a ^h ^s
+^a ^n ^e ^c ^n ^h ^o ^j
+^a ^m ^u ^s
+^a ^m ^r
+^a ^m ^a ^m ^a ^p ^a ^p
+^a ^l ^y ^a ^k ^i ^m
+^a ^l ^y ^a ^h ^s
+^a ^l ^i ^n ^a ^d
+^a ^i ^p ^m ^i ^l ^o
+^a ^i ^n ^e ^s ^e ^y
+^a ^i ^n ^a ^m ^e ^l ^a
+^a ^i ^n ^a ^h ^s
+^a ^i ^c ^i ^l ^o ^p
+^a ^h ^n ^a ^r ^a
+^a ^h ^a ^s
+^a ^g ^r ^e ^v
+^a ^g ^a ^r ^b
+^a ^f ^o ^f
+^a ^d ^n ^a ^d
+^a ^c ^i ^n
+^a ^c ^i ^l ^a ^t ^e ^m
+^a ^a ^t
+^_ ^n ^i ^v ^e ^k
+^M $1 $2 $3
+^J ]
+^D i0x
+^C ,3
+^B $1 $2 $3
+^A o3z
+^@
+^6 ^1 ^0 ^2
+^4 ^3 ^2 ^1 o45 r
+^2 ^3 ^4 ^5 o41 r
+^2 ^1 ^3 ^2 ^1 o53
+^1 t ^3
+^1 T9 r
+^0 ^0 ^4 o32 r
+] i9s
+] c spL
+] ,6 ,4
+T6 Y2 T0
+T5 T6 T7 T8
+K o53
+D6 [ s9k
+D3 o4X
+D2 o3X
+D1 o3G
+D1 o2C D3
+D1 o1V D3
+D1 D2 o3C
+D1 $2 $0 $1 $4
+@9 z1 c
+@5 ^j
+-9 o64
+-7 ,8
+-7 *76
+-7 *46 Y1
+-6 ^_
+-6 D7
+-5 Z1 oBb
+-5 K
+-5 -5 -5 -5
+-5 $I }
+-3 o4a
+-0 *01 ^k
+-0 $2 $0 $0 $4
+-0 $1 $2 $3 $4 $5
++6 i7l
++4 o5e
++4 +4 +4 +4
++0 s23
+*B8 o5_ u
+*86 c *97
+*78 -6
+*65 ^k s)U
+*63 ] '5
+*54
+*35 r
+*26 '5
+*16 o5w
+*08 T0 *13
+'A @a
+'A +2
+'9 sfg
+'8 i4u
+'7 ^D
+'6 c Z1
+'5 o4d
+'5 o0m
+'4 i1f
+'4 i11 *02
+'4 $.
+$y $o $l $o
+$i Z2 D6
+$i $n
+$e o9l
+$e i4b
+$K { T4
+$9 o0P
+$9 $9 $5 $5
+$9 $8 $7 $0
+$8 $0 $0 $1
+$7 o0k smc
+$7 $3 $2 $1
+$7 $1
+$6 $2
+$6 $1
+$5 $1
+$4 ^C
+$3 E .2
+$3 $4 $6 $7
+$3 $4 $5 $8
+$3 $4 $5 $5
+$3 $3 $3 $3 $3
+$2 L5 Z1
+$2 $4 $6 $5
+$1 say
+$1 $6 $1 $5
+$1 $3 $4 $4
+$1 $2 $3 $4 $5 $6
+$1 $1 $9 $8
+$0 $1 $2 $3 $4 $5
+} '4 } } }
+u sE3 $Z
+sa4 u
+o7n ]
+o6z
+o4R o5O
+o44 .5
+o1M ]
+o0n $2 $0 $0 $4
+o0h shk
+o0X -1
+o0K o5L
+o0K o5G
+o0K o4D
+o0J o4C
+o0I o2C
+l o7e
+l o5i
+l o3@
+l ^t ^o ^h
+l ^n ^u
+l ] $r
+l [ ^v
+l $y
+l $r $e
+l $a
+l $! $! $!
+i82 o90 iA0 oB3
+i71 i82 i93 iA4 iB5
+i4T
+i3a +4
+i3W l
+i3E
+i2k [
+i2k $1 $2 $3
+i1o i2n i3y
+i1a D3
+i1a .2
+i0(
+c i1t
+c $9 $9 $9 $0
+c $9 $8 $0 $2
+c $9 $7 $1 $1
+c $9 $5 $6 $7
+c $9 $3 $2 $1
+c $9 $1 $3 $2
+c $9 $0 $8 $7
+c $9 $0 $3 $4
+c $8 $9 $0 $4
+c $8 $8 $0 $4
+c $8 $1 $3 $3
+c $8 $1 $1 $2
+c $7 $8 $7 $7
+c $7 $8 $6 $7
+c $7 $7 $7 $8
+c $6 $9 $7 $8
+c $6 $8 $9 $9
+c $6 $8 $0 $0
+c $6 $5 $2 $2
+c $5 $9 $8 $7
+c $5 $8 $1 $2
+c $5 $6 $7 $1
+c $5 $6 $4 $5
+c $5 $5 $1 $9
+c $5 $5 $1 $3
+c $5 $4 $7 $8
+c $5 $4 $0 $1
+c $4 $6 $7 $3
+c $4 $5 $6 $9
+c $4 $3 $3 $4
+c $4 $2 $7 $5
+c $4 $2 $0 $2
+c $3 $6 $0 $0
+c $3 $5 $5 $5
+c $3 $5 $2 $2
+c $3 $3 $5 $6
+c $3 $3 $4 $5
+c $3 $3 $0 $2
+c $3 $2 $4 $2
+c $3 $2 $1 $7
+c $2 $9 $1 $8
+c $2 $8 $9 $9
+c $2 $7 $2 $2
+c $2 $5 $6 $7
+c $2 $5 $4 $5
+c $2 $5 $4 $4
+c $2 $5 $2 $6
+c $2 $5 $1 $7
+c $2 $4 $6 $7
+c $2 $3 $@
+c $2 $3 $9 $9
+c $2 $3 $4 $9
+c $2 $3 $4 $1
+c $2 $2 $9 $9
+c $2 $2 $4 $6
+c $2 $0 $1 $7
+c $1 $6 $9 $9
+c $1 $6 $5 $5
+c $1 $2 $3 $9
+c $0 $4 $6 $7
+c $0 $4 $5 $6
+^y ^t ^o ^t
+^y ^s ^s ^a ^j
+^y ^o ^p ^o ^p
+^y ^n ^o ^h ^t
+^y ^e ^t ^u ^c
+^y ^b T2
+^u ^i ^d ^u ^a ^l ^c
+^t ^e ^e ^f ^y ^p ^p ^a ^h
+^t ^a ^n ^t ^a ^n
+^t ^a ^c ^t ^a ^c
+^s ^p ^e ^e ^r ^c
+^s ^o ^t ^a ^p
+^s ^e ^r ^a ^r
+^s ^e ^p ^i ^r ^t ^s
+^s ^a ^t ^e ^l ^l ^a ^g
+^s ^a ^d ^s ^a
+^r ^i ^a ^d ^l ^a
+^r ^e ^t ^n ^a ^b
+^r ^e ^r ^e
+^r ^e ^k ^a ^f
+^r ^e ^f ^s ^i ^u ^l
+^r ^e ^b ^l ^i ^w
+^r ^e ^b ^e ^h
+^q ^w ^e ^r ^t ^y ^u ^i ^o ^p
+^q ^i ^f ^a ^y ^s
+^p ^o ^l ^o ^l
+^p ^o ^i ^u ^y
+^o ^t ^i ^s ^a ^m ^o ^t
+^o ^t ^i ^h ^c ^a ^n
+^o ^r ^e ^p ^a ^r
+^o ^r ^d ^n ^a ^s ^i ^l
+^o ^o ^l ^o ^o ^l
+^o ^n ^a ^i ^r ^o ^s
+^o ^l ^l ^i ^p
+^o ^h ^n ^i ^n ^a ^m
+^o ^d ^l ^o ^g
+^o ^d ^a ^l ^e ^h
+^n ^u ^f ^n ^u ^f
+^n ^o ^t ^l ^o ^k
+^n ^o ^s ^x ^a ^j
+^n ^o ^m ^a ^m
+^n ^o ^i ^n ^i ^m
+^n ^o ^g ^n ^i ^h ^c
+^n ^j ^i ^t ^r ^a ^m
+^n ^i ^r ^a ^s ^e ^c
+^n ^i ^l ^y ^a ^k
+^n ^i ^l ^y ^a ^j
+^n ^i ^l ^i ^p
+^n ^i ^k ^i ^k
+^n ^e ^s ^n ^a ^j
+^n ^e ^h ^t ^a ^n
+^n ^e ^b ^n ^e ^b
+^n ^a ^v ^z ^a ^r
+^n ^a ^m ^t
+^n ^a ^m ^s ^u
+^n ^a ^m ^n ^o ^c
+^n ^a ^m ^b
+^n ^a ^i ^h ^r
+^n ^a ^i ^a ^r ^b
+^n ^a ^h ^u ^t ^a ^b
+^n ^a ^g ^a ^e ^k
+^n ^a ^e ^k
+^m ^a ^r ^k ^a
+^l ^r ^i ^g ^y ^t ^t ^e ^r ^p
+^l ^l ^a ^b ^m ^u ^g
+^l ^k ^j ^h ^g
+^l ^a ^z ^i ^r
+^l ^a ^b ^q ^i
+^k ^o ^k ^o
+^k ^n ^i ^b
+^k ^i ^j
+^k ^i ^d ^a
+^j ^j ^j ^j
+^j ^e ^j
+^j ^d ^j ^d
+^i ^v ^i ^e ^d
+^i ^t ^u ^c
+^i ^t ^s ^i ^m
+^i ^o ^p ^i ^o ^p
+^i ^o ^m ^i ^o ^m
+^i ^m ^s ^i ^u ^l
+^i ^m ^o ^y
+^i ^k ^n ^i ^p
+^i ^h ^s ^n ^e ^k
+^i ^g ^o ^p
+^i ^d ^a ^y
+^i ^a ^h ^k
+^h ^s ^a ^j
+^h ^a ^l ^i ^l ^e ^d
+^g ^o ^d ^k
+^g ^n ^u ^s
+^g ^n ^i ^h ^t
+^g ^n ^e ^t
+^g ^n ^e ^j
+^e ^w ^e ^w
+^e ^r ^m
+^e ^r ^d ^a ^m ^u ^t
+^e ^r ^b ^m ^e ^i ^c ^i ^d
+^e ^m ^s ^o ^c
+^e ^k ^a ^l ^f ^w ^o ^n ^s
+^e ^i ^t ^e ^e ^w ^s
+^e ^i ^p ^e ^i ^t ^u ^c
+^e ^i ^l ^u ^a ^p
+^e ^i ^l ^a ^o ^g
+^e ^i ^k ^n ^i ^p
+^e ^h ^c ^u ^l ^e ^p
+^e ^h ^c ^a ^c
+^e ^e ^r ^b ^u ^a
+^e ^e ^l ^i ^a ^b
+^e ^d ^o ^m ^t ^s ^a ^e ^b
+^e ^d ^i ^u ^g
+^e ^b ^u ^n
+^d ^n ^a ^l ^i ^a ^h ^t
+^d ^n ^a ^l ^e ^l
+^d ^m ^m
+^d ^i ^h ^s ^a ^r
+^d ^e ^r
+^c ^e ^k
+^a ^t ^r ^o ^t
+^a ^t ^a ^t ^a ^p
+^a ^t ^a ^l ^p
+^a ^s ^r ^a ^b
+^a ^r ^u ^t ^n ^e ^v
+^a ^r ^a ^d ^a ^m
+^a ^p ^a ^p ^a ^m ^a ^m
+^a ^n ^o ^t
+^a ^n ^n ^e ^k
+^a ^n ^n ^a ^i ^t
+^a ^n ^h ^o ^j
+^a ^m ^e ^r
+^a ^l ^y ^n
+^a ^l ^y ^e ^k
+^a ^l ^o ^r
+^a ^l ^l ^o ^p
+^a ^l ^i ^v ^a ^d
+^a ^i ^d ^n ^a ^s
+^a ^i ^a ^k
+^a ^g ^g ^n ^a
+^a ^d ^i ^v ^a ^d
+^a ^c ^a ^h ^c
+^a ^a ^a ^a ^a
+^a $1 $2 $3 $4
+^_ ^l ^e ^i ^n ^a ^d
+^_ ^e ^s ^o ^j
+^E ^W ^W
+^D $1 $2 $3
+^A .2
+^A ,4
+^A $1 $1
+^2 ^1 i63 o74
+^0 ^1 T2
+[ i1i
+T0 i2o $3
+T0 T2 T4 T6
+D8 o4b
+D4 c
+D3 o3Y
+D2 *26 i3b
+D1 o3K
+D1 o3J
+D1 o2G
+D1 D3 o3C
+D1 D2 o3P
+D1 D2 o3J
+D1 -3
+@1 ^a
+-9 E -5
+-9 -9
+-7 D8
+-6 i82
+-5 -5
+-3 o4u
+-3 o4i
+-2 $2 $0 $0 $1
+-2 $1 $2 $3 $4
+-1 -1 -1
+-0 $1 $2 $3 $4
++A E
++4 o5i
++4 *64
++3 soe
++3 o4a
++2 o3a
++2 ]
++2 $2 $0 $0 $3
++2 $1 $2 $3 $4 $5
++2 $1 $2 $3 $4
++1 @a
++1 '5
++0 o1u
++0 +0 +0 +0 +0 +0 +0 +0
++0 $2 $0 $0 $4
+*76 o6a
+*76 +7
+*36 i1w
+*35 o0X
+*34 +5
+*32 i6_
+*25 *42 R5
+*16 i5a
+*15 o0Z
+*07 c
+'B r
+'A +1
+'9 @a
+'8 K o5p
+'6 ^G
+'5 +3
+'5 $i
+'4 ^l
+'4 +1
+'3 Z5
+$n *93 '4
+$d c Z1
+$b $a $r
+$a o7f
+$T *87 u
+$R $J
+$9 $9 $8 $1
+$9 $9 $0 $4
+$9 $4 $5 $6
+$9 $0
+$8 @m
+$7 E ,3
+$7 @i
+$6 L5 c
+$6 $9
+$6 $8
+$5 @6
+$5 $8
+$4 o0E
+$3 Y1
+$2 t
+$2 $7
+$2 $5
+$2 $0 $0 $5 $!
+$1 smn
+$1 $5 $4 $5
+$1 $1 $3 $5
+$0 Y2
+$0 $6 $9 $9
+$0 $3 $0 $0
+$0 $0 $3
+sbB
+oAz
+o8k
+o4G ,5
+o1J
+o0z $2 $0 $0 $4
+o0Z $2 $5
+o0Y $7 $7
+o0Y $3
+o0Y $1 $5
+o0S $3
+o0K o4C
+o0K $2 $0 $0 $3
+o0D o5A
+o0(
+l o6i
+l o4z
+l o44
+l o1i
+l o0d
+l ^m ^i
+l [ ^z
+l $n $o
+l $m $u
+l $l $o $v $e
+i8r +6
+i78
+i6G
+i50 $9
+i4a i52 i60
+i4_ i51 o60
+i4@ i51 i62 o73
+i49 i59 i69 ,7
+i45 i54 i63 i72 o81
+i43 i53 i63 ,7
+i41 i59 i67 o70
+i3u i4e i5l
+i3o o4k
+i3i i41 i52 o63
+i3b .7
+i2z
+i2t $1 $2 $3
+i2g $1 $2 $3
+c o0t
+c ^*
+c Z2 s5%
+c T6
+c $9 $8 $7 $1
+c $9 $8 $4 $5
+c $9 $0 $9 $8
+c $8 $9 $8 $8
+c $8 $9 $0 $7
+c $7 $9 $8 $8
+c $7 $7 $7 $2
+c $7 $5 $6 $7
+c $7 $0 $9 $0
+c $6 $1 $2 $2
+c $6 $0 $7 $7
+c $5 $7 $3 $3
+c $5 $6 $7 $5
+c $5 $6 $6 $7
+c $5 $6 $2 $1
+c $5 $5 $6 $7
+c $4 $6 $5 $9
+c $4 $3 $2 $2
+c $4 $2 $7 $4
+c $4 $2 $3 $4
+c $3 $6 $9 $0
+c $3 $6 $6 $3
+c $3 $5 $0 $4
+c $3 $4 $9 $0
+c $3 $4 $5 $9
+c $3 $3 $6 $5
+c $3 $2 $5 $5
+c $2 $9 $2 $8
+c $2 $8 $3 $8
+c $2 $5 $3 $4
+c $2 $4 $3 $5
+c $2 $3 $4 $4
+c $2 $0 $0 $3 $!
+c $1 $5 $9 $9
+c $1 $3 $9 $9
+c $1 $3 $4 $2
+c $1 $3 $1 $8
+c $1 $2 $3 $4 $5 $6 $7
+c $1 $2 $3 $2
+c $0 $6 $9 $9
+c $0 $0 $9 $1
+c $0 $0 $8 $8
+c $0 $0 $7 $6
+c $0 $0 $0 $8
+^y ^r ^t ^e ^m ^o ^e ^g
+^y ^p ^p ^i ^p
+^y ^o ^b ^i ^b
+^s ^p ^e ^e ^p
+^s ^o ^t ^e ^h ^c
+^s ^o ^l ^l ^o ^p
+^s ^k ^c ^o ^l ^b
+^s ^e ^l ^k ^n ^i ^r ^p ^s
+^s ^e ^i ^t ^t ^i ^k
+^r ^e ^z ^a ^t
+^r ^e ^t ^t ^u ^l ^f
+^r ^e ^h ^p ^o ^t ^s ^i ^r ^c
+^r ^e ^d ^a ^e ^l ^r ^e ^e ^h ^c
+^r ^b ^r ^b
+^r ^a ^e ^b ^y ^m ^m ^u ^g
+^p ^o ^p ^l ^o ^l
+^p ^o ^o ^r ^t
+^p ^a ^l ^o ^h
+^p
+^o ^u ^t ^e ^q
+^o ^t ^i ^r ^o ^t
+^o ^t ^i ^l ^o ^p
+^o ^t ^i ^l ^e ^u ^n ^a ^m
+^o ^t ^i ^b ^a ^g
+^o ^n ^a ^t ^a ^l ^p
+^o ^j ^o ^j ^o ^j
+^o ^i ^r ^a ^m ^r ^e ^p ^u ^s
+^o ^d ^r ^a ^p ^o ^e ^l
+^o ^d ^l ^a ^v
+^o ^d ^i ^p ^a ^r
+^n ^o ^s ^l ^i ^n
+^n ^o ^s ^i ^e ^j
+^n ^o ^l ^a ^b
+^n ^i ^r ^d ^l ^a
+^n ^i ^l ^a ^l
+^n ^i ^d ^l ^a
+^n ^e ^r ^a ^d
+^n ^a ^w ^r ^a ^m
+^n ^a ^w ^a ^k
+^n ^a ^u ^t
+^n ^a ^r ^b ^i ^g
+^n ^a ^m ^t ^a ^c
+^n ^a ^m ^i ^h
+^n ^a ^m ^i ^a
+^n ^a ^l ^a ^g
+^n ^a ^i ^d ^i ^s ^b ^o
+^n ^a ^h ^r ^u ^b
+^n ^a ^c ^n ^a ^c
+^m ^s ^s
+^m ^a ^k ^m ^a ^k
+^l ^u ^r ^i ^m ^a
+^l ^r ^i ^g ^r ^e ^p ^u ^s
+^l ^o ^o ^c ^m ^a ^i
+^l ^o ^n ^a ^m ^i
+^l ^e ^s ^o ^j
+^l ^a ^l ^a ^l
+^l ^a ^l ^a
+^k ^n ^i ^o
+^j ^e ^s
+^i ^r ^a ^m ^o
+^i ^p ^m ^a ^h ^c
+^i ^m ^e ^m
+^i ^k ^c ^i ^r
+^i ^j ^n ^a ^s
+^i ^i ^n ^a ^d
+^i ^a ^y
+^h ^t ^e ^n ^a ^j
+^h ^n ^o ^j
+^h ^n ^a ^h ^k
+^h ^a ^z ^m ^a ^h
+^g ^n ^o ^u ^r ^t
+^g ^n ^i ^t ^r ^a ^f
+^g ^d ^d
+^f ^f ^f ^f
+^e ^y ^a ^t
+^e ^t ^n ^o ^d
+^e ^n ^i ^l ^e ^g ^n ^a
+^e ^n ^a ^c ^y ^d ^n ^a ^c
+^e ^l ^y ^a ^k
+^e ^l ^l ^o ^c ^i ^n
+^e ^k ^a ^s
+^e ^i ^z
+^e ^i ^w ^e ^h ^c
+^e ^i ^r ^y ^k
+^e ^i ^l ^r ^a ^c
+^e ^i ^l ^l ^o ^l
+^e ^i ^l ^l ^a ^h
+^e ^i ^g ^g ^e ^m
+^e ^g ^i ^a ^g
+^e ^e ^w ^e ^e ^w
+^e ^e ^p ^e ^e ^p
+^e ^e ^l ^e ^e ^l
+^e ^d ^a ^l ^s
+^e ^c ^n ^e ^p ^s
+^d ^s ^k
+^d ^s ^d
+^d ^n ^a ^u ^j
+^d ^i ^v ^a ^d ^n ^a ^u ^j
+^d ^e ^e ^l ^a ^w
+^d ^d ^i ^v ^a ^d
+^d ^d ^e ^r
+^d ^a ^m ^a ^h ^o ^m
+^c ^y ^m
+^c ^x ^z ^d ^s ^a
+^c ^o ^g ^n
+^c ^i ^t ^n ^e ^h ^t ^u ^a
+^b ^x ^e ^l ^a
+^b ^a ^n ^i ^a ^z
+^a ^z ^r ^i ^m
+^a ^z ^o ^n ^i ^p ^s ^e
+^a ^y ^r
+^a ^y ^l
+^a ^t ^s ^i ^t ^u ^a ^b
+^a ^t ^o ^t
+^a ^t ^i ^l ^r ^a ^k
+^a ^s ^s
+^a ^s ^i ^n ^a
+^a ^r ^u ^t ^n ^e ^v ^a
+^a ^r ^o ^m ^a ^z
+^a ^n ^n
+^a ^l ^y ^k ^s
+^a ^l ^o ^c ^o ^h ^c
+^a ^l ^l ^i ^t ^a
+^a ^l ^l ^i ^d ^a ^p
+^a ^k ^y ^l
+^a ^i ^n ^a ^m ^o ^r
+^a ^h ^s ^e
+^a ^h ^s ^a ^h ^s
+^a ^h ^o ^j
+^a ^c ^i ^c
+^_ ^r ^e ^c ^c ^o ^s
+^C $1 $2
+^A $2 $2
+^A $1 $4
+^3 ^2 ^1 i61 i72 o83
+] *28 +5
+[ o2O
+T0 i2o $2
+E T6 $D
+E $9
+D5 o5B
+D1 o2R
+D1 i2i
+D1 $)
+-7 sdg
+-7 o3#
+-6 o58
+-6 l K
+-6 -6
+-5 D6
+-4 o5e
+-4 i5e
+-2 -2 -2 -2
+-2 -2 -2
+-0 '4 z1
+-0 $2 $0 $0 $3
+-0 $2 $0 $0 $2
+-0 $1 $2 $3 $4 $5 $6
++8 o0y
++7 i1p
++6 +6
++5 i58
++3 o4i
++3 +3 +3 +3
++2 E
++0 $2 $0 $0 $2
++0 $1 $2 $3
+*A6 *79
+*A1 y5 '8
+*9B
+*91 r }
+*78 Z1
+*56 Y2 .4
+*54 ,4
+*53 '5 saj
+*45 Z1
+*39 D3 -5
+*35 Z1
+*35 D3
+*12 l k
+*01 { $6
+'B T7
+'B *23
+'B $l
+'A o7l
+'9 Y1 $p
+'8 o0E
+'7 ^T
+'6 o3P
+'5 o2k
+'5 -1
+'4 ^P
+$p Y1 i8v
+$j $r
+$j $o $h $n
+$i $t $e
+$i $n $g
+$d $1 $2 $3 $4
+$b $a $b $e
+$a t
+$a $1 $2 $3 $4 $5
+$_ $5 $5 $5
+$P $E
+$E D4 -3
+$9 Y1 C
+$9 $1 $3 $2
+$8 *78
+$5 $6
+$4 Y1
+$4 $9
+$4 $7
+$4 $3 $9 $9
+$3 $9
+$3 $4 $5 $9
+$3 $4 $5 $1
+$2 o6z E
+$2 $6 $9 $9
+$1 @y
+$1 $4 $3 $5
+$0 $0 $4 $5
+$0 $0 $0 $6
+} ] ] {
+t ^G
+ss- $u $p
+oBs
+o2Y
+o1a o2n
+o1[
+o0z $1 $2 $3 $4 $5
+o0y $1 $2 $3 $4
+o0Z $1 $2 $3 $4
+o0Y ,5
+o0W $1 $2 $3 $4
+o0J o5T
+o0I o3C
+l o3l
+l ^s ^i ^m
+l [ ^x
+l $q
+l $o $n $e
+i8i i9n oAg
+i8# o13
+i6n i71 i82
+i64 ]
+i61 i72 i83 i94 iA5 oB6
+i5]
+i4y '5
+i4a -5
+i4G
+i44 ss4 $4
+i42 i53 i64 o75
+i41 i59 i69 o77
+i41 i52 o63 i74 i85 i96 iA7 iB8 RC
+i3o
+i3c D5
+i3a i41 i52 o63
+i30 L7 R4
+i2u
+c slt
+c o1@
+c i8_
+c d '9
+c ^!
+c $9 $9 $8 $1
+c $9 $5 $0 $3
+c $9 $2 $1 $2
+c $9 $0 $2 $1
+c $8 $7 $9 $9
+c $7 $8 $9 $3
+c $7 $8 $6 $6
+c $7 $7 $0 $3
+c $6 $7 $1 $4
+c $6 $1 $2 $6
+c $5 $7 $7 $7
+c $5 $5 $9 $0
+c $4 $6 $5 $3
+c $4 $5 $5 $5
+c $4 $5 $0 $3
+c $4 $4 $9 $9
+c $4 $4 $5 $7
+c $4 $3 $3 $3
+c $4 $0 $9 $8
+c $3 $6 $2 $4
+c $3 $4 $5 $0
+c $2 $6 $6 $6
+c $2 $4 $5 $5
+c $2 $3 $3 $7
+c $2 $2 $4 $7
+c $2 $0 $0 $4 $!
+c $1 $1
+c $0 $2 $9
+^s ^r ^e ^p ^o ^o ^p
+^s ^a ^t ^i ^k ^u ^l
+^s ^a ^t ^i ^h ^c ^n ^a ^m
+^r ^r ^r ^r
+^r ^e ^p ^p ^i ^d
+^r ^e ^m ^m ^i ^h ^s
+^r ^e ^e ^m ^a
+^r ^a ^t ^a ^q
+^q ^w ^e ^r
+^q ^i ^f ^a
+^p ^i ^l ^c ^i ^n ^i ^m
+^o ^y ^o ^c ^o ^p
+^o ^t ^i ^r ^o ^d
+^o ^t ^i ^p ^o ^c
+^o ^t ^i ^n ^a ^s ^u ^g
+^o ^t ^i ^l ^u ^a ^r
+^o ^p ^a ^w ^g
+^o ^o ^o ^o
+^o ^i ^r ^a ^c ^u ^l
+^o ^h ^s ^o ^h ^s
+^o ^h ^n ^i ^z ^o ^a ^o ^j
+^o ^h ^c ^i ^w
+^o ^d ^r ^a ^g ^d ^e
+^n ^o ^s ^i ^e ^y
+^n ^o ^r ^y ^a ^b
+^n ^o ^l ^y ^a ^j
+^n ^i ^k ^m ^u ^p
+^n ^e ^d ^n ^e ^d
+^n ^e ^c ^y ^r ^b
+^n ^a ^y ^a ^h ^s
+^n ^a ^o ^h ^j
+^n ^a ^m ^y ^p ^p ^a ^h
+^n ^a ^m ^k ^c ^a ^j
+^n ^a ^m ^i ^n ^i ^m
+^n ^a ^m ^h ^a ^r
+^n ^a T2
+^m ^m ^m ^m ^m
+^m ^m ^a ^j
+^m ^l ^e ^g ^n ^a
+^m ^i ^z ^a
+^m ^e ^m ^e
+^l ^r ^i ^g ^s ^y ^d ^d ^a ^d
+^l ^o ^p ^l ^o ^p
+^l ^o ^o ^c ^r ^e ^p ^u ^s
+^l ^e ^t ^s ^i ^r ^k
+^l ^e ^i ^l ^e
+^l ^e ^d ^n ^a ^y
+^l ^a ^i ^n ^e ^g
+^k ^e ^v ^i ^n
+^k ^c ^e ^r ^e ^d
+^k ^c ^a ^p ^f ^l ^o ^w
+^j ^h ^g ^f ^d ^s ^a
+^i ^u ^g ^i ^u ^l
+^i ^s ^a ^s
+^i ^r ^i ^v
+^i ^o ^h ^i ^o ^h
+^i ^n ^a ^v ^o ^j
+^i ^m ^e ^r ^e ^j
+^i ^k ^u ^h ^c
+^i ^d ^a ^h ^s
+^h ^e ^l ^a ^s
+^g ^u ^b ^e ^n ^u ^j
+^g ^n ^o ^u ^h ^p
+^g ^n ^o ^p
+^g ^n ^i ^k
+^g ^n ^a ^h ^t
+^g ^m ^o ^l ^o ^l
+^f ^i ^t
+^e ^s ^o ^l ^o ^n
+^e ^s ^e ^r ^y ^t
+^e ^r ^a ^y
+^e ^n ^o ^z ^l ^l ^i ^k
+^e ^n ^o ^r
+^e ^n ^a ^l ^p ^r ^i ^a
+^e ^l ^d ^n ^i ^k
+^e ^k ^u ^l ^f
+^e ^k ^a ^h ^s ^k ^l ^i ^m
+^e ^i ^v ^a ^j
+^e ^i ^p ^e ^l ^p ^p ^a
+^e ^d ^a ^r ^g
+^e ^c ^y ^o ^r
+^e ^a ^r ^b
+^e ^a ^h ^s
+^e ^a ^h ^c
+^d ^r ^o ^w ^s ^a ^p
+^d ^r ^o ^l ^r ^a ^w
+^d ^e ^s ^w ^a ^q
+^d ^e T2
+^c ^c T2
+^a ^z ^z ^i
+^a ^z ^r ^a ^g
+^a ^v ^i ^l ^o
+^a ^u ^t ^a ^c ^a ^c
+^a ^u ^b
+^a ^t ^s ^i ^r ^t
+^a ^t ^o ^l ^e ^p
+^a ^t ^i ^l ^o ^b
+^a ^t ^i ^d ^n ^a ^p
+^a ^t ^e ^g ^o ^g
+^a ^s ^s ^e ^j
+^a ^p ^n ^a ^u ^j
+^a ^n ^y ^e ^l ^a
+^a ^n ^n ^e ^k ^c ^m
+^a ^m ^e ^m
+^a ^l ^y ^t
+^a ^l ^o ^y
+^a ^l ^i ^h ^c ^o ^m
+^a ^i ^p ^a ^t
+^a ^i ^b ^a ^f
+^a ^f ^a ^r ^i ^j
+^a ^e ^n ^i ^u ^g
+^a ^e ^h ^t ^l ^a
+^_ ^n ^a ^u ^j
+^_ ^l ^e ^u ^g ^i ^m
+^A $1 $3
+^< D2
+^5 ^2 T2
+^4 ^1 T2
+^3 T1
+^0 ^0 ^2 o32 r
+] $i $n $g
+[ i2u
+[ ^L l
+T0 i2o $5
+T0 T2 T3 T4 T5
+E o5P
+E T1
+D8 i4a
+D4 o4G
+D4 R4 Z2
+D4 D7
+D4 ,5
+D3 i4e
+D1 i0Z -5
+C ^a
+-8 ,9
+-5 o6o
+-4 o5o
+-2 o3o
++6 Y2 c
++5 +5 +5
++3 i4a
++1 sbq
++1 $2 $0 $0 $3
++0 i1e
+*A9 o9n
+*A5 c *25
+*89 o7p
+*87 c
+*78 '9
+*75 o0J
+*60 i2v
+*60 ^A
+*53 l
+*47
+*32 s4T c
+*16 snp
+*15 ^H
+*12 snp
+'B o6l
+'A o3k
+'A i7s
+'9 i2l
+'8 i2d
+'6 ^O
+'5 R4
+'4 o04
+'4 i3t
+'4 ^L
+'4 Z3
+'3 ^a
+$q i5w
+$m i6u
+$l $e $e
+$i $s
+$i $n $e
+$g $u $y
+$e *67
+$b $e $a $r
+$G $1 $2 $3
+$9 R5
+$8 $9 $9 $9
+$8 $0
+$7 i45
+$6 $7
+$5 $6 $7 $1
+$4 E *76
+$4 $1
+$3 t
+$3 @o
+$3 $3 $3 $1
+$3 $2
+$2 o8b
+$2 *78
+$2 $4 $4 $4
+$1 $7 $9 $9
+$1 $3 $9 $9
+$1 $2 $3 $4 $5 $6 $7
+$1 $2 $3 $4 $4
+$1 $2 $3 $4 $0
+$0 $0 $5 $5
+$- o5x
+} E {
+u ^x $x ^x $x
+r {
+o8]
+o6A c
+o5)
+o3x
+o2l E
+o2^ t
+o1a t
+o0z $1 $2 $3 $4
+o0v $2 $0 $0 $3
+o0v $2 $0 $0 $2
+o0e i1g
+o0Z $2 $0 $0 $5
+o0Y .4
+o0Y $1 $2 $3 $4
+o0/ T1
+l ssf
+l o2t
+l o1e
+l o1a
+l o0i
+l i5b o6o o7y
+l $z
+l $s $h
+l $m $p
+l $m $a $r
+k +7 ^J
+i8s i91 iA2
+i7[
+i6o i71 i82
+i6o i71 i81
+i6b o7o $i
+i5T o6H
+i53 $3
+i52 o60 ss0 $3
+i4_ i52 ,6
+i4! i5! ,6
+i3e *71
+i3K l
+i2n
+i1a -2
+i11 i32 i53 i74 $5
+i0C
+c o68
+c ^$
+c T2 T1 T3
+c $9 $9 $9 $1
+c $9 $9 $8 $5
+c $7 $8 $9 $5
+c $7 $8 $1 $2
+c $5 $6 $4 $4
+c $5 $5 $6 $1
+c $4 $5 $6 $1
+c $3 $9 $8 $7
+c $3 $7 $7 $1
+c $3 $4 $5 $1
+c $3 $2 $9 $8
+c $2 $8 $3 $1
+c $2 $6 $1 $5
+c $2 $5 $3 $5
+c $2 $4 $3 $3
+c $1 $7 $3 $8
+c $1 $6 $5 $4
+c $1 $3 $7 $5
+c $1 $2 $6 $0
+c $1 $2 $3
+^y ^t ^s ^a ^b
+^y ^o ^t ^o ^t
+^y ^a ^h ^y ^a ^h
+^s ^t ^u ^n ^z ^e ^e ^d
+^s ^s ^e ^n ^l ^o ^o ^c
+^s ^i ^l ^o ^h
+^s ^e ^i ^n ^o ^p
+^s ^d ^i ^k ^l ^o ^o ^c
+^r ^i ^h ^a ^y
+^r ^e ^y ^o ^r
+^r ^e ^d ^l ^i ^u ^b
+^q ^q ^q ^q ^q
+^q ^i ^z ^a ^h
+^o ^t ^t ^o ^t
+^o ^t ^i ^s ^e ^r ^d ^n ^a
+^o ^t ^i ^l ^o ^l
+^o ^t ^i ^j ^e ^l ^a
+^o ^o ^o ^b
+^o ^l ^e ^j
+^o ^k ^o ^k ^o ^k
+^o ^i ^u ^y ^t ^r ^e ^w ^q
+^o ^c ^n ^a ^l ^o ^p
+^n ^o ^s ^r ^e ^j
+^n ^o ^r ^y ^t
+^n ^o ^a
+^n ^j ^i ^f ^l ^o ^d
+^n ^i ^s ^a ^s ^a
+^n ^i ^l ^e ^s ^o ^y
+^n ^e ^v ^e ^k
+^n ^e ^u ^q
+^n ^e ^t ^n ^e ^b
+^n ^e ^d ^e ^a ^r ^b
+^n ^a ^m ^x ^a ^m
+^n ^a ^m ^o
+^n ^a ^h ^o ^l
+^n ^a ^f ^e ^w ^w
+^m ^o ^o ^p
+^m ^o ^m ^i ^h
+^m ^i ^t ^m ^i ^t
+^l i0i
+^l ^u ^z ^a ^z ^u ^r ^c
+^l ^r ^i ^g ^l ^o ^o ^c
+^l ^o ^k ^i ^a ^m
+^l ^i ^m ^a ^r
+^l ^e ^s ^s ^e ^w
+^l ^e ^i ^m ^a
+^l ^e ^i ^d ^a
+^l ^e ^g ^n ^a ^s ^i ^u ^l
+^l ^a ^e ^m ^t ^a ^o
+^k ^s ^k ^s
+^k ^j ^h ^g ^f ^d ^s ^a
+^i ^r ^k ^i ^f
+^i ^m ^i ^n ^i ^m
+^i ^m ^h ^a ^f
+^i ^l ^a ^i ^l ^a
+^i ^h ^i ^h ^i ^h
+^h ^h ^h ^h
+^h ^g ^i ^e ^l ^a ^h
+^h ^g ^a ^r ^r ^a ^d
+^g ^o ^d ^t
+^g ^n ^i ^m ^g ^n ^i ^m
+^f ^i ^l ^a ^h ^k
+^e ^y ^b ^i ^h
+^e ^w ^q ^d ^s ^a
+^e ^t ^a ^u ^h ^a ^c ^a ^c
+^e ^r ^b ^m ^e ^i ^v ^o ^n
+^e ^r ^b ^m ^e ^i ^t ^p ^e ^s
+^e ^n ^n ^a ^i ^l
+^e ^n ^a ^n
+^e ^m ^o ^s ^e ^w ^a ^m ^i
+^e ^m ^e ^m ^e ^m
+^e ^l ^e ^h ^c
+^e ^e ^r ^f
+^e ^e
+^e ^b
+^d ^e ^o ^j
+^c ^n ^a ^d
+^b ^n ^i ^t ^s ^u ^j
+^a ^t ^n ^a ^m ^a ^s
+^a ^t ^e ^l ^u ^h ^c
+^a ^s ^s ^i ^l ^u ^j
+^a ^s ^a ^s ^a ^s
+^a ^r ^o ^d ^a ^t ^u ^p ^m ^o ^c
+^a ^r ^e ^r ^r ^a ^b
+^a ^r ^e ^r ^b ^a ^c
+^a ^r ^e ^j
+^a ^o ^h ^c ^o
+^a ^n ^y ^a ^l ^a
+^a ^n ^i ^r ^a ^s
+^a ^l ^o ^h ^a ^l ^o ^h
+^a ^l ^l ^u ^d ^b ^a
+^a ^l ^i ^d
+^a ^k ^a ^k ^a ^k
+^a ^j ^r ^o ^j
+^a ^i ^b ^a ^r
+^a ^h ^m
+^a ^h ^e ^m ^a ^h ^e ^m ^a ^k
+^a ^f ^e ^t ^s
+^a ^c ^u ^h ^c ^a ^p
+^a ^c ^o ^p
+^a ^c ^k
+^a ^a ^a ^a ^a ^a
+^_ ^y ^t ^t ^i ^k
+^_ ^o ^t ^u ^r ^a ^n
+^[
+^J $5
+^G $1 $2 $3
+^F .2
+^E .4
+^C s2s
+^9 T1
+^8 ^9 ^9 ^1
+^8 T1
+^6 ^1 T2
+^6 ^0 ^0 ^2
+^5 ^4 ^3 ^2 ^1 T5
+^4 ^2 T2
+^4 ^0 ^0 ^2
+^3 ^1 T2
+^1 ^0 ^0 ^2
+^0 ^2 T2
+] ] ] ] ]
+T6 Z1 o0l
+T0 T3 T4 T5
+L0 ^s
+D4 ^X
+D1 o2Z ]
+D1 i2s
+D0 smd
+D0 @8 Z2
+C $2 $1
+@F shr
+-8 Y2
+-7 s2e Y2
+-7 o84
+-7 c srM
+-6 o56
+-6 *67
+-5 i6a
+-5 @a
+-4 .5
+-4 ,5
+-3 o4o
+-3 ]
+-3 *45
+-2 $2 $0 $0 $3
+-1 ssi k
+-1 i1u
+-0 {
+-0 r
+,6 c
++6 ^J
++4 Z2
++3 @v o33
++2 L6 u
++2 +2 +2 +2
++2 $2 $0 $0 $4
++0 @t
++0 +0
++0 $2 $0 $0 $3
++0 $1 $2 $3 $4 $5
+*97 syi
+*6A c sjc
+*62
+*57 *46
+*57
+*48 ^9
+*37
+*12 '5 D0
+*01 *53 R6
+'B soa
+'9 o4h
+'9 i6o
+'9 ^d
+'9 T2
+'6 shb
+'6 D2
+'5 o3k
+'5 *13
+'4 o1m
+'3 +2
+$t
+$h $o $m $e
+$e $r
+$e $n
+$d i7a
+$c Z1
+$b $r $r
+$b $a $y
+$a i6p
+$B $1 $2 $3
+$8 @y
+$6 $1 $2 $3
+$5 $8 p2
+$5 $6 $7 $7
+$5 $2
+$4 $5 $5 $5
+$4 $2
+$3 $8
+$3 $7
+$3 $4 $4 $4
+$3 $0
+$2 $0 $0 $4 $!
+$1 $9
+$1 $7 $3 $8
+$1 $2 $3 $5 $4
+$0 $8
+u $X ^X ^x $x
+s19 Z1
+p4 sao
+o4O o5P
+o0L
+o0C
+l o6k
+l o5j
+l o3.
+l o0e
+l ^t ^a ^c
+l ^o ^r ^p
+l ^o ^n ^o ^m
+l ^n ^o ^c
+l [ ^y
+l [ ^j
+l [ ^g
+l $y $a
+l $w $e $b
+l $p $a
+l $o $n
+l $o
+l $m $m
+l $m $c
+k o1a
+i6u s@* Y2
+i6X
+i63
+i61 i72 i83 o94
+i61 i72 i83 i94 oA5
+i5T t
+i51 $3
+i51 $0
+i4T o5H
+i41 i52 i63 i74 i85 i96 oA7
+i3o i41 i52 o63
+i3a -4
+i2i [ +0
+i2i
+i2R
+i1i D3
+i1i
+i1g
+i0f i1l
+c slz
+c i7-
+c ^7
+c $9 $3 $4 $5
+c $8 $7 $7 $7
+c $8 $2 $8 $8
+c $6 $7 $5 $8
+c $6 $5 $5 $5
+c $6 $0 $8 $7
+c $5 $6 $8 $7
+c $5 $2 $2 $1
+c $4 $6 $8 $9
+c $3 $5 $2 $3
+c $3 $4 $0 $2
+c $2 $7 $6 $6
+c $2 $0 $6 $7
+^z ^t ^u ^n ^z ^e ^e ^d
+^y ^l ^l ^e ^k ^s
+^x ^x ^x ^x ^x ^x
+^x ^i ^n ^a ^d
+^w ^w ^w ^w ^w ^w
+^s ^o ^t ^i ^r ^r ^e ^p
+^s ^o ^d ^e ^p
+^s ^g ^o ^d ^e ^v ^o ^l ^i
+^s ^a ^c ^a ^c
+^r ^i ^h ^a ^j
+^r ^e ^v ^o ^l ^g ^o ^d
+^o ^t ^i ^g ^e ^v
+^o ^o ^b ^a ^l ^l ^e ^b
+^o ^l ^o ^p ^o ^p
+^o ^l ^l ^i ^u ^q ^o ^l
+^o ^l ^l ^i ^l ^o ^b
+^o ^l ^i ^f ^n ^a ^p
+^o ^h ^c ^n ^e ^h ^c
+^o ^g ^e ^r ^r ^o ^b
+^n ^o ^s ^r ^a ^k
+^n ^o ^c ^n ^i ^l
+^n ^i ^d ^a ^k
+^n ^a ^y ^k
+^n ^a ^o ^r
+^n ^a ^m ^r ^m
+^m ^o ^m ^e ^v ^o ^l
+^m ^o ^a
+^m ^l ^p
+^m ^a ^i ^l ^i ^w
+^l ^r ^i ^g ^y ^x ^e ^s
+^l ^o ^o ^o ^c
+^l ^o ^o ^l
+^l ^o ^o ^c ^r ^m
+^l ^o ^j ^i ^r ^f
+^l ^e ^r ^r ^a ^f
+^l ^e ^i ^d ^b ^a
+^l ^e ^i ^d ^a ^j
+^l ^e ^a ^z ^a
+^l ^a ^m ^k ^a
+^k ^n ^i ^v ^e ^k
+^k ^m ^k ^m
+^j ^s ^k
+^i ^n ^u ^y
+^i ^l ^a ^y
+^i ^k ^o ^p
+^h ^c ^i ^t ^s
+^g ^o ^d ^b
+^g ^n ^o ^h ^p
+^g ^n ^i ^w ^t ^h ^g ^i ^n
+^g ^n ^e ^k
+^g ^n ^a ^b ^a
+^g ^g ^g ^g ^g
+^g ^g ^g ^g
+^f ^o ^o ^p
+^e ^s ^e ^s
+^e ^o ^t ^a ^t ^o ^p
+^e ^n ^y ^a ^z
+^e ^m ^i ^r ^a ^k
+^e ^i ^k ^c ^u ^d
+^e ^i ^h ^s ^o ^j
+^e ^e ^m ^s ^e
+^e ^e ^h ^e ^e ^t
+^e ^d ^a ^l ^b ^y ^e ^b
+^e ^c ^a ^f ^t ^t ^u ^b
+^d ^r ^o ^w ^s ^s ^a ^p
+^d ^r ^e ^p ^u ^s
+^d ^r ^a ^c ^i ^r
+^d ^o ^o ^m ^h ^a ^m
+^d ^o ^o ^g
+^d ^i ^k ^l ^o ^o ^k
+^d ^a ^e ^h ^t ^t ^u ^b
+^d ^a ^d ^i ^v ^a ^n
+^b ^k ^k
+^a ^z ^i ^r
+^a ^t ^l ^a ^r ^e ^p
+^a ^s ^k ^e ^l ^a
+^a ^p ^p ^e ^p
+^a ^n ^n ^e ^k ^a ^m
+^a ^n ^n ^a ^b
+^a ^l ^l ^i ^n ^o ^b
+^a ^k ^n ^a ^u ^j
+^a ^i ^r ^a ^k ^a ^z
+^a ^i ^l ^h ^a ^t
+^a ^g ^i ^n
+^a ^e ^p ^t ^e ^e ^w ^s
+^a ^d ^n ^a ^u ^j
+^a ^c T2
+^a ^a ^z
+^M i2R
+^J $8
+^J $1 $2 $3
+^E ,5
+^A $0 $7
+^8 ^1 T2
+^8 ^0 T2
+^7 ^2 T2
+^5 ^0 ^0 ^2
+^3 ^2 ^1 i71 i82 o93
+^2 ^3 ^4 ^5 ^6 ^7 o61 r
+^2 ^2 T2
+] ^(
+[ E
+Y2
+T0 i2o $4
+L7 o2z
+E syv
+D4 k L7
+D3 *09 ]
+D2 i3o
+D2 c
+D1 o3X
+D1 o2Z
+D1 i2P
+@6 o57
+.3 ]
+-8 o4b
+-2 $2 $0 $0 $4
+*A8
+*89 -7
+*78 o1r
+*76 i44
+*74 i5r
+*60 ^S
+*39 o58
+*31 i1e
+*30
+*25 '5
+*24 src
+*12 '5
+'B o8f
+'B @y
+'9 o4j
+'9 i1t
+'6 sfs
+'5 o2z
+$i $k $e
+$i $2 $0 $0 $3
+$h $i $g $h
+$h $a $l $l
+$f $r
+$c $a $r
+$a L6
+$a DA
+$_ $2 $0 $0 $3
+$Y $T
+$X $d
+$C $1 $2 $3
+$6 $7 $9 $8
+$6 $4
+$6 $0
+$5 iA0
+$5 $0
+$4 $8
+$4 $6
+$2 @u
+$2 $9
+$2 $5 $4 $9
+$2 $5 $4 $4
+$2 $0
+$1 $8
+$1 $2 $3 $4 $6
+$0 R7
+} .0
+u $X ^X ^X $X
+o86 ^T
+o6w
+o5b
+o4g ]
+o3g
+o1o
+o1D u
+l o6g
+l o5n
+l o4v
+l o1o
+l ^y ^a ^l ^p
+l ^o ^e ^n
+l [ ^u
+l [ ^T
+l [ ^B
+l $x
+l $t $i
+l $r $o $c $k
+l $p $i
+l $o $v $a
+l $o $r
+l $n $o $w
+l $m $e $n
+l $m $b
+l $m $1
+l $l $o
+l $l $l
+k c
+i8c i9o
+i81 i92 iA3 oB4
+i6i i7t
+i56
+i52 o60 ss0 $5
+i52 o60 ss0 $4
+i4u
+i4n i52 i60
+i4[
+i42 i50 i60
+i41 i52 i63 i74 i85 o96
+i3i D5
+i3i
+i3T o4H
+i0T ^Y
+c spd
+c si1
+c o11
+c o0k
+c i6e
+c ^x
+c ^5 ^1 ^0 ^2
+c T2
+c +0
+c $X ^X
+c $9 $8 $7 $9
+c $8 $9 $0 $5
+c $6 $7 $5 $7
+c $4 $7 $0 $4
+c $3 $3 $2 $8
+c $1 $2 $3 $8
+c $1
+^y ^o ^b ^r ^e ^l ^l ^i ^k
+^x ^x ^x ^x ^x
+^t ^o ^p ^t ^o ^p
+^s ^e ^t ^o ^g ^i ^b
+^s ^e ^i ^g ^g ^o ^d
+^s ^a ^t ^i ^b ^e ^s
+^o ^z ^a ^l ^o ^l
+^o ^t ^i ^r ^u ^t ^r ^a
+^o ^t ^i ^n ^o ^t
+^o ^t ^i ^l ^u ^a ^s
+^o ^t ^i ^l ^e ^o ^j
+^o ^t ^e ^r ^o ^t
+^o ^r ^r ^a ^p ^a ^h ^c
+^o ^o ^o ^o ^o ^o
+^o ^m ^e ^r ^p ^u ^s
+^o ^l ^o ^l ^o ^l
+^o ^k ^a ^i ^g ^o ^p
+^o ^c ^s ^a ^l ^e ^v
+^n ^o ^h ^c ^i ^p
+^n ^o ^d ^y ^a ^j
+^n ^i ^t ^i ^t
+^n ^e ^d ^e ^a ^j
+^n ^a ^y ^r ^d ^a
+^n ^a ^y ^h ^r
+^n ^a ^v ^u ^d
+^n ^a ^m ^q ^u ^l
+^n ^a ^m ^a ^z ^z ^i ^p
+^n ^a ^j ^n ^a ^j
+^n ^a ^i ^l ^i ^w
+^n ^a ^h ^j
+^n ^a ^h ^i ^a ^r
+^m ^o ^m ^y ^m ^e ^v ^o ^l ^i
+^m ^o ^m ^e ^v ^o ^l ^i
+^m ^m ^m ^m ^m ^m
+^l ^r ^i ^g ^y ^l ^r ^i ^g
+^l ^o ^c ^y ^a ^m
+^l ^e ^u ^m ^e ^l
+^k ^c ^r ^a ^m
+^i ^p ^n ^a ^u ^j
+^g ^x ^e ^l ^a
+^g ^s ^i ^u ^l
+^g ^o ^d ^e ^t ^a ^n
+^g ^n ^o ^n
+^g ^n ^i ^p ^o ^o ^p
+^g ^i ^p ^g ^i ^p
+^f ^i ^n ^a ^h
+^e ^p ^o ^n
+^e ^m ^o ^s ^e ^w ^a ^m ^a ^i
+^e ^m ^l ^e ^u ^q ^i ^r
+^e ^m ^i ^t ^n ^u ^f
+^e ^l ^o ^l
+^e ^i ^l ^y ^a ^k
+^e ^i ^k ^o ^o ^k
+^e ^i ^b ^a
+^e ^d ^i ^o ^r ^d ^n ^a
+^e ^c ^a ^f ^p ^o ^o ^p
+^e ^a ^m ^e ^a ^m
+^d ^n ^o ^m ^i ^d
+^d ^n ^a ^l ^o ^g ^e ^l
+^d ^a ^p ^y ^l ^i ^l
+^d ^a ^e ^d
+^d ^a T2
+^c ^x ^e ^l ^a
+^b ^b ^b ^b
+^a ^y ^s
+^a ^v ^o ^j
+^a ^u ^a ^e ^t ^s
+^a ^t ^t ^e ^l ^o ^i ^v
+^a ^s ^d ^d ^s ^a
+^a ^n ^y
+^a ^n ^o ^h ^j
+^a ^n ^i ^v ^e ^k
+^a ^n ^a ^n ^n ^a ^b
+^a ^m ^a ^m ^i ^m
+^a ^l ^o ^h ^c
+^a ^l ^a ^v ^a ^z
+^a ^k ^i ^p ^a ^k ^i ^p
+^a ^i ^l ^i ^m ^a ^f ^i ^m
+^a ^e ^s ^o ^j
+^a ^e ^s ^e ^u ^q ^o ^l
+^C $1 $2 $3
+^9 ^9 T2
+^5 ^1 T2
+^4 ^0 T2
+^3 ^2 ^1 T3
+^3 ^0 ^0 ^2
+^0 ^0 T2
+[ D4 Z3
+L4
+E Y5
+D6 i0O
+D3 y3
+D1 E
+@6 i7_
+@0 c
+.0 ^Z
+-3 -3
+-2 {
+-2 t o9<
+-2 i3o
+-2 $1 $2 $3 $4 $5
+-0 +7
+,A
++8 i6#
++6 ]
++2 '4
++1 +1 +1
++0 z1
++0 $1 $2 $3 $4
+*91 o1a
+*8A D8
+*78 i6k
+*78 ^n
+*73 ^s
+*67 c
+*65 i4h
+*57 i3s
+*35 ^#
+*21 +4
+*1B s1G -8
+*12 sma
+*04 +0 '4
+*03 l +0
+'B T1
+'7 sdr
+'7 f
+'6 sjv
+'6 D1 o0K
+'5 o1g
+'4 $0
+$u Z2
+$j $a $y
+$e $s $t
+$c i6h
+$b $o $b
+$b $e
+$a $r $t
+$a $r $a $h
+$a $b
+$a $2 $0 $0 $2
+$K c oAC
+$B $F $F
+$9 t
+$9 o5i t
+$9 $8
+$8 $9
+$7 $0
+$5 $6 $7 $0
+$4 $3
+$3 $5
+$2 $5 $5 $1
+$1 @b
+$1 +B
+$1 $2 $3 $4 $5 $6 $7 $8 $9 $0
+$1 $2 $3 $4 $5 $6 $7 $8
+$1 $2 $3 $4 $3
+$0 $6
+t $Z
+o5k
+o4s
+o42 i50 ss0 $4
+o3Y o4T
+o0z t
+o0m t
+o0Z
+o0I o3G
+o0E o4G
+l o5u o4a
+l o5f
+l o3e
+l ^u ^e
+l ^t ^a ^f
+l ^p ^m ^a ^c
+l ^o ^c
+l ^n ^o ^o ^m
+l ^n ^e
+l ^m ^e
+l ] $y
+l ] $X
+l [ ^q
+l [ ^n
+l [ ^L
+l [ ^D
+l $y $o
+l $u
+l $t $o
+l $r $t
+l $p $r
+l $o $m
+l $o $l
+l $m $y
+k r
+i81 o0K
+i7S c
+i71 i82 i93 oA4
+i5i E
+i5e i61 i72 o83
+i5G
+i57 $9
+i4o i51 i62 o73
+i41 i52 i63 i74 o85
+i3e i41 i52 o63
+i3Y o8! c
+i35 i44 i53 i62 o71
+i1a u
+i0t i1a
+d o5b
+c r
+c o44
+c i42
+c ^x $x ^x $x
+c ^t ^s ^e ^t
+c ^A
+c T6 T8 T2 T4
+c T1 T2
+c $x ^x ^X $X
+c $K
+c $5 $8 $3 $4
+c $3 $8 $9 $0
+^z
+^y ^o ^b ^e ^t ^u ^c
+^y ^n ^o ^p ^e ^l ^t ^t ^i ^l ^y ^m
+^y ^b ^a ^b ^e ^t ^u ^c
+^s ^y ^p ^p ^u ^p
+^s ^o ^r ^r ^a ^c
+^s ^a ^s ^a ^s ^a
+^r ^e ^v ^o ^l ^t ^a ^c
+^p ^p ^p ^p
+^p ^o ^p ^o
+^o ^t ^i ^v ^a ^t
+^o ^t ^i ^s ^e ^s ^o ^j
+^o ^t ^i ^l ^e ^u ^m ^a ^s
+^o ^t ^i ^d ^l ^a
+^o ^o ^z ^o ^o ^z
+^o ^d ^l ^a ^v ^i ^r
+^n ^o ^p ^n ^o ^p
+^n ^i ^r ^a ^c ^s ^o
+^n ^i ^h ^c ^u ^l ^e ^p
+^n ^a ^z ^u ^a ^f
+^n ^a ^m ^o ^n
+^n ^a ^m ^a ^n ^a ^n ^a ^b
+^m ^u ^h ^a ^n
+^m ^i ^y
+^m ^a ^m ^a ^m
+^m ^a ^c ^m ^a ^c
+^l ^e ^u ^n ^a ^m ^n ^e
+^l ^a ^k ^i ^a ^h
+^k ^o ^k ^o ^k ^o
+^k ^k ^k ^k ^k ^k
+^k ^k ^k ^k ^k
+^k ^k ^j ^j
+^k ^c ^i ^r ^d ^n ^e ^k
+^i ^z ^a ^j
+^i ^d ^n ^a ^u ^j
+^h ^s ^i ^f
+^h ^s T2
+^h ^c T2
+^g ^o ^d ^g ^o ^d
+^g ^n ^o ^h ^t
+^g ^n ^e ^t ^n ^a ^g
+^g ^g ^g ^g ^g ^g
+^e ^l ^g ^g ^i ^m ^s
+^e ^i ^p ^p ^u ^p
+^e ^i ^h ^c ^a ^l
+^e ^d
+^e ^J
+^d l }
+^d ^i ^k ^e ^t ^a ^r ^a ^k
+^d ^d ^d ^d
+^c ^m ^c ^m
+^c ^i ^r ^t ^a ^p
+^c ^e ^l ^e ^m ^e
+^b ^o ^b ^i ^h
+^b ^b
+^a ^n ^s ^o ^b
+^a ^j ^n ^o ^p ^s ^e
+^a ^i ^t ^n ^a ^s
+^a ^h ^l ^e ^o ^c
+^a ^g ^e ^m
+^a ^g ^a ^g ^a ^g
+^a ^e ^n ^h ^i ^m
+^a ^c ^u ^l ^o ^t
+^_ ^s ^s ^e ^c ^n ^i ^r ^p
+^D @m
+^C T1
+^A i3A
+^6 T1
+^3 ^4 ^1 T3
+^3 ^2 T2
+^1 ^2 ^3
+^1 ^1 T2
+K E
+E o6r
+E ^/
+D3 c
+C
+@j c
+@d T3
+@7 o3w
+@5 o3r
+@5 ^G +0
+@2 o2e
+-9 D4 Z1
+-8 ^J
+-7 Y2
+-5 sro t
+-4 t
+-2 i3i
+-2 i3a
+-2 *12 s0;
+-1 -1 -1 -1
+-0 -0 -0
++A o2n
++8 sjs
++8 o0G
++8 $Q
++4 +4
++4 *54
++1 R1
++1 +1
++0 +0 +0 +0
+*BA c
+*83 i54
+*76
+*72 o3w
+*67 o75
+*59 D0 o5t
+*54 o4i
+*46 ^P
+*30 t
+*20 -3
+*18 o5g
+*15
+*05 i1y
+*04 ^#
+'B Z1 [
+'B +5
+'A $p t
+'9 i3n
+'6 ^L
+'5 D3
+'4 ^S
+'4 Z1
+'4 @q ^J
+'4 $o
+'3 z1
+$l $i $k $e
+$l $e
+$l $a $w
+$j $o $y
+$j $c
+$j $P c
+$i Z1
+$i $d
+$g $o
+$g $a $y
+$e $l $l $a
+$c *67
+$b $o $o
+$b $e $e
+$a $s
+$a $2 $0 $0 $3
+$C
+$9 Z1 se9
+$7 *87
+$7 $8
+$6 p4 '5 D1
+$5 $4
+$5 $0 $0 $9
+$4 $5 $7 $6
+$2 R6
+$2 $0 $1 $4
+$2 $0 $0 $2
+$1 .9
+$1 $6
+$1 $2 $3 $4 $5
+$1 $2 $3 $4
+$- '3 Z1
+oAa
+o8g
+o50 Z2
+o4Y o5T
+o4D *40
+o2P o3E
+o0e ^f ^E
+o0Z $1 $2 $3 $4 $5
+o0X u
+l o2a
+l ^y ^k ^s
+l ^x ^e
+l ^t ^e ^j
+l ^s
+l ^r ^o ^f
+l ^r ^e ^p
+l ^n ^u ^s
+l ^n ^i
+l [ ^P
+l [ ^E
+l [ ^A
+l $u $p
+l $u $m
+l $t $y
+l $s $k $i
+l $s $k
+l $r $a $y
+l $p $p
+l $p $i $e
+l $o $w
+l $o $i $d
+l $n $e $s $s
+l $m $i
+l $l $o $v $e $r
+l $@ $y $a $h $o $o $. $c $o $m
+l $@ $m $a $i $l $. $r $u
+i8p i9e
+i8_ i6_ E
+i82
+i7c
+i6_ c 'B
+i5s
+i5i i6t
+i52 i60 i70
+i51 i62 i73 i84 o95
+i4{
+i4p
+i4_ i51 i62 o73
+i3r i41 i52 o63
+i3n i41 i52 o63
+i3i c
+i3]
+i2r t
+i2r
+i2p c
+i2C l [
+i0\
+d o5w
+c }
+c i1o
+c ^e ^h ^t
+c T9
+c T7
+c T4
+c $X ^X $x ^x
+c $L
+c $@ $g $m $a $i $l $. $c $o $m
+c $3 $4 $4 $1
+^s ^t ^i ^b ^b ^a ^r
+^s ^s ^s ^s ^s ^s
+^s ^a ^t ^i ^p ^a ^p
+^r ^e ^t ^s ^o ^b
+^p ^a ^r ^p ^a ^r
+^o ^t ^i ^y ^u ^h ^c
+^o ^t ^i ^t ^u ^p
+^o ^t ^i ^s ^u ^s ^e ^j
+^o ^s ^a ^l ^o ^l
+^o ^r ^e ^t ^n ^i ^u ^q
+^o ^p ^o ^p ^o ^p
+^o ^p ^o ^l ^o ^l
+^o ^l ^l ^e ^h ^i ^h
+^n ^i ^h ^c ^u ^h ^c
+^n ^e ^v ^i ^t ^s
+^n ^e ^h ^r
+^n ^a ^j ^e ^l ^a
+^n ^a ^h ^y ^a ^r
+^n ^a ^a ^m ^r ^a
+^n
+^m ^o ^m ^m ^o ^m
+^l ^l ^l ^l
+^l ^e ^y ^n ^a ^d
+^l ^e ^i ^s ^o
+^l ^e ^i ^s ^a ^j
+^l ^e ^g ^n ^a ^m
+^l ^e ^g ^i ^m
+^l ^a ^l ^a ^t
+^l ^a ^f ^u ^a ^n
+^k ^o ^o ^n
+^i ^y ^o ^y
+^i ^p ^a ^p ^u ^t
+^i ^n ^i ^m
+^h ^t ^i ^r ^a ^h
+^h ^h ^h ^h ^h
+^g ^n ^o ^l
+^f ^f ^i ^l ^a
+^e ^y ^e
+^e ^y ^a ^n
+^e ^r ^i ^f
+^e ^k ^s ^a ^s
+^e ^i ^p ^e ^i ^p
+^e ^i ^k ^o ^o ^r ^b
+^e ^i ^d ^a ^m
+^e ^c ^i
+^e ^c ^a ^f ^y ^p ^p ^a ^h
+^e ^c ^a ^f
+^d ^r ^a ^z ^i ^r ^a ^h ^c
+^d ^d ^d ^d ^d ^d
+^d ^a ^e ^h ^p ^o ^o ^p
+^d ^a ^d ^d ^n ^a ^m ^o ^m
+^d ^a ^b
+^c ^n ^i ^v ^e ^k
+^c ^i ^s ^s ^a ^r ^u ^j
+^b ^u ^l ^c ^x ^n ^i ^w
+^b ^o ^b T3
+^a ^t ^i ^t ^u ^p
+^a ^t ^i ^p ^a ^p
+^a ^n ^r ^e ^f
+^a ^n ^i ^s ^a ^m
+^a ^n ^a
+^a ^m ^i ^k
+^a ^m ^a ^m ^u ^t
+^a ^l ^o ^p ^o ^p
+^a ^d ^e ^n ^i ^p
+^a ^a ^l ^o ^h
+^_ ^e ^t ^u ^c
+^_ ^e ^i ^t ^u ^c
+^6 ^2 T2
+^5 ^0 ^0 ^2 T4
+^4 ^3 ^2 ^1 T4
+^3 ^0 T2
+^2 ^0 ^0 ^2
+^1 ^2 T2
+^1 ^0 T2
+] $e $d
+] $A
+TE
+L7 t T1
+L6 Z5
+K o48
+E d
+E ^T
+E ^S
+E $o
+D3 u $4
+D3 o0h s!n
+@f ^#
+@4 D5
+@. D6
+-9 Z1 -6
+-7 ^/
+-6 i7o
+-6 ]
+-3 D4 Z2
+-2 o3i
+-1 c
+-0 c
+-0 -0
++B o10
++9 c
++7 sB= K
++6 ^-
++6 $e
++4 +4 +4
++3 c
++2 [
++2 +2 +2
++1 +1 +1 +1
+*94 o0t
+*90 s"? o0V
+*8A E
+*72 i3r
+*42 Y1
+*34 sd> c
+*34 $8
+*14 Z2
+*14 Z1
+*13 c
+*10 l z2
+*03 iA5 D2
+'B o00
+'B k
+'8 @z @g
+'6 D1
+'5 Z2 @d
+'4 +0
+'3 ^p
+'3 Z2
+'3 $g
+'3 $S
+${
+$w
+$l $e $a
+$l $a $b
+$k i8o
+$i $c
+$h $i
+$e Z1
+$e $a
+$d $a $v $i $d
+$c $v
+$a $v
+$a $t
+$a $n $a
+$a $i $r
+$a $c
+$N c
+$9 Z1
+$8 t
+$7 E
+$7 *98
+$6 r
+$5 Z1
+$4 *89
+$3 *97
+$2 $0 $0 $4
+$1 oB8
+$1 *89
+$1 $5
+$0 $7
+$0 $5
+$0 $4 $0 $5
+$0 $2
+$0 $1
+{ 'B ^z
+so0 se3 u
+r *02 K
+o6s c
+o5a
+o3q
+o3j
+o1i D2
+o1e [
+o0Y $2 $0 $0 $6
+o0J $1 $2 $3 $4 $5 $6
+o0<
+l o4D
+l ^y ^a ^d
+l ^x ^a
+l ^w ^o ^n ^s
+l ^w ^o ^c
+l ^t ^h ^g ^i ^n
+l ^t ^a ^b
+l ^s ^s ^a ^p
+l ^r ^e ^t ^a ^w
+l ^r ^a ^w
+l ^r ^a ^p
+l ^r ^a ^e ^b
+l ^o ^o ^z
+l ^n ^u ^g
+l ^n ^o ^n
+l ^n ^a ^m
+l ] $M
+l [ ^o
+l [ ^Z
+l [ ^U
+l [ ^R
+l [ ^N
+l [ ^K
+l [ ^G
+l Z1 $y
+l $w $a $y
+l $v $i
+l $p $o $p
+l $p $a $s $s
+l $p $a $r $k
+l $n
+l $m $o $o
+l $m $a $e
+l $m $a
+l $l $y
+l $. $n $e $t
+i8T o9H
+i7T o8H
+i7- o8b i9a $e $d
+i6x
+i5h
+i51 i62 i73 i84 i95 oA6
+i3k
+i2P o3E
+i1h
+i1e
+i1R c
+i0D
+c o5u
+c o5W
+c o58
+c ^X
+c ]
+c T6 T2 T4
+c $c
+c $@
+^t ^a ^m ^t ^a ^m
+^r }
+^r ^e ^v ^o ^l ^y ^p ^p ^u ^p
+^p ^o ^p ^y ^l ^o ^l
+^p ^o ^p ^o ^p
+^p ^o ^o ^o ^p
+^o ^t ^i ^l ^e ^x ^a
+^o ^t ^i ^g ^e ^i ^d
+^o ^t ^i ^e ^t ^a ^m
+^o ^r ^b ^o ^r ^b
+^o ^o ^o ^o ^o
+^n ^i ^t ^s ^o ^j
+^n ^e ^v ^i ^t ^s ^e
+^n ^e ^r ^n ^e ^r
+^n ^e ^e ^s ^a ^y
+^n ^a ^w ^a ^t
+^n ^a ^i ^r ^d ^e
+^l ^r ^i ^g ^t ^o ^h
+^l ^r ^i ^g ^r ^e ^c ^c ^o ^s
+^l ^r ^i ^g ^e ^t ^u ^c
+^l ^o ^o ^c ^o ^s
+^l ^o ^l ^p ^o ^p
+^l ^o ^l ^o ^l ^o ^l
+^l ^o ^b ^s ^i ^e ^b
+^l ^l ^l ^l ^l ^l
+^l ^i ^h ^d ^a ^f
+^l ^e ^o ^h ^j
+^l ^e ^i ^z ^a ^j
+^j
+^i ^m ^i ^k ^a ^h
+^i ^l ^e ^r ^a ^y
+^h ^s ^a
+^g ^o ^d ^y ^p ^p ^u ^p
+^g ^n ^a ^h ^k
+^e ^r
+^e ^l ^e ^t
+^e ^i ^g ^g ^i ^p
+^e ^e ^e ^e
+^d ^l ^o ^g
+^d ^e ^h ^s ^a ^r
+^c ^l ^e ^i ^n ^a ^d
+^b ^a T2
+^a ^y ^n ^a ^d
+^a ^t ^t ^e ^g ^o ^g
+^a ^t ^e ^n ^i ^t ^a ^p
+^a ^r ^t ^l ^u
+^a ^n ^n ^a ^i ^k
+^a ^c ^a ^c ^a ^c
+^^ ^^ s^i ^h ^t
+^S
+^I u
+^E $1 $2 $3
+^A D4
+^5 ^1 ^0 ^2
+^0 ^0 ^0 ^2
+^0 T9
+] $k
+[ i2p
+[ *03
+K o3c
+E i0J
+E ^P
+E T8
+E .2
+E +5
+D5 *57
+D2 o3y
+C o0G
+-B s;m o0A
+-5 ]
+-5 *24
+-4 -4
+-3 c
+-2 -2
+-1 -1
+-1
++A
++7 $V
++5 +5
++4
++3 o4o
++3 +3 +3
++3 +3
++2 $7 T7
++0 r
++0 ]
++0 E
++0 +0 +0
+*B4 E ,7
+*A8 o67
+*87 o0p
+*86
+*74 +5
+*67 *10 ^T
+*61 o0#
+*56 +5
+*54 c
+*42 T0
+*31 oB" *54
+*27 i4w
+*25 T0
+*21 o3p
+*13 s./ Y2
+'8 ^R
+'7 sfn
+'5 t
+'5
+'3 Z3
+$l D4
+$l $i $f $e
+$j
+$h $e
+$f Z1
+$f $a
+$e $m
+$d $o
+$c $m
+$b
+$a $n
+$a $2 $0 $0 $4
+$a $1
+$G $G
+$7 Z1
+$7 @b
+$4 $5
+$2 $4
+$2 $3
+$2 $0 $0 $5
+$2 $0 $0 $3
+$1 Z1
+$1 $4
+$1 $0
+$0 i50
+$0 $4
+$0 $3
+$! D3
+$" D0 '3
+@* +3
+$. $b
+$0
+$0 D5 $3
+$1 $2
+$1 $2 $3
+$1 $3
+$1 *21
+$1 *54
+$1 +2 Z1
+$1 +4
+$1 +6
+$1 .2
+$1 E
+$1 o1u
+$1 o2l
+$1 o3n
+$1 o4c
+$1 o4e
+$1 o5e
+$1 o5l
+$1 o6a
+$2 $1
+$2 *32
+$2 ,3
+$2 T0
+$2 Z1
+$2 i31
+$2 o5e
+$3 $1
+$3 *56
+$3 D1
+$4
+$4 $0
+$4 D1
+$5 *76
+$5 R4
+$5 o1e
+$6
+$7 +0 t
+$7 Z1 D2
+$7 [
+$7 k
+$8
+$8 D2
+$8 D4
+$8 D5
+$8 E
+$8 o1u
+$9
+$9 $7 $7
+$9 $8 $0
+$9 $8 $8
+$9 D5
+$9 o1i
+$:
+$@ $g $m $a $i $l $. $c $o $m
+$B E
+$D t
+$W c
+$a $h
+$a D4
+$a D5
+$a D6
+$a E
+$a i5a
+$b $i
+$b $o $y
+$c $a
+$d
+$e $d
+$f
+$g
+$h $o
+$h $p
+$h } K
+$i
+$m
+$o
+$s c
+'4 c
+'5 $1
+'5 Z3
+'5 c @r
+'8 *02
+'9 [
+*03 o3t
+*04 $5
+*05 *52
+*05 c
+*12 K
+*14 c
+*20 +0
+*21 o1e
+*21 o2w
+*23 +2
+*24 *52
+*25 c y4
+*26 D3
+*2A ^U
+*31 o1e
+*32 o2c
+*32 o2r
+*32 o3h
+*32 o3p
+*32 o3s
+*34 o4o
+*34 o4u
+*35 *54
+*35 *B0 -4
+*40 c
+*43
+*43 K
+*43 ^o D4
+*46 D4
+*56 *12
+*67 *86
+*76 '8
+*76 Y2 E
+*84 i6c
+*85 i7e
+*86 c
++0 *5B Y2
++0 Z1
++0 t
++0 }
++1
++1 *14
++1 ]
++1 c
++1 o2w
++2 $a
++2 +2
++2 K
++2 Y1
++2 c
++3 $4 D5
++3 $7
++3 $s
++3 Z1
++3 o4u
++4 $k
++5 $o
++5 $y
++5 $z
++5 *75
++5 o0y sBH
++5 o49
++6 E
++6 l K
++8
++8 c
+-0
+-0 *02
+-0 -0 sei
+-1 *12
+-1 [ Z2
+-2 $2
+-2 *52
+-4 $3
+-4 ,2 oB7
+-4 c
+-5 $s
+-6 $1
+-6 $8
+-6 E
+-7 $5
+-7 $7
+-7 K
+-8
+@* D3
+E $m
+E $r
+E ^K
+E ^i
+E o2y
+K o3b
+] c D6
+^1 ^2 ^3 T3
+^2 ^0 ^0 ^2 T4
+^a ^e ^s
+^a p4
+^b ^a ^g ^b ^a ^g
+^e ^a ^n ^e ^a ^n
+^g ^i ^p
+^g ^n ^i ^v ^e ^k
+^g ^o ^d
+^g ^o ^d ^l ^o ^o ^c
+^h ^h ^h ^h ^h ^h
+^i ^m ^h ^a ^y ^s
+^j ^s ^s ^u ^k ^o ^g
+^l ^e ^i ^r ^a ^d
+^l ^o ^o ^o ^l
+^l ^r ^i ^g ^f ^l ^o ^w
+^p ^p ^p ^p ^p
+c $!
+c $! $!
+c $6
+c $@ $y $a $h $o $o $. $c $o $m
+c $e
+c T2 T4
+c i2a
+c i2l
+c i3e
+c i5M
+c o1e
+c o1y
+i2R c
+i6I c
+i6v
+l $. $m
+l $@ $h $o $t $m $a $i $l $. $c $o
+l [ ^H
+l [ ^S
+l ^n ^o
+o0H +5
+o1A c
+o1r t
+o2k c
+o2s c
+o3i c
+o4j c
+o4o c
+o6T i6Y
+o6i c
+o9y
+y2


### PR DESCRIPTION
## Summary

- Add dictionary attacks (`hashcat -a 0`): `crackctl task create --wordlist <id>`
- Add dictionary+rules attacks: `crackctl task create --wordlist <id> --rules-file <id>`
- Add `TransferFileChunk` protocol message for streaming wordlist/rules files to workers over the Noise channel (~40KB chunks, cached by agent)
- Bundle [OneRuleToRuleThemStill](https://github.com/stealthsploit/OneRuleToRuleThemStill) (48,439 rules by [Will Hunt](https://github.com/stealthsploit), MIT license) with full attribution
- Credit hashcat and Jens "atom" Steube in `rules/ATTRIBUTION.md`
- Campaign engine now handles `PhaseConfig::Dictionary` phases (was stubbed)
- `--mask` is now optional in `crackctl task create` (mutually exclusive with `--wordlist`)

## Integration test results

| Test | Result |
|------|--------|
| Dictionary attack (20-word wordlist, NTLM) | 2/5 cracked (`password`, `123456`) |
| Dictionary + OneRuleToRuleThemStill rules | **5/5 cracked** (all hashes including rule-mutated variants) |
| Brute-force regression (`?l?l?l?l`) | Works as before, cracked `test` |
| Unit tests (69) | All pass |

## Test plan

- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` — 69 tests pass
- [x] Dictionary attack end-to-end: wordlist transfer + hashcat -a 0
- [x] Dictionary+rules end-to-end: wordlist + OTRTS rules transfer + hashcat -a 0 -r
- [x] Brute-force regression: existing mask attacks still work

Closes #8