### PR TITLE
Fix all code review findings: race conditions, security, correctness

### DIFF
--- a/crates/crack-agent/Cargo.toml
+++ b/crates/crack-agent/Cargo.toml
@@ -2,6 +2,7 @@
 name = "crack-agent"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "crack-agent"

--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -350,6 +350,17 @@ async fn connect_and_run(
                         total_chunks,
                         data_b64,
                     } => {
+                        // Validate file_id is a proper UUID to prevent path traversal
+                        Uuid::parse_str(&file_id).context("invalid file_id: not a valid UUID")?;
+
+                        // Bounds checks
+                        if total_chunks > 10_000 {
+                            return Err(anyhow!("file transfer too large"));
+                        }
+                        if chunk_index >= total_chunks {
+                            continue;
+                        }
+
                         // Decode chunk data
                         let data = base64::engine::general_purpose::STANDARD
                             .decode(&data_b64)
@@ -795,6 +806,9 @@ async fn save_hash_file(
     file_id: &str,
     b64_data: &str,
 ) -> anyhow::Result<PathBuf> {
+    // Validate file_id is a proper UUID to prevent path traversal
+    Uuid::parse_str(file_id).context("invalid file_id: not a valid UUID")?;
+
     let cache_dir = config.cache_dir();
     tokio::fs::create_dir_all(&cache_dir).await?;
 

--- a/crates/crack-agent/src/runner.rs
+++ b/crates/crack-agent/src/runner.rs
@@ -1,4 +1,6 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Context};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -113,8 +115,11 @@ impl HashcatRunner {
         // Output file
         cmd.arg("-o").arg(&config.outfile_path);
         // hashcat 7.x uses comma-separated format values (not bitmask like 6.x).
-        // 1 = hash, 2 = plain → "hash:plain" output.
+        // 1 = hash, 2 = plain → "hash<sep>plain" output.
         cmd.arg("--outfile-format=1,2");
+        // Use tab separator to avoid ambiguity with hashes or plaintexts that
+        // contain colons (the default separator).
+        cmd.arg("--separator").arg("\t");
 
         // Custom charsets (-1, -2, -3, -4)
         if let Some(charsets) = &config.custom_charsets {
@@ -123,8 +128,12 @@ impl HashcatRunner {
             }
         }
 
-        // Extra user-supplied arguments
+        // Extra user-supplied arguments (filtered for safety)
         for arg in &config.extra_args {
+            if is_dangerous_arg(arg) {
+                warn!(arg = %arg, "rejecting dangerous extra_arg");
+                continue;
+            }
             cmd.arg(arg);
         }
 
@@ -182,9 +191,14 @@ impl HashcatRunner {
         let tx_outfile = tx.clone();
         let tx_stderr = tx.clone();
 
+        // Shared set to deduplicate hashes across stdout, outfile watcher, and
+        // the final outfile read.
+        let seen_hashes: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let seen_outfile = Arc::clone(&seen_hashes);
+
         // Spawn a task to watch the outfile for new cracked hashes
         let outfile_handle = tokio::spawn(async move {
-            watch_outfile(&outfile, tx_outfile).await;
+            watch_outfile(&outfile, tx_outfile, seen_outfile).await;
         });
 
         // Spawn a task to capture stderr
@@ -242,13 +256,16 @@ impl HashcatRunner {
                     })
                     .await;
             } else if let Some((hash, plaintext)) = status::parse_outfile_line(&line) {
-                // hashcat prints cracked hashes to stdout as "hash:plaintext".
-                // Filter out hashcat info lines (contain spaces/dots before ':',
+                // hashcat prints cracked hashes to stdout as "hash\tplaintext".
+                // Filter out hashcat info lines (contain spaces/dots before separator,
                 // or the "hash" part is too short to be a real hash).
                 let is_info_line = hash.contains(' ') || hash.contains("...") || hash.len() < 16;
                 if !is_info_line {
-                    info!(hash = %hash, "hash cracked (stdout)");
-                    let _ = tx.send(RunnerEvent::HashCracked { hash, plaintext }).await;
+                    let is_new = seen_hashes.lock().unwrap().insert(hash.clone());
+                    if is_new {
+                        info!(hash = %hash, "hash cracked (stdout)");
+                        let _ = tx.send(RunnerEvent::HashCracked { hash, plaintext }).await;
+                    }
                 }
             } else {
                 debug!(line = %line, "hashcat stdout (non-JSON)");
@@ -272,12 +289,16 @@ impl HashcatRunner {
         // The watcher polls every 2s, but hashcat can complete faster than that.
         // Note: hashcat only creates the outfile when it cracks something,
         // so a missing outfile on exit_code=1 (exhausted) is completely normal.
-        match tokio::fs::read_to_string(&self.outfile_path).await {
-            Ok(contents) => {
+        match tokio::fs::read(&self.outfile_path).await {
+            Ok(bytes) => {
+                let contents = String::from_utf8_lossy(&bytes);
                 for line in contents.lines() {
                     if let Some((hash, plaintext)) = status::parse_outfile_line(line) {
-                        info!(hash = %hash, plaintext = %plaintext, "hash cracked (final outfile read)");
-                        let _ = tx.send(RunnerEvent::HashCracked { hash, plaintext }).await;
+                        let is_new = seen_hashes.lock().unwrap().insert(hash.clone());
+                        if is_new {
+                            info!(hash = %hash, plaintext = %plaintext, "hash cracked (final outfile read)");
+                            let _ = tx.send(RunnerEvent::HashCracked { hash, plaintext }).await;
+                        }
                     }
                 }
             }
@@ -346,11 +367,36 @@ impl HashcatRunner {
     }
 }
 
+/// Reject extra_args that could interfere with orchestration or write to
+/// arbitrary paths.
+fn is_dangerous_arg(arg: &str) -> bool {
+    const BLOCKED_PREFIXES: &[&str] = &[
+        "-o",
+        "--outfile",
+        "--potfile",
+        "--session",
+        "--remove",
+        "--restore",
+        "--keyspace",
+        "--stdout",
+        "--separator",
+    ];
+    let lower = arg.to_ascii_lowercase();
+    BLOCKED_PREFIXES
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
 /// Watch an outfile for newly appended lines (cracked hashes).
 ///
-/// This polls the file periodically.  Each new line in format `hash:plaintext`
-/// is sent through the channel.
-async fn watch_outfile(path: &Path, tx: mpsc::Sender<RunnerEvent>) {
+/// This polls the file periodically.  Each new line in format `hash\tplaintext`
+/// is sent through the channel.  Uses raw bytes + lossy conversion to avoid
+/// panicking on non-UTF-8 outfile content.
+async fn watch_outfile(
+    path: &Path,
+    tx: mpsc::Sender<RunnerEvent>,
+    seen: Arc<Mutex<HashSet<String>>>,
+) {
     use tokio::fs;
     use tokio::time::{interval, Duration};
 
@@ -370,25 +416,30 @@ async fn watch_outfile(path: &Path, tx: mpsc::Sender<RunnerEvent>) {
             continue;
         }
 
-        // Read the new portion
-        match fs::read_to_string(path).await {
-            Ok(contents) => {
-                // We need to skip bytes we already processed
-                let new_data = if last_size as usize <= contents.len() {
-                    &contents[last_size as usize..]
+        // Read the file as raw bytes to avoid UTF-8 panics
+        match fs::read(path).await {
+            Ok(bytes) => {
+                // Skip bytes we already processed
+                let new_bytes = if (last_size as usize) <= bytes.len() {
+                    &bytes[last_size as usize..]
                 } else {
-                    &contents
+                    &bytes
                 };
+
+                let new_data = String::from_utf8_lossy(new_bytes);
 
                 for line in new_data.lines() {
                     if let Some((hash, plaintext)) = status::parse_outfile_line(line) {
-                        info!(hash = %hash, "hash cracked!");
-                        if tx
-                            .send(RunnerEvent::HashCracked { hash, plaintext })
-                            .await
-                            .is_err()
-                        {
-                            return;
+                        let is_new = seen.lock().unwrap().insert(hash.clone());
+                        if is_new {
+                            info!(hash = %hash, "hash cracked!");
+                            if tx
+                                .send(RunnerEvent::HashCracked { hash, plaintext })
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
                         }
                     }
                 }

--- a/crates/crack-agent/src/status.rs
+++ b/crates/crack-agent/src/status.rs
@@ -16,7 +16,8 @@ pub fn parse_status_line(line: &str) -> Option<HashcatStatus> {
     serde_json::from_str::<HashcatStatus>(trimmed).ok()
 }
 
-/// Parse a line from the hashcat outfile (format=3: `hash:plaintext`).
+/// Parse a line from the hashcat outfile (format=1,2 with tab separator:
+/// `hash\tplaintext`).
 ///
 /// Returns `(hash, plaintext)` or `None` if the line doesn't contain a
 /// separator.
@@ -25,8 +26,8 @@ pub fn parse_outfile_line(line: &str) -> Option<(String, String)> {
     if trimmed.is_empty() {
         return None;
     }
-    // outfile-format=3 produces "hash:plaintext"
-    let (hash, plain) = trimmed.split_once(':')?;
+    // outfile-format=1,2 with --separator=\t produces "hash\tplaintext"
+    let (hash, plain) = trimmed.split_once('\t')?;
     Some((hash.to_string(), plain.to_string()))
 }
 
@@ -148,7 +149,7 @@ mod tests {
     #[test]
     fn test_parse_outfile_line() {
         let (hash, plain) =
-            parse_outfile_line("5f4dcc3b5aa765d61d8327deb882cf99:password").unwrap();
+            parse_outfile_line("5f4dcc3b5aa765d61d8327deb882cf99\tpassword").unwrap();
         assert_eq!(hash, "5f4dcc3b5aa765d61d8327deb882cf99");
         assert_eq!(plain, "password");
     }
@@ -162,5 +163,14 @@ mod tests {
     #[test]
     fn test_parse_outfile_line_no_separator() {
         assert!(parse_outfile_line("no_separator_here").is_none());
+    }
+
+    #[test]
+    fn test_parse_outfile_line_colon_in_plaintext() {
+        // Colons in the plaintext should not cause a split (we use tab separator)
+        let (hash, plain) =
+            parse_outfile_line("5f4dcc3b5aa765d61d8327deb882cf99\tpass:word").unwrap();
+        assert_eq!(hash, "5f4dcc3b5aa765d61d8327deb882cf99");
+        assert_eq!(plain, "pass:word");
     }
 }

--- a/crates/crack-common/Cargo.toml
+++ b/crates/crack-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "crack-common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/crack-common/src/auth.rs
+++ b/crates/crack-common/src/auth.rs
@@ -51,12 +51,24 @@ impl Keypair {
         let priv_path = dir.join("private.key");
         let pub_path = dir.join("public.key");
 
-        // Write private key with restrictive permissions
-        std::fs::write(&priv_path, &self.private_key)?;
+        // Write private key with restrictive permissions.
+        // On Unix, create the file with mode 0o600 atomically to avoid a
+        // window where the key is world-readable.
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&priv_path, std::fs::Permissions::from_mode(0o600))?;
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&priv_path)?;
+            f.write_all(&self.private_key)?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&priv_path, &self.private_key)?;
         }
 
         std::fs::write(&pub_path, &self.public_key)?;

--- a/crates/crack-coord/Cargo.toml
+++ b/crates/crack-coord/Cargo.toml
@@ -2,6 +2,7 @@
 name = "crack-coord"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "crack-coord"

--- a/crates/crack-coord/src/api/files.rs
+++ b/crates/crack-coord/src/api/files.rs
@@ -92,7 +92,12 @@ pub async fn download_file(
     let data = files::read_file(&files_dir, &record.id)
         .map_err(|e| ApiError::Internal(format!("failed to read file: {e}")))?;
 
-    let content_disposition = format!("attachment; filename=\"{}\"", record.filename);
+    // Sanitize filename to prevent header injection via quotes, newlines, or null bytes.
+    let safe_filename = record
+        .filename
+        .replace('"', "'")
+        .replace(['\n', '\r', '\0'], "");
+    let content_disposition = format!("attachment; filename=\"{}\"", safe_filename);
 
     Ok((
         StatusCode::OK,

--- a/crates/crack-coord/src/api/mod.rs
+++ b/crates/crack-coord/src/api/mod.rs
@@ -5,6 +5,7 @@ mod workers;
 
 use std::sync::Arc;
 
+use axum::extract::DefaultBodyLimit;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -125,5 +126,6 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/v1/status", get(tasks::system_status))
         .route("/api/v1/potfile/stats", get(tasks::potfile_stats))
         .route("/api/v1/potfile/plaintexts", get(tasks::potfile_plaintexts))
+        .layer(DefaultBodyLimit::max(512 * 1024 * 1024)) // 512 MB
         .with_state(state)
 }

--- a/crates/crack-coord/src/monitor.rs
+++ b/crates/crack-coord/src/monitor.rs
@@ -213,8 +213,7 @@ async fn reassign_abandoned_chunks(state: &AppState) -> anyhow::Result<()> {
         }
 
         // Create a new pending chunk for the remaining work
-        let new_chunk_id = uuid::Uuid::new_v4();
-        db::create_chunk(&state.db, chunk.task_id, new_skip, new_limit).await?;
+        let new_chunk = db::create_chunk(&state.db, chunk.task_id, new_skip, new_limit).await?;
 
         // Mark the old chunk as fully abandoned (don't retry it again)
         db::update_chunk_status(
@@ -226,7 +225,7 @@ async fn reassign_abandoned_chunks(state: &AppState) -> anyhow::Result<()> {
 
         info!(
             old_chunk = %chunk.id,
-            new_chunk = %new_chunk_id,
+            new_chunk = %new_chunk.id,
             task = %chunk.task_id,
             remaining = new_limit,
             "reassigned abandoned chunk"

--- a/crates/crack-coord/src/storage/db.rs
+++ b/crates/crack-coord/src/storage/db.rs
@@ -415,14 +415,17 @@ pub async fn delete_task(pool: &SqlitePool, id: Uuid) -> Result<bool> {
     Ok(result.rows_affected() > 0)
 }
 
-pub async fn increment_task_cracked_count(pool: &SqlitePool, id: Uuid, delta: u32) -> Result<()> {
-    sqlx::query("UPDATE tasks SET cracked_count = cracked_count + ?1 WHERE id = ?2")
-        .bind(delta)
-        .bind(id.to_string())
-        .execute(pool)
-        .await
-        .context("incrementing cracked count")?;
-    Ok(())
+pub async fn increment_task_cracked_count(pool: &SqlitePool, id: Uuid, delta: u32) -> Result<u32> {
+    let row = sqlx::query(
+        "UPDATE tasks SET cracked_count = cracked_count + ?1 WHERE id = ?2 RETURNING cracked_count",
+    )
+    .bind(delta)
+    .bind(id.to_string())
+    .fetch_one(pool)
+    .await
+    .context("incrementing cracked count")?;
+
+    Ok(row.get::<u32, _>("cracked_count"))
 }
 
 pub async fn set_task_keyspace(
@@ -582,7 +585,7 @@ pub async fn claim_pending_chunk(
     };
 
     // Claim it: set status to dispatched and assign worker
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE chunks SET status = 'dispatched', assigned_worker = ?1, assigned_at = ?2 WHERE id = ?3 AND status = 'pending'"
     )
     .bind(worker_id)
@@ -591,6 +594,11 @@ pub async fn claim_pending_chunk(
     .execute(pool)
     .await
     .context("claiming pending chunk")?;
+
+    // Another worker already claimed this chunk between the SELECT and UPDATE
+    if result.rows_affected() == 0 {
+        return Ok(None);
+    }
 
     let task = get_task(pool, chunk.task_id)
         .await?

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -391,8 +391,17 @@ async fn handle_worker_message(
                 worker_id = %wid,
                 "received HashCracked from worker"
             );
-            db::insert_cracked_hash(&state.db, *task_id, hash, plaintext, wid).await?;
-            db::increment_task_cracked_count(&state.db, *task_id, 1).await?;
+            let inserted =
+                db::insert_cracked_hash(&state.db, *task_id, hash, plaintext, wid).await?;
+
+            // Only increment the count and check completion if the hash was
+            // actually new (not a duplicate).
+            if !inserted {
+                debug!(task_id = %task_id, hash = %hash, "duplicate hash ignored");
+                return Ok(());
+            }
+
+            let new_count = db::increment_task_cracked_count(&state.db, *task_id, 1).await?;
 
             state.emit(AppEvent::HashCracked {
                 task_id: *task_id,
@@ -401,7 +410,7 @@ async fn handle_worker_message(
 
             // Check if all hashes for this task have been cracked.
             if let Some(task) = db::get_task(&state.db, *task_id).await? {
-                if task.cracked_count + 1 >= task.total_hashes {
+                if new_count >= task.total_hashes {
                     info!(task_id = %task_id, "all hashes cracked, completing task");
                     db::update_task_status(&state.db, *task_id, TaskStatus::Completed).await?;
 

--- a/crates/crackctl/Cargo.toml
+++ b/crates/crackctl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "crackctl"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "crackctl"

--- a/crates/crackctl/src/display.rs
+++ b/crates/crackctl/src/display.rs
@@ -5,13 +5,19 @@ use crate::client::{CampaignDetailResponse, PotfileStats};
 
 // ── Helpers ──
 
-/// Truncate a string to `max` characters, appending "..." if truncated.
+/// Truncate a string to `max` bytes, appending "..." if truncated.
+/// Ensures the truncation point falls on a valid UTF-8 char boundary.
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max.saturating_sub(3)])
+        return s.to_string();
     }
+    let end = s
+        .char_indices()
+        .take_while(|(i, _)| *i + 3 < max)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+    format!("{}...", &s[..end])
 }
 
 /// First 8 characters of an ID (for UUID or other string IDs).
@@ -173,7 +179,7 @@ pub fn print_task_detail(task: &Task, chunks: &[Chunk]) {
         for chunk in chunks {
             let chunk_id_str = chunk.id.to_string();
             let id = short_id(&chunk_id_str);
-            let progress = format!("{:.1}%", chunk.progress * 100.0);
+            let progress = format!("{:.1}%", chunk.progress);
             let speed = human_speed(chunk.speed);
 
             println!(


### PR DESCRIPTION
## Summary

Addresses all findings from the full codebase code review.

### Critical (3)
- **[C1]** Atomic task completion check — `increment_task_cracked_count` returns new count via SQL RETURNING
- **[C2]** Deduplicate HashCracked events — agent-side HashSet + coordinator only increments on new row insert
- **[C3]** Path traversal prevention — validate file_id is a UUID before cache path construction

### Warnings (10)
- **[W1]** Check rows_affected in claim_pending_chunk (prevent double-dispatch)
- **[W2]** UTF-8 safe outfile watcher (read bytes, not string)
- **[W3]** Tab separator for hashcat outfile (handles colon-containing hashes)
- **[W4]** Atomic private key file creation with 0o600 permissions
- **[W5]** 512MB upload size limit via DefaultBodyLimit
- **[W6]** Sanitize Content-Disposition filename
- **[W7]** Fix monitor logging wrong chunk ID
- **[W8]** UTF-8 safe string truncation in display
- **[W9]** Fix progress showing 10000% (was double-multiplied)
- **[W10]** Add license.workspace to all crate Cargo.toml files

### Suggestions (2)
- **[S1]** Extra args allowlist — reject dangerous hashcat flags on agent
- **[S2]** Validate file transfer bounds (total_chunks max, chunk_index range)

## Test plan
- [x] cargo fmt --all --check passes
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test --workspace — 70 tests pass (+1 new test for colon-in-plaintext)

Closes #14, closes #15, closes #16, closes #17, closes #18