### PR TITLE
feat(coord): keyspace cache + non-blocking task preparation (Slice 1/11)

### DIFF
--- a/crates/crack-coord/src/monitor.rs
+++ b/crates/crack-coord/src/monitor.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use crack_common::models::Task;
 use tracing::{error, info, warn};
 
 use crate::scheduler::chunker;
@@ -38,96 +39,115 @@ pub async fn run_monitor(state: Arc<AppState>) {
     }
 }
 
-/// Find pending tasks, compute their keyspace and hash count, and transition
-/// them to running so they become dispatchable.
-async fn prepare_pending_tasks(state: &AppState) -> anyhow::Result<()> {
+/// Find pending tasks and spawn a preparation task for each one that isn't
+/// already being prepared. Prep can take minutes for large wordlists (hashcat
+/// --keyspace linearly scans the file), so we must not block the monitor loop
+/// or heartbeats stall for the duration of the scan.
+async fn prepare_pending_tasks(state: &Arc<AppState>) -> anyhow::Result<()> {
     let pending = db::get_pending_tasks(&state.db).await?;
 
     for task in pending {
-        info!(task_id = %task.id, task_name = %task.name, "preparing pending task");
+        let task_id = task.id;
 
-        // 1. Count hashes in the hash file
-        let _hash_file = match db::get_file_record(&state.db, &task.hash_file_id).await? {
-            Some(f) => f,
-            None => {
-                error!(task_id = %task.id, "hash file {} not found, failing task", task.hash_file_id);
-                db::update_task_status(
-                    &state.db,
-                    task.id,
-                    crack_common::models::TaskStatus::Failed,
-                )
-                .await?;
+        // Claim the task for preparation. If it's already being prepared (from
+        // a prior tick), skip.
+        {
+            let mut preparing = state.preparing_tasks.write().await;
+            if !preparing.insert(task_id) {
                 continue;
             }
-        };
-
-        let file_data = match files::read_file(&state.files_dir(), &task.hash_file_id) {
-            Ok(data) => data,
-            Err(e) => {
-                error!(task_id = %task.id, error = %e, "failed to read hash file");
-                db::update_task_status(
-                    &state.db,
-                    task.id,
-                    crack_common::models::TaskStatus::Failed,
-                )
-                .await?;
-                continue;
-            }
-        };
-
-        let content = String::from_utf8_lossy(&file_data);
-        let total_hashes = content.lines().filter(|l| !l.trim().is_empty()).count() as u32;
-
-        if total_hashes == 0 {
-            error!(task_id = %task.id, "hash file is empty, failing task");
-            db::update_task_status(&state.db, task.id, crack_common::models::TaskStatus::Failed)
-                .await?;
-            continue;
         }
 
-        // 2. Compute keyspace via hashcat
-        let keyspace = match chunker::compute_keyspace(
-            &state.hashcat_path,
-            task.hash_mode,
-            &task.attack_config,
-            &state.files_dir(),
-        )
-        .await
-        {
-            Ok(ks) => ks,
-            Err(e) => {
-                error!(task_id = %task.id, error = %e, "failed to compute keyspace");
-                db::update_task_status(
-                    &state.db,
-                    task.id,
-                    crack_common::models::TaskStatus::Failed,
-                )
-                .await?;
-                continue;
+        let state_for_spawn = state.clone();
+        tokio::spawn(async move {
+            if let Err(e) = prepare_one(&state_for_spawn, task).await {
+                warn!(%task_id, error = %e, "task preparation failed");
             }
-        };
-
-        info!(
-            task_id = %task.id,
-            total_hashes,
-            keyspace,
-            "task prepared, transitioning to running"
-        );
-
-        // 3. Store keyspace and hash count
-        db::set_task_keyspace(&state.db, task.id, keyspace, total_hashes).await?;
-
-        // 4. Transition to running
-        db::update_task_status(
-            &state.db,
-            task.id,
-            crack_common::models::TaskStatus::Running,
-        )
-        .await?;
-
-        state.emit(AppEvent::TaskUpdated { task_id: task.id });
+            state_for_spawn
+                .preparing_tasks
+                .write()
+                .await
+                .remove(&task_id);
+        });
     }
 
+    Ok(())
+}
+
+/// Prepare a single task: validate hash file, count hashes, compute keyspace,
+/// transition to Running. Runs inside a spawned task so it doesn't block the
+/// monitor loop.
+async fn prepare_one(state: &AppState, task: Task) -> anyhow::Result<()> {
+    info!(task_id = %task.id, task_name = %task.name, "preparing pending task");
+
+    // 1. Ensure the hash file still exists in the files table.
+    if db::get_file_record(&state.db, &task.hash_file_id)
+        .await?
+        .is_none()
+    {
+        error!(task_id = %task.id, "hash file {} not found, failing task", task.hash_file_id);
+        db::update_task_status(&state.db, task.id, crack_common::models::TaskStatus::Failed)
+            .await?;
+        return Ok(());
+    }
+
+    // 2. Count hashes in the hash file.
+    let file_data = match files::read_file(&state.files_dir(), &task.hash_file_id) {
+        Ok(data) => data,
+        Err(e) => {
+            error!(task_id = %task.id, error = %e, "failed to read hash file");
+            db::update_task_status(&state.db, task.id, crack_common::models::TaskStatus::Failed)
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let content = String::from_utf8_lossy(&file_data);
+    let total_hashes = content.lines().filter(|l| !l.trim().is_empty()).count() as u32;
+
+    if total_hashes == 0 {
+        error!(task_id = %task.id, "hash file is empty, failing task");
+        db::update_task_status(&state.db, task.id, crack_common::models::TaskStatus::Failed)
+            .await?;
+        return Ok(());
+    }
+
+    // 3. Compute keyspace via hashcat (cached for dictionary attacks).
+    let keyspace = match chunker::compute_keyspace(
+        &state.db,
+        &state.hashcat_path,
+        task.hash_mode,
+        &task.attack_config,
+        &state.files_dir(),
+    )
+    .await
+    {
+        Ok(ks) => ks,
+        Err(e) => {
+            error!(task_id = %task.id, error = %e, "failed to compute keyspace");
+            db::update_task_status(&state.db, task.id, crack_common::models::TaskStatus::Failed)
+                .await?;
+            return Ok(());
+        }
+    };
+
+    info!(
+        task_id = %task.id,
+        total_hashes,
+        keyspace,
+        "task prepared, transitioning to running"
+    );
+
+    // 4. Store keyspace and hash count, then transition to running.
+    db::set_task_keyspace(&state.db, task.id, keyspace, total_hashes).await?;
+    db::update_task_status(
+        &state.db,
+        task.id,
+        crack_common::models::TaskStatus::Running,
+    )
+    .await?;
+
+    state.emit(AppEvent::TaskUpdated { task_id: task.id });
     Ok(())
 }
 

--- a/crates/crack-coord/src/scheduler/chunker.rs
+++ b/crates/crack-coord/src/scheduler/chunker.rs
@@ -2,9 +2,10 @@ use std::path::Path;
 
 use anyhow::{bail, Context};
 use crack_common::models::AttackConfig;
+use sqlx::SqlitePool;
 use tracing::info;
 
-use crate::storage::files;
+use crate::storage::{db, files};
 
 /// Compute the total keyspace for an attack configuration.
 ///
@@ -13,6 +14,7 @@ use crate::storage::files;
 /// optimizer which may merge multiple trailing mask positions into the
 /// amplifier, resulting in a smaller base keyspace than a naive calculation.
 pub async fn compute_keyspace(
+    pool: &SqlitePool,
     hashcat_path: &str,
     hash_mode: u32,
     attack_config: &AttackConfig,
@@ -23,6 +25,8 @@ pub async fn compute_keyspace(
             mask,
             custom_charsets,
         } => {
+            // Brute-force keyspace is computed by hashcat from the mask alone
+            // (pure math, no file scan). Fast enough to skip caching.
             let keyspace = compute_keyspace_via_hashcat(
                 hashcat_path,
                 hash_mode,
@@ -35,6 +39,15 @@ pub async fn compute_keyspace(
         }
         AttackConfig::Dictionary { wordlist_file_id } => {
             let wordlist_path = files::resolve_file_path(files_dir, wordlist_file_id)?;
+            let wordlist_sha = sha256_for_file(pool, wordlist_file_id).await?;
+
+            if let Some(ref sha) = wordlist_sha {
+                if let Some(k) = db::get_cached_keyspace(pool, sha, None, hash_mode).await? {
+                    info!(wordlist = %wordlist_file_id, keyspace = k, "keyspace cache hit (dict)");
+                    return Ok(k);
+                }
+            }
+
             let keyspace = compute_dictionary_keyspace(
                 hashcat_path,
                 hash_mode,
@@ -43,6 +56,10 @@ pub async fn compute_keyspace(
             )
             .await?;
             info!(wordlist = %wordlist_file_id, keyspace, "computed dictionary keyspace via hashcat --keyspace");
+
+            if let Some(sha) = wordlist_sha {
+                db::insert_cached_keyspace(pool, &sha, None, hash_mode, keyspace).await?;
+            }
             Ok(keyspace)
         }
         AttackConfig::DictionaryWithRules {
@@ -51,6 +68,16 @@ pub async fn compute_keyspace(
         } => {
             let wordlist_path = files::resolve_file_path(files_dir, wordlist_file_id)?;
             let rules_path = files::resolve_file_path(files_dir, rules_file_id)?;
+            let wordlist_sha = sha256_for_file(pool, wordlist_file_id).await?;
+            let rules_sha = sha256_for_file(pool, rules_file_id).await?;
+
+            if let (Some(ref w), Some(ref r)) = (&wordlist_sha, &rules_sha) {
+                if let Some(k) = db::get_cached_keyspace(pool, w, Some(r), hash_mode).await? {
+                    info!(wordlist = %wordlist_file_id, rules = %rules_file_id, keyspace = k, "keyspace cache hit (dict+rules)");
+                    return Ok(k);
+                }
+            }
+
             let keyspace = compute_dictionary_keyspace(
                 hashcat_path,
                 hash_mode,
@@ -59,9 +86,22 @@ pub async fn compute_keyspace(
             )
             .await?;
             info!(wordlist = %wordlist_file_id, rules = %rules_file_id, keyspace, "computed dictionary+rules keyspace via hashcat --keyspace");
+
+            if let (Some(w), Some(r)) = (wordlist_sha, rules_sha) {
+                db::insert_cached_keyspace(pool, &w, Some(&r), hash_mode, keyspace).await?;
+            }
             Ok(keyspace)
         }
     }
+}
+
+/// Resolve a file ID to its sha256 hex, if recorded. Returns None when the
+/// file isn't in the `files` table or has no sha (legacy rows). Empty sha
+/// strings are treated as missing to avoid polluting the cache with a bogus
+/// key shared by every sha-less row.
+async fn sha256_for_file(pool: &SqlitePool, file_id: &str) -> anyhow::Result<Option<String>> {
+    let record = db::get_file_record(pool, file_id).await?;
+    Ok(record.map(|r| r.sha256).filter(|s| !s.is_empty()))
 }
 
 /// Run `hashcat --keyspace` for a dictionary attack (mode 0).

--- a/crates/crack-coord/src/state.rs
+++ b/crates/crack-coord/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -22,6 +22,10 @@ pub struct AppState {
 
     /// Connected workers: worker_id → sender for Noise messages.
     pub worker_connections: RwLock<HashMap<String, WorkerConnection>>,
+
+    /// Task IDs currently being prepared by the monitor (keyspace + hash count).
+    /// Prevents double-spawn when a prep takes longer than one monitor tick.
+    pub preparing_tasks: RwLock<HashSet<Uuid>>,
 
     /// Broadcast channel for TUI events.
     pub events: broadcast::Sender<AppEvent>,
@@ -97,6 +101,7 @@ impl AppState {
             hashcat_path,
             bind_addr,
             worker_connections: RwLock::new(HashMap::new()),
+            preparing_tasks: RwLock::new(HashSet::new()),
             events,
         })
     }

--- a/crates/crack-coord/src/storage/db.rs
+++ b/crates/crack-coord/src/storage/db.rs
@@ -128,6 +128,15 @@ CREATE TABLE IF NOT EXISTS campaign_phases (
     completed_at TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_campaign_phase_order ON campaign_phases(campaign_id, phase_index);
+
+CREATE TABLE IF NOT EXISTS keyspace_cache (
+    wordlist_sha256 TEXT NOT NULL,
+    rules_sha256 TEXT NOT NULL DEFAULT '',
+    hash_mode INTEGER NOT NULL,
+    keyspace INTEGER NOT NULL,
+    computed_at TEXT NOT NULL,
+    PRIMARY KEY (wordlist_sha256, rules_sha256, hash_mode)
+);
 "#;
 
 // ── Database init ──
@@ -1072,6 +1081,50 @@ pub async fn delete_file_record(pool: &SqlitePool, id: &str) -> Result<bool> {
 // Additional helpers (used by API, transport, scheduler, monitor)
 // ════════════════════════════════════════════════════════════════════════════
 
+pub async fn get_cached_keyspace(
+    pool: &SqlitePool,
+    wordlist_sha256: &str,
+    rules_sha256: Option<&str>,
+    hash_mode: u32,
+) -> Result<Option<u64>> {
+    let rules = rules_sha256.unwrap_or("");
+    let row = sqlx::query(
+        "SELECT keyspace FROM keyspace_cache \
+         WHERE wordlist_sha256 = ?1 AND rules_sha256 = ?2 AND hash_mode = ?3",
+    )
+    .bind(wordlist_sha256)
+    .bind(rules)
+    .bind(hash_mode as i64)
+    .fetch_optional(pool)
+    .await
+    .context("reading keyspace cache")?;
+    Ok(row.map(|r| r.get::<i64, _>("keyspace") as u64))
+}
+
+pub async fn insert_cached_keyspace(
+    pool: &SqlitePool,
+    wordlist_sha256: &str,
+    rules_sha256: Option<&str>,
+    hash_mode: u32,
+    keyspace: u64,
+) -> Result<()> {
+    let rules = rules_sha256.unwrap_or("");
+    sqlx::query(
+        "INSERT OR REPLACE INTO keyspace_cache \
+         (wordlist_sha256, rules_sha256, hash_mode, keyspace, computed_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )
+    .bind(wordlist_sha256)
+    .bind(rules)
+    .bind(hash_mode as i64)
+    .bind(keyspace as i64)
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await
+    .context("writing keyspace cache")?;
+    Ok(())
+}
+
 pub async fn list_file_records(pool: &SqlitePool) -> Result<Vec<FileRecord>> {
     let rows = sqlx::query("SELECT * FROM files ORDER BY uploaded_at DESC")
         .fetch_all(pool)
@@ -1757,4 +1810,108 @@ pub async fn create_campaign_task(
     get_task(pool, id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("task not found after insert"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_pool() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str(":memory:")
+            .unwrap()
+            .foreign_keys(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .unwrap();
+        sqlx::raw_sql(INIT_SQL).execute(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn keyspace_cache_miss_returns_none() {
+        let pool = mem_pool().await;
+        let result = get_cached_keyspace(&pool, "abc", None, 1000).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn keyspace_cache_roundtrip_without_rules() {
+        let pool = mem_pool().await;
+        insert_cached_keyspace(&pool, "wl_sha", None, 1000, 42_000_000)
+            .await
+            .unwrap();
+        let result = get_cached_keyspace(&pool, "wl_sha", None, 1000)
+            .await
+            .unwrap();
+        assert_eq!(result, Some(42_000_000));
+    }
+
+    #[tokio::test]
+    async fn keyspace_cache_roundtrip_with_rules() {
+        let pool = mem_pool().await;
+        insert_cached_keyspace(&pool, "wl_sha", Some("rules_sha"), 1000, 99)
+            .await
+            .unwrap();
+        let result = get_cached_keyspace(&pool, "wl_sha", Some("rules_sha"), 1000)
+            .await
+            .unwrap();
+        assert_eq!(result, Some(99));
+    }
+
+    #[tokio::test]
+    async fn keyspace_cache_rules_vs_no_rules_are_different_entries() {
+        let pool = mem_pool().await;
+        insert_cached_keyspace(&pool, "wl", None, 1000, 10)
+            .await
+            .unwrap();
+        insert_cached_keyspace(&pool, "wl", Some("r"), 1000, 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            get_cached_keyspace(&pool, "wl", None, 1000).await.unwrap(),
+            Some(10)
+        );
+        assert_eq!(
+            get_cached_keyspace(&pool, "wl", Some("r"), 1000)
+                .await
+                .unwrap(),
+            Some(20)
+        );
+    }
+
+    #[tokio::test]
+    async fn keyspace_cache_hash_mode_partitions_keys() {
+        let pool = mem_pool().await;
+        insert_cached_keyspace(&pool, "wl", None, 1000, 10)
+            .await
+            .unwrap();
+        insert_cached_keyspace(&pool, "wl", None, 22000, 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            get_cached_keyspace(&pool, "wl", None, 1000).await.unwrap(),
+            Some(10)
+        );
+        assert_eq!(
+            get_cached_keyspace(&pool, "wl", None, 22000).await.unwrap(),
+            Some(20)
+        );
+    }
+
+    #[tokio::test]
+    async fn keyspace_cache_insert_is_idempotent() {
+        let pool = mem_pool().await;
+        insert_cached_keyspace(&pool, "wl", None, 1000, 10)
+            .await
+            .unwrap();
+        insert_cached_keyspace(&pool, "wl", None, 1000, 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            get_cached_keyspace(&pool, "wl", None, 1000).await.unwrap(),
+            Some(20)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
First slice of the big-file handling plan (see \`plans/nifty-booping-puddle.md\` in the working session — this PR lands changes without touching user-visible surface).

Two fixes bundled because they address the same pain:

1. **Keyspace cache** — new \`keyspace_cache\` SQLite table keyed by \`(wordlist_sha256, rules_sha256, hash_mode)\`. Dictionary / Dictionary+Rules attacks check the cache before running \`hashcat --keyspace\` (a linear file scan that takes ~3-5 min for 100 GB wordlists) and write back on miss. Brute-force attacks skip the cache — their keyspace is pure math inside hashcat and cheap.

2. **Non-blocking task prep** — monitor's \`prepare_pending_tasks\` used to await each task's keyspace computation inline, blocking heartbeats / health checks / chunk reassignment for the full duration of the scan. Now it spawns per task, tracked by an \`AppState::preparing_tasks\` dedup set to prevent double-spawn across ticks.

## Why now
Working toward making 100 GB wordlists viable end to end. This is the prerequisite: the other slices (streaming upload, content-addressed cache, lifecycle GC) all depend on hashing being keyed by sha256, and on task prep being non-blocking. Nothing user-visible changes in this PR.

## Scope
- \`storage/db.rs\` — new table in INIT_SQL, 2 new helpers (\`get_cached_keyspace\`, \`insert_cached_keyspace\`), 6 unit tests covering miss/hit/rules-partition/mode-partition/idempotency/round-trip
- \`scheduler/chunker.rs\` — \`compute_keyspace\` takes a \`pool\` param; new private helper \`sha256_for_file\`; cache lookup before hashcat, cache write on miss
- \`monitor.rs\` — \`prepare_pending_tasks\` spawns per task; extracted \`prepare_one\`; takes \`&Arc<AppState>\` so it can clone into spawns
- \`state.rs\` — new \`preparing_tasks: RwLock<HashSet<Uuid>>\` field on \`AppState\`

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all existing tests pass + 6 new tests (41 in crack-coord, was 35)
- [x] \`cargo audit\` — 0 findings
- [ ] CI Format / Clippy / Test / Security Audit all green
- [ ] Manual smoke after merge: run a dictionary task, verify the first run logs "computed dictionary keyspace" and the second logs "keyspace cache hit (dict)"

Auto-merge will queue this; no action needed once CI passes.