### PR TITLE
feat(upload): stream bytes end-to-end with progress bar (Slice 3/11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +641,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tower-http",
  "tracing",
@@ -646,11 +659,14 @@ dependencies = [
  "chrono",
  "clap",
  "crack-common",
+ "futures-util",
+ "indicatif",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -952,6 +968,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1598,6 +1620,19 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -3850,6 +3885,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,13 @@ toml = "1"
 # Cross-platform
 dirs = "6"
 
+# Streaming utilities (for large-file upload paths)
+tokio-util = { version = "0.7", features = ["io"] }
+futures-util = "0.3"
+
+# Terminal UI (CLI progress bar on big uploads)
+indicatif = "0.18"
+
 # Internal crates
 crack-common = { path = "crates/crack-common" }
 crack-agent = { path = "crates/crack-agent" }

--- a/crates/crack-coord/Cargo.toml
+++ b/crates/crack-coord/Cargo.toml
@@ -36,3 +36,4 @@ toml = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 reqwest = { workspace = true }
+tokio-util = { workspace = true }

--- a/crates/crack-coord/src/api/files.rs
+++ b/crates/crack-coord/src/api/files.rs
@@ -18,10 +18,12 @@ pub async fn upload_file(
     State(state): State<Arc<AppState>>,
     mut multipart: Multipart,
 ) -> ApiResult<impl IntoResponse> {
-    let mut file_data: Option<(String, Vec<u8>)> = None;
-    let mut file_type = "hash".to_string();
+    let files_dir = state.files_dir();
 
-    while let Some(field) = multipart
+    let mut file_type = "hash".to_string();
+    let mut saved: Option<(String, String, u64, String)> = None; // (file_id, sha256, size, filename)
+
+    while let Some(mut field) = multipart
         .next_field()
         .await
         .map_err(|e| ApiError::BadRequest(format!("multipart error: {e}")))?
@@ -31,11 +33,42 @@ pub async fn upload_file(
         match field_name.as_str() {
             "file" => {
                 let filename = field.file_name().unwrap_or("upload").to_string();
-                let data = field
-                    .bytes()
+
+                // Stream the field straight to a `.partial` file while hashing
+                // incrementally. Nothing is buffered in RAM beyond the current
+                // chunk — supports arbitrary upload sizes bounded only by disk.
+                let mut writer = files::FileWriter::create(&files_dir, &filename)
                     .await
-                    .map_err(|e| ApiError::BadRequest(format!("failed to read file: {e}")))?;
-                file_data = Some((filename, data.to_vec()));
+                    .map_err(|e| {
+                        ApiError::Internal(format!("failed to open file for writing: {e}"))
+                    })?;
+
+                loop {
+                    match field.chunk().await {
+                        Ok(Some(chunk)) => {
+                            if let Err(e) = writer.write_chunk(&chunk).await {
+                                writer.abort().await;
+                                return Err(ApiError::Internal(format!(
+                                    "failed to write chunk: {e}"
+                                )));
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            writer.abort().await;
+                            return Err(ApiError::BadRequest(format!(
+                                "failed to read upload stream: {e}"
+                            )));
+                        }
+                    }
+                }
+
+                let (file_id, sha256, size) = writer
+                    .finalize()
+                    .await
+                    .map_err(|e| ApiError::Internal(format!("failed to finalize upload: {e}")))?;
+
+                saved = Some((file_id, sha256, size, filename));
             }
             "file_type" => {
                 let value = field
@@ -50,13 +83,8 @@ pub async fn upload_file(
         }
     }
 
-    let (filename, data) =
-        file_data.ok_or_else(|| ApiError::BadRequest("missing 'file' field".to_string()))?;
-
-    // Save to disk (also computes sha256).
-    let files_dir = state.files_dir();
-    let (file_id, sha256) = files::save_file(&files_dir, &filename, &data)
-        .map_err(|e| ApiError::Internal(format!("failed to save file: {e}")))?;
+    let (file_id, sha256, size_bytes, filename) =
+        saved.ok_or_else(|| ApiError::BadRequest("missing 'file' field".to_string()))?;
 
     // Content dedup: if we already have a file with this sha256, drop the
     // one we just wrote and return the existing record. Keeps the operator
@@ -88,7 +116,7 @@ pub async fn upload_file(
         id: file_id,
         filename,
         file_type,
-        size_bytes: data.len() as i64,
+        size_bytes: size_bytes as i64,
         sha256,
         disk_path,
         uploaded_at: Utc::now(),

--- a/crates/crack-coord/src/api/mod.rs
+++ b/crates/crack-coord/src/api/mod.rs
@@ -85,10 +85,13 @@ pub fn create_router(state: Arc<AppState>) -> Router {
                 .delete(tasks::delete_task),
         )
         .route("/api/v1/tasks/{id}/results", get(tasks::get_task_results))
-        // Files
+        // Files — uploads are streamed directly to disk, so the global
+        // 512 MiB limit doesn't apply. Disabled only on this route.
         .route(
             "/api/v1/files",
-            post(files::upload_file).get(files::list_files),
+            post(files::upload_file)
+                .get(files::list_files)
+                .layer(DefaultBodyLimit::disable()),
         )
         .route("/api/v1/files/{id}", get(files::download_file))
         // Workers

--- a/crates/crack-coord/src/storage/files.rs
+++ b/crates/crack-coord/src/storage/files.rs
@@ -2,7 +2,108 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
+
+/// Streaming writer for an incoming upload. Writes to a `.partial` companion
+/// file so a crash or error leaves no half-finished entry in the canonical
+/// name slot; only a successful `finalize()` does the atomic rename.
+///
+/// SHA-256 and size are computed incrementally as chunks arrive. Callers
+/// drive the write loop (no axum/multipart types here — storage stays
+/// transport-agnostic).
+pub struct FileWriter {
+    file_id: String,
+    partial_path: PathBuf,
+    final_path: PathBuf,
+    file: tokio::fs::File,
+    hasher: Sha256,
+    size: u64,
+}
+
+impl FileWriter {
+    pub async fn create(files_dir: &Path, filename: &str) -> Result<Self> {
+        tokio::fs::create_dir_all(files_dir)
+            .await
+            .with_context(|| format!("creating files directory: {}", files_dir.display()))?;
+
+        let file_id = Uuid::new_v4().to_string();
+
+        let ext = Path::new(filename)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+
+        let disk_name = if ext.is_empty() {
+            file_id.clone()
+        } else {
+            format!("{file_id}.{ext}")
+        };
+
+        let final_path = files_dir.join(&disk_name);
+        let partial_path = files_dir.join(format!("{disk_name}.partial"));
+
+        let file = tokio::fs::File::create(&partial_path)
+            .await
+            .with_context(|| format!("creating {}", partial_path.display()))?;
+
+        Ok(Self {
+            file_id,
+            partial_path,
+            final_path,
+            file,
+            hasher: Sha256::new(),
+            size: 0,
+        })
+    }
+
+    pub async fn write_chunk(&mut self, bytes: &[u8]) -> Result<()> {
+        self.file
+            .write_all(bytes)
+            .await
+            .with_context(|| format!("writing to {}", self.partial_path.display()))?;
+        self.hasher.update(bytes);
+        self.size += bytes.len() as u64;
+        Ok(())
+    }
+
+    /// Finish the upload: flush to disk, rename `.partial` to the final name,
+    /// and return `(file_id, sha256_hex, size_bytes)`.
+    pub async fn finalize(mut self) -> Result<(String, String, u64)> {
+        self.file
+            .flush()
+            .await
+            .with_context(|| format!("flushing {}", self.partial_path.display()))?;
+        drop(self.file);
+
+        let sha256 = format!("{:x}", self.hasher.finalize());
+
+        tokio::fs::rename(&self.partial_path, &self.final_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "renaming {} -> {}",
+                    self.partial_path.display(),
+                    self.final_path.display()
+                )
+            })?;
+
+        tracing::debug!(
+            file_id = %self.file_id,
+            size = self.size,
+            sha256 = %sha256,
+            "Saved file to disk (streaming)"
+        );
+
+        Ok((self.file_id, sha256, self.size))
+    }
+
+    /// Remove the `.partial` file if the upload was aborted. Best-effort; a
+    /// leftover `.partial` will be tolerated by future GC sweeps.
+    pub async fn abort(self) {
+        let _ = tokio::fs::remove_file(&self.partial_path).await;
+    }
+}
 
 /// Save file data to disk with a UUID-based filename.
 ///
@@ -129,4 +230,90 @@ pub fn delete_file(files_dir: &Path, file_id: &str) -> Result<()> {
         "file not found for deletion: {file_id} in {}",
         files_dir.display()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a unique scratch directory under the OS temp dir. Cleanup is
+    /// best-effort via `Drop` on the returned guard.
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!("crack-coord-test-{}", Uuid::new_v4()));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[tokio::test]
+    async fn file_writer_roundtrip_computes_sha_and_size() {
+        let dir = TempDir::new();
+        let mut writer = FileWriter::create(&dir.path, "sample.txt").await.unwrap();
+        writer.write_chunk(b"hello").await.unwrap();
+        writer.write_chunk(b" world").await.unwrap();
+        let (file_id, sha256, size) = writer.finalize().await.unwrap();
+
+        assert_eq!(size, 11);
+        // sha256("hello world")
+        assert_eq!(
+            sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+
+        let on_disk = resolve_file_path(&dir.path, &file_id).unwrap();
+        let data = std::fs::read(&on_disk).unwrap();
+        assert_eq!(data, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn file_writer_partial_is_renamed_on_finalize() {
+        let dir = TempDir::new();
+        let mut writer = FileWriter::create(&dir.path, "note.md").await.unwrap();
+        writer.write_chunk(b"x").await.unwrap();
+        let partial = writer.partial_path.clone();
+        assert!(partial.exists(), ".partial should exist during write");
+
+        writer.finalize().await.unwrap();
+        assert!(!partial.exists(), ".partial should be renamed on finalize");
+    }
+
+    #[tokio::test]
+    async fn file_writer_abort_removes_partial() {
+        let dir = TempDir::new();
+        let mut writer = FileWriter::create(&dir.path, "note.md").await.unwrap();
+        writer.write_chunk(b"abc").await.unwrap();
+        let partial = writer.partial_path.clone();
+        assert!(partial.exists());
+
+        writer.abort().await;
+        assert!(!partial.exists(), "abort should remove the .partial file");
+    }
+
+    #[tokio::test]
+    async fn file_writer_empty_upload_produces_empty_file() {
+        let dir = TempDir::new();
+        let writer = FileWriter::create(&dir.path, "empty.bin").await.unwrap();
+        let (file_id, sha256, size) = writer.finalize().await.unwrap();
+
+        assert_eq!(size, 0);
+        // sha256 of empty string
+        assert_eq!(
+            sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+
+        let on_disk = resolve_file_path(&dir.path, &file_id).unwrap();
+        assert_eq!(std::fs::metadata(&on_disk).unwrap().len(), 0);
+    }
 }

--- a/crates/crackctl/Cargo.toml
+++ b/crates/crackctl/Cargo.toml
@@ -22,3 +22,6 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
+futures-util = { workspace = true }
+indicatif = { workspace = true }

--- a/crates/crackctl/src/client.rs
+++ b/crates/crackctl/src/client.rs
@@ -2,7 +2,15 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use crack_common::models::*;
+use futures_util::stream::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
+use tokio_util::io::ReaderStream;
+
+/// Files this size or larger get a live progress bar on upload. Smaller
+/// files stream silently — same behaviour as before, just without the
+/// full-file-in-RAM read.
+const PROGRESS_THRESHOLD_BYTES: u64 = 100 * 1024 * 1024;
 
 // ── Types local to the CLI client ──
 
@@ -337,11 +345,43 @@ impl Client {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "upload".to_string());
 
-        let file_bytes = tokio::fs::read(path)
+        let file = tokio::fs::File::open(path)
             .await
-            .with_context(|| format!("failed to read file: {}", path.display()))?;
+            .with_context(|| format!("failed to open file: {}", path.display()))?;
+        let size = file
+            .metadata()
+            .await
+            .with_context(|| format!("stat failed for {}", path.display()))?
+            .len();
 
-        let file_part = reqwest::multipart::Part::bytes(file_bytes)
+        // A hidden progress bar still accepts `.inc(n)` calls without any
+        // output, so we can wire the stream once and let the threshold
+        // decide whether anything shows up on-screen.
+        let pb = if size >= PROGRESS_THRESHOLD_BYTES {
+            let bar = ProgressBar::new(size);
+            bar.set_style(
+                ProgressStyle::with_template(
+                    "{msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+            );
+            bar.set_message(format!("Uploading {file_name}"));
+            bar
+        } else {
+            ProgressBar::hidden()
+        };
+
+        let pb_for_stream = pb.clone();
+        let stream = ReaderStream::new(file).map(move |result| {
+            if let Ok(ref chunk) = result {
+                pb_for_stream.inc(chunk.len() as u64);
+            }
+            result
+        });
+
+        let body = reqwest::Body::wrap_stream(stream);
+        let file_part = reqwest::multipart::Part::stream_with_length(body, size)
             .file_name(file_name)
             .mime_str("application/octet-stream")
             .context("invalid MIME")?;
@@ -357,6 +397,8 @@ impl Client {
             .send()
             .await
             .context("failed to reach coordinator")?;
+
+        pb.finish_and_clear();
 
         let resp = Self::check(resp).await?;
         let record: FileRecord = resp.json().await.context("failed to parse file record")?;


### PR DESCRIPTION
## Summary
Third slice of the big-file handling plan. Upload path no longer buffers the full file in memory anywhere:

- **\`crackctl\`** opens the file, wraps it in a \`tokio_util::io::ReaderStream\`, feeds that through an \`indicatif\` progress bar for uploads ≥ 100 MiB, and hands it to \`reqwest::Body::wrap_stream\`. No more \`tokio::fs::read\`.
- **Coord multipart handler** calls \`field.chunk().await\` in a loop, writing each chunk straight to a \`.partial\` file via tokio's async \`write_all\`, with incremental sha256. On finalize: rename atomically to the canonical name. On any error: \`.partial\` is removed.
- **Axum body limit** lifted only on \`POST /api/v1/files\` (other routes still enforce 512 MiB).
- **Dedup from Slice 2 still fires** — the streaming writer reports the sha256 back, dedup check runs on that, and the newly-written file is removed if a match exists.

## Walls fixed
Of the 10 walls documented in \`plans/nifty-booping-puddle.md\`, this slice closes #1–#4 (CLI full-file read, 512 MiB HTTP cap, full-field buffer, in-memory SHA-256) and #8 (agent-side \`fs::read\`). Walls 5–7 remain — they're Slices 5–6 (pull RPC + content cache).

## New deps
- \`tokio-util = { version = "0.7", features = ["io"] }\` — for \`ReaderStream\`
- \`futures-util = "0.3"\` — for \`StreamExt::map\` on the progress-tap
- \`indicatif = "0.18"\` — for the upload progress bar

All three are widely-used, actively-maintained, zero-controversy crates.

## Operator-visible change
Exactly one thing: uploads ≥ 100 MiB now show a live progress bar. Everything else is silent.

\`\`\`
\$ crackctl file upload /data/big-wordlist.txt --type wordlist
Uploading big-wordlist.txt [=====>        ] 1.2 GB/5.0 GB (210 MB/s, 18s)
\`\`\`

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all pass (+4 new unit tests for \`FileWriter\`: roundtrip, partial rename, abort cleanup, empty upload)
- [x] \`cargo audit\` — 0 findings (482 crate deps now)
- [ ] CI green
- [ ] Manual smoke: \`truncate -s 5G /tmp/big\`, \`crackctl file upload /tmp/big --type wordlist\`, confirm progress bar renders, upload completes, \`ls -lh data/files/\` shows the file, sha256 matches
- [ ] Manual smoke: kill mid-upload, confirm only \`.partial\` exists (no half-written canonical file)
- [ ] Manual smoke: small upload (\`echo hi > /tmp/small.txt\`), confirm no progress bar renders

Auto-merge queued.