### PR TITLE
Bump version to 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.8.1 to 0.8.2
- Triggers release build with binaries for all 5 platforms

## Changelog since 0.8.1

- Added dictionary phases to all campaign templates
- Dictionary phases skipped if no wordlist provided (backward compatible)
- New `--wordlist` and `--rules-file` flags on `crackctl campaign create`
- Fixed CI: cargo fmt, clippy warnings, audit ignore for transitive `rsa` advisory
- Documented potfile handling in README
- Renamed repository to Crackswarm