### PR TITLE
ci: auto-merge dependabot patch/minor bumps when checks pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch and minor updates
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: gh pr comment "$PR_URL" --body "Major version bump detected ($DEP_NAMES: $PREVIOUS → $NEW). Auto-merge skipped — please review manually."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS: ${{ steps.metadata.outputs.previous-version }}
+          NEW: ${{ steps.metadata.outputs.new-version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml`. On every dependabot PR it inspects `update-type` via `dependabot/fetch-metadata@v2` and enables GitHub's native auto-merge (`gh pr merge --auto --squash`) for `semver-patch` and `semver-minor`.
- `semver-major` bumps get a comment and stay open for manual review — CI can pass on a major bump while runtime behavior shifts (especially relevant for crypto-adjacent crates like `hkdf`, `snow`).
- Repo setting `allow_auto_merge` has been flipped on so `--auto` actually queues. Branch protection on `main` already requires Format / Clippy / Test / Security Audit, so the queued merge only lands when all four are green.

## Test plan
- [ ] Merge this PR.
- [ ] Close + reopen (or wait for next dependabot run on) one of the existing patch/minor PRs (#24, #25, #26) and confirm the workflow runs, hits the "Enable auto-merge" step, and the PR enters auto-merge state.
- [ ] Confirm #22 (hkdf 0.12 → 0.13, labeled `semver-minor` by dependabot but effectively breaking in 0.x) — decide whether to tighten the filter to exclude 0.x minor bumps after observing behavior.