### PR TITLE
chore(ci): bump dependabot/fetch-metadata v2 → v3

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
Bumps \`dependabot/fetch-metadata\` from v2 to v3 in \`.github/workflows/dependabot-auto-merge.yml\`.

## Release notes reviewed
- **v3.0.0** — sole breaking change is Node.js runtime v20 → v24 (action infrastructure; user-visible outputs unchanged).
- **v3.1.0** — ships a direct bugfix: "resolve update-type null for Python, Composer, and Terraform PRs" (#704) and "handle duplicate dependency names in parseMetadataLinks" (#700). Both relevant to the \`update-type\` field our workflow keys off.

The \`update-type\` output still emits \`version-update:semver-patch\` / \`-minor\` / \`-major\` — the \`if:\` conditions in the workflow don't need changes.

## Risk
Low. The action's public API is stable across the major; only the runtime was bumped.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: next dependabot PR triggers the auto-merge workflow; confirm both steps run (fetch-metadata → \`gh pr merge --auto --squash\` for patch/minor, or the major-bump comment path)