### PR TITLE
chore(ci): polish dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "actions/*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
## Summary
Two small quality-of-life changes to \`.github/dependabot.yml\`:

1. **\`open-pull-requests-limit: 10\`** on both \`cargo\` and \`github-actions\` ecosystems. Dependabot's default is 5 — low enough that during a quiet week a backlog can stall out. 10 is a modest ceiling that still prevents runaway PRs.
2. **\`groups: actions\`** bundles all \`actions/*\` patch+minor bumps into a single PR for the \`github-actions\` ecosystem. Majors still come as individual PRs (so the auto-merge workflow's major-bump comment gate still applies).

## Why
- Last week we had 4 concurrent dependabot PRs and hit a rebase cascade. Grouping the \`actions/*\` family reduces future noise without losing the ability to review majors individually.
- Higher PR limit means fewer dropped updates if things pile up.

## What is NOT changed
- Cargo deps are **not** grouped. Rust library changes often need targeted review (we saw that yesterday with hkdf 0.12→0.13). Grouped cargo PRs would force reviewing unrelated crates together. Leaving cargo as one-PR-per-crate.
- No \`reviewers\`, \`labels\`, or \`commit-message\` fields added — the repo only has one maintainer and the defaults are fine.

## Test plan
- [ ] CI passes
- [ ] Next week's dependabot run produces the new shape (grouped actions PRs; individual cargo PRs)