### PR TITLE
fix: clippy 1.95 lints and rustls-webpki CVE patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,9 +2752,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/crack-coord/src/campaign/analyzer.rs
+++ b/crates/crack-coord/src/campaign/analyzer.rs
@@ -144,7 +144,7 @@ impl PositionStats {
         }
 
         let mut sorted: Vec<(char, u32)> = self.chars.iter().map(|(&c, &n)| (c, n)).collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let mut coverage = 0u32;
         let needed = (self.total as f64 * threshold) as u32;
@@ -200,7 +200,7 @@ pub fn analyze(
 
     // Sort by frequency descending
     let mut ranked: Vec<(Skeleton, u32)> = skeleton_counts.into_iter().collect();
-    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     // Filter: minimum count threshold
     ranked.retain(|(_, count)| *count >= config.min_skeleton_count);
@@ -342,7 +342,7 @@ pub fn analyze(
     }
 
     let mut suffix_ranked: Vec<(String, u32)> = suffix_counts.into_iter().collect();
-    suffix_ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    suffix_ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (suffix, count) in suffix_ranked.iter().take(10) {
         if *count < config.min_skeleton_count {

--- a/crates/crack-coord/src/campaign/engine.rs
+++ b/crates/crack-coord/src/campaign/engine.rs
@@ -218,9 +218,7 @@ async fn find_next_subtask(
         } => {
             // Current length = number of charset tokens in the completed mask
             let charset_len = charset.len();
-            let current_length = if charset_len > 0 {
-                completed_mask.len() / charset_len
-            } else {
+            let Some(current_length) = completed_mask.len().checked_div(charset_len) else {
                 return Ok(None);
             };
             let next_length = current_length + 1;

--- a/crates/crack-coord/src/tui/event.rs
+++ b/crates/crack-coord/src/tui/event.rs
@@ -20,15 +20,11 @@ pub fn spawn_event_reader(tick_rate: Duration) -> mpsc::UnboundedReceiver<TermEv
         loop {
             if event::poll(tick_rate).unwrap_or(false) {
                 match event::read() {
-                    Ok(Event::Key(key)) => {
-                        if tx.send(TermEvent::Key(key)).is_err() {
-                            return;
-                        }
+                    Ok(Event::Key(key)) if tx.send(TermEvent::Key(key)).is_err() => {
+                        return;
                     }
-                    Ok(Event::Resize(w, h)) => {
-                        if tx.send(TermEvent::Resize(w, h)).is_err() {
-                            return;
-                        }
+                    Ok(Event::Resize(w, h)) if tx.send(TermEvent::Resize(w, h)).is_err() => {
+                        return;
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## Summary
CI broke on \`main\` this week from two independent events:
- **rustc 1.95** rolled out 2026-04-14 with new clippy lints (\`unnecessary_sort_by\`, \`manual_checked_ops\`, \`collapsible_match\`) that trip our \`-D warnings\` gate in 6 places.
- **rustls-webpki 0.103.10** was flagged for RUSTSEC-2026-0098, -0099, -0104 — all blocking Security Audit.

Both surface on every PR (dependabot #22/#24/#25 and the auto-merge workflow PR #27), because CI runs the new toolchain + current advisory DB.

## Changes
- \`crack-coord/src/campaign/analyzer.rs\` — three \`sort_by(|a,b| b.1.cmp(&a.1))\` → \`sort_by_key(|b| std::cmp::Reverse(b.1))\`
- \`crack-coord/src/campaign/engine.rs\` — \`if charset_len > 0 { ... / ... } else { return }\` → \`let Some(..) = x.checked_div(y) else { return }\`
- \`crack-coord/src/tui/event.rs\` — \`match { Arm => if guard { return } }\` → \`match { Arm if guard => return }\`
- \`Cargo.lock\` — \`cargo update -p rustls-webpki\` (0.103.10 → 0.103.13, transitive via rustls → reqwest)

Behaviour-preserving. No API changes.

## Test plan
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean (local rustc 1.94; CI will confirm on 1.95)
- [x] \`cargo audit\` — exit 0; only the pre-existing rand unsound warnings remain (warnings don't block)
- [x] \`cargo test --workspace\` — all green
- [ ] CI on this PR passes all four jobs
- [ ] After merge: rebase #22 / #24 / #25 / #27 so they pick up the new \`main\` and auto-merge