### PR TITLE
Bump version to 0.8.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.4"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Bump workspace version to 0.8.4 to trigger release build with all code review fixes.