### PR TITLE
Update Cargo.lock (iri-string patch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "crack-agent"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "crack-common"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "crack-coord"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "crackctl"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1563,9 +1563,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",


### PR DESCRIPTION
## Summary

- Update transitive dependency `iri-string` 0.7.11 -> 0.7.12 (patch)

## Test plan

- [x] `cargo test --workspace` — 69 tests pass