### PR TITLE
feat(coord): dedup uploads by sha256 content hash (Slice 2/11)

### DIFF
--- a/crates/crack-coord/src/api/files.rs
+++ b/crates/crack-coord/src/api/files.rs
@@ -5,6 +5,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use chrono::Utc;
+use tracing::info;
 
 use crack_common::models::FileRecord;
 
@@ -52,10 +53,32 @@ pub async fn upload_file(
     let (filename, data) =
         file_data.ok_or_else(|| ApiError::BadRequest("missing 'file' field".to_string()))?;
 
-    // Save to disk
+    // Save to disk (also computes sha256).
     let files_dir = state.files_dir();
     let (file_id, sha256) = files::save_file(&files_dir, &filename, &data)
         .map_err(|e| ApiError::Internal(format!("failed to save file: {e}")))?;
+
+    // Content dedup: if we already have a file with this sha256, drop the
+    // one we just wrote and return the existing record. Keeps the operator
+    // command identical (`crackctl file upload …`) while avoiding duplicate
+    // on-disk copies of the same content across re-uploads.
+    if let Some(existing) = db::find_file_by_sha256(&state.db, &sha256).await? {
+        if let Err(e) = files::delete_file(&files_dir, &file_id) {
+            // Not fatal — disk orphan will get picked up by future GC.
+            tracing::warn!(
+                file_id = %file_id,
+                error = %e,
+                "dedup: failed to remove newly-written duplicate from disk"
+            );
+        }
+        info!(
+            existing_id = %existing.id,
+            filename = %filename,
+            sha256 = %sha256,
+            "dedup: returning existing file record for matching sha256"
+        );
+        return Ok((StatusCode::OK, Json(existing)));
+    }
 
     // Build disk path for the record
     let disk_path = files_dir.join(&file_id).to_string_lossy().to_string();

--- a/crates/crack-coord/src/storage/db.rs
+++ b/crates/crack-coord/src/storage/db.rs
@@ -22,6 +22,11 @@ CREATE TABLE IF NOT EXISTS files (
     uploaded_at TEXT NOT NULL
 );
 
+-- Non-unique: any existing deployment with duplicate sha256 rows would
+-- otherwise refuse to start. Uniqueness is enforced at upload time by
+-- short-circuiting on a match; new duplicates can't be introduced.
+CREATE INDEX IF NOT EXISTS idx_files_sha256 ON files(sha256);
+
 CREATE TABLE IF NOT EXISTS tasks (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
@@ -1066,6 +1071,22 @@ pub async fn get_file_record(pool: &SqlitePool, id: &str) -> Result<Option<FileR
     }
 }
 
+/// Look up a file by its sha256 content hash. Returns the oldest matching
+/// row (by uploaded_at) when multiple exist — legacy deployments may have
+/// duplicates that predate the upload-dedup short-circuit.
+pub async fn find_file_by_sha256(pool: &SqlitePool, sha256: &str) -> Result<Option<FileRecord>> {
+    let row = sqlx::query("SELECT * FROM files WHERE sha256 = ?1 ORDER BY uploaded_at ASC LIMIT 1")
+        .bind(sha256)
+        .fetch_optional(pool)
+        .await
+        .context("fetching file record by sha256")?;
+
+    match row {
+        Some(ref r) => Ok(Some(row_to_file_record(r)?)),
+        None => Ok(None),
+    }
+}
+
 #[allow(dead_code)]
 pub async fn delete_file_record(pool: &SqlitePool, id: &str) -> Result<bool> {
     let result = sqlx::query("DELETE FROM files WHERE id = ?1")
@@ -1913,5 +1934,68 @@ mod tests {
             get_cached_keyspace(&pool, "wl", None, 1000).await.unwrap(),
             Some(20)
         );
+    }
+
+    fn sample_file_record(id: &str, sha: &str, uploaded_at: DateTime<Utc>) -> FileRecord {
+        FileRecord {
+            id: id.to_string(),
+            filename: format!("{id}.txt"),
+            file_type: "wordlist".to_string(),
+            size_bytes: 100,
+            sha256: sha.to_string(),
+            disk_path: format!("/tmp/{id}"),
+            uploaded_at,
+        }
+    }
+
+    #[tokio::test]
+    async fn find_file_by_sha256_returns_none_when_missing() {
+        let pool = mem_pool().await;
+        let result = find_file_by_sha256(&pool, "absent").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_file_by_sha256_finds_match() {
+        let pool = mem_pool().await;
+        let rec = sample_file_record("aaa-111", "deadbeef", Utc::now());
+        insert_file_record(&pool, &rec).await.unwrap();
+
+        let found = find_file_by_sha256(&pool, "deadbeef")
+            .await
+            .unwrap()
+            .expect("should have found match");
+        assert_eq!(found.id, "aaa-111");
+    }
+
+    #[tokio::test]
+    async fn find_file_by_sha256_returns_oldest_when_duplicates_exist() {
+        // Simulates a legacy deployment with two rows sharing a sha (the
+        // dedup index is non-unique so this can exist). The helper must
+        // pick the oldest, which is the canonical one the upload path
+        // short-circuits to.
+        let pool = mem_pool().await;
+        let older = sample_file_record(
+            "older-id",
+            "shared-sha",
+            DateTime::parse_from_rfc3339("2026-04-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        let newer = sample_file_record(
+            "newer-id",
+            "shared-sha",
+            DateTime::parse_from_rfc3339("2026-04-15T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        insert_file_record(&pool, &older).await.unwrap();
+        insert_file_record(&pool, &newer).await.unwrap();
+
+        let found = find_file_by_sha256(&pool, "shared-sha")
+            .await
+            .unwrap()
+            .expect("should have found match");
+        assert_eq!(found.id, "older-id");
     }
 }

--- a/crates/crack-coord/src/storage/files.rs
+++ b/crates/crack-coord/src/storage/files.rs
@@ -102,7 +102,6 @@ pub fn resolve_file_path(files_dir: &Path, file_id: &str) -> Result<PathBuf> {
 /// Delete a file from disk by its file_id.
 ///
 /// Tries the bare file_id first, then falls back to any file whose name starts with the file_id.
-#[allow(dead_code)]
 pub fn delete_file(files_dir: &Path, file_id: &str) -> Result<()> {
     // Try exact match first
     let exact = files_dir.join(file_id);


### PR DESCRIPTION
## Summary
Second slice of the big-file handling plan. The operator command (\`crackctl file upload <path>\`) is unchanged — re-uploading the same content now short-circuits and returns the existing file's ID instead of storing a second copy.

## Why
Existing behaviour: every upload generates a new UUID, a new disk file, and a new DB row — even when the bytes are identical to something already stored. Operators lose disk space across iterative engagement work (re-uploading the same potfile, wordlist, or hash dump).

This slice makes \`sha256\` the content key for uploads. Later slices (pull-based agent cache, reference-counted GC) rely on this.

## Scope
- \`storage/db.rs\` — non-unique \`idx_files_sha256\` index, \`find_file_by_sha256\` helper (returns oldest match), 3 new unit tests
- \`api/files.rs\` — upload handler checks \`find_file_by_sha256\` after \`save_file\`; on match, deletes the newly-written disk copy and returns the existing record with \`200 OK\` (vs \`201 Created\` for a fresh upload — dedup is observable to API callers if they care)
- \`storage/files.rs\` — \`delete_file\` loses its \`#[allow(dead_code)]\` attribute (now called)

## Why non-unique index
A \`UNIQUE\` index on \`sha256\` would fail at startup on any existing deployment that already has duplicate rows (init runs \`CREATE UNIQUE INDEX IF NOT EXISTS\` against an incompatible dataset). Since the short-circuit prevents new duplicates, the practical invariant holds going forward; legacy duplicates are grandfathered in. Promoting to \`UNIQUE\` is a future migration slice if we decide it's worth it.

## What doesn't change
- Upload path still loads the full file into memory. Streaming upload is Slice 3.
- No change to small-file behaviour: a dedup hit just saves a disk write.
- No data migration for legacy duplicates — they remain in the table untouched.

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 44 tests in crack-coord (was 41), all pass
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] Manual smoke: \`crackctl file upload X\`, note ID, \`crackctl file upload X\` again, confirm same ID returned and \`ls data/files\` has only one copy

Auto-merge queued.