### PR TITLE
feat(upload): same-host hardlink fast path (Slice 4/11)

### DIFF
--- a/crates/crack-coord/src/api/files.rs
+++ b/crates/crack-coord/src/api/files.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::{Multipart, Path, State};
@@ -5,6 +6,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crack_common::models::FileRecord;
@@ -129,6 +131,131 @@ pub async fn upload_file(
 pub async fn list_files(State(state): State<Arc<AppState>>) -> ApiResult<Json<Vec<FileRecord>>> {
     let records = db::list_file_records(&state.db).await?;
     Ok(Json(records))
+}
+
+/// Returned by `GET /api/v1/server-info`. Clients use this to detect
+/// whether their upload source is on the same device as the coord's
+/// file store; on a match, they can request a hard-link instead of
+/// streaming bytes.
+#[derive(Serialize, Deserialize)]
+pub struct ServerInfo {
+    /// Absolute path to the coord's `files_dir` on disk.
+    pub files_dir: String,
+    /// Device ID of the files_dir's filesystem (0 on non-Unix platforms).
+    pub device_id: u64,
+}
+
+pub async fn server_info(State(state): State<Arc<AppState>>) -> ApiResult<Json<ServerInfo>> {
+    let files_dir = state.files_dir();
+    tokio::fs::create_dir_all(&files_dir).await?;
+    let device_id = device_id_of(&files_dir)?;
+    Ok(Json(ServerInfo {
+        files_dir: files_dir.to_string_lossy().to_string(),
+        device_id,
+    }))
+}
+
+#[derive(Deserialize)]
+pub struct HardlinkRequest {
+    /// Absolute path on the coord's local filesystem.
+    pub source_path: String,
+    pub file_type: String,
+    pub filename: String,
+}
+
+pub async fn hardlink_file(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<HardlinkRequest>,
+) -> ApiResult<impl IntoResponse> {
+    let source_path = PathBuf::from(&req.source_path);
+    if !source_path.is_absolute() {
+        return Err(ApiError::BadRequest(
+            "source_path must be absolute".to_string(),
+        ));
+    }
+
+    let files_dir = state.files_dir();
+    tokio::fs::create_dir_all(&files_dir).await?;
+
+    // Verify source is on the same device as files_dir (hard links can't
+    // cross filesystems), and that it's a regular file.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let source_meta = tokio::fs::metadata(&source_path)
+            .await
+            .map_err(|e| ApiError::BadRequest(format!("source not readable: {e}")))?;
+        if !source_meta.is_file() {
+            return Err(ApiError::BadRequest(
+                "source must be a regular file".to_string(),
+            ));
+        }
+        let files_meta = tokio::fs::metadata(&files_dir).await?;
+        if source_meta.dev() != files_meta.dev() {
+            return Err(ApiError::BadRequest(
+                "source is on a different device than files_dir".to_string(),
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = &source_path;
+        return Err(ApiError::BadRequest(
+            "hardlink fast path requires a Unix-like OS".to_string(),
+        ));
+    }
+
+    let (file_id, sha256, size_bytes) =
+        files::hard_link_from(&files_dir, &source_path, &req.filename)
+            .await
+            .map_err(|e| ApiError::Internal(format!("hard-link failed: {e}")))?;
+
+    // Dedup: if we already have this content, remove the newly-created link
+    // and return the existing record. The source file is untouched.
+    if let Some(existing) = db::find_file_by_sha256(&state.db, &sha256).await? {
+        if let Err(e) = files::delete_file(&files_dir, &file_id) {
+            tracing::warn!(
+                file_id = %file_id,
+                error = %e,
+                "dedup: failed to remove newly-created hardlink from disk"
+            );
+        }
+        info!(
+            existing_id = %existing.id,
+            filename = %req.filename,
+            sha256 = %sha256,
+            "dedup: returning existing file record for matching sha256 (hardlink path)"
+        );
+        return Ok((StatusCode::OK, Json(existing)));
+    }
+
+    let disk_path = files_dir.join(&file_id).to_string_lossy().to_string();
+    let record = FileRecord {
+        id: file_id,
+        filename: req.filename,
+        file_type: req.file_type,
+        size_bytes: size_bytes as i64,
+        sha256,
+        disk_path,
+        uploaded_at: Utc::now(),
+    };
+    db::insert_file_record(&state.db, &record).await?;
+    Ok((StatusCode::CREATED, Json(record)))
+}
+
+fn device_id_of(path: &std::path::Path) -> ApiResult<u64> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(path)
+            .map_err(|e| ApiError::Internal(format!("stat {}: {e}", path.display())))?;
+        Ok(meta.dev())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(0)
+    }
 }
 
 pub async fn download_file(

--- a/crates/crack-coord/src/api/mod.rs
+++ b/crates/crack-coord/src/api/mod.rs
@@ -93,7 +93,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
                 .get(files::list_files)
                 .layer(DefaultBodyLimit::disable()),
         )
+        .route("/api/v1/files/hardlink", post(files::hardlink_file))
         .route("/api/v1/files/{id}", get(files::download_file))
+        .route("/api/v1/server-info", get(files::server_info))
         // Workers
         .route("/api/v1/workers", get(workers::list_workers))
         .route("/api/v1/workers/authorize", post(workers::authorize_worker))

--- a/crates/crack-coord/src/storage/files.rs
+++ b/crates/crack-coord/src/storage/files.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use uuid::Uuid;
 
 /// Streaming writer for an incoming upload. Writes to a `.partial` companion
@@ -103,6 +103,74 @@ impl FileWriter {
     pub async fn abort(self) {
         let _ = tokio::fs::remove_file(&self.partial_path).await;
     }
+}
+
+/// Hard-link an existing file on the coord's filesystem into the file store
+/// without copying bytes. The caller is responsible for verifying the source
+/// is on the same device as `files_dir` (hard links can't cross filesystems).
+///
+/// sha256 is computed by streaming the linked file; returns `(file_id, sha256, size)`.
+pub async fn hard_link_from(
+    files_dir: &Path,
+    source_path: &Path,
+    filename: &str,
+) -> Result<(String, String, u64)> {
+    tokio::fs::create_dir_all(files_dir)
+        .await
+        .with_context(|| format!("creating files directory: {}", files_dir.display()))?;
+
+    let file_id = Uuid::new_v4().to_string();
+    let ext = Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    let disk_name = if ext.is_empty() {
+        file_id.clone()
+    } else {
+        format!("{file_id}.{ext}")
+    };
+    let dest = files_dir.join(&disk_name);
+
+    tokio::fs::hard_link(source_path, &dest)
+        .await
+        .with_context(|| {
+            format!(
+                "hard-linking {} -> {}",
+                source_path.display(),
+                dest.display()
+            )
+        })?;
+
+    // Stream sha256 of the linked content. No second on-disk copy, but we
+    // still have to read all bytes once to compute the hash.
+    let mut file = tokio::fs::File::open(&dest)
+        .await
+        .with_context(|| format!("opening hard-linked {}", dest.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut size: u64 = 0;
+    loop {
+        let n = file
+            .read(&mut buf)
+            .await
+            .with_context(|| format!("reading hard-linked {}", dest.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        size += n as u64;
+    }
+    let sha256 = format!("{:x}", hasher.finalize());
+
+    tracing::debug!(
+        file_id = %file_id,
+        source = %source_path.display(),
+        size,
+        sha256 = %sha256,
+        "Hard-linked file into store"
+    );
+
+    Ok((file_id, sha256, size))
 }
 
 /// Save file data to disk with a UUID-based filename.
@@ -315,5 +383,56 @@ mod tests {
 
         let on_disk = resolve_file_path(&dir.path, &file_id).unwrap();
         assert_eq!(std::fs::metadata(&on_disk).unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn hard_link_from_roundtrip_computes_sha_and_size() {
+        let dir = TempDir::new();
+        let source = dir.path.join("source.txt");
+        std::fs::write(&source, b"hello world").unwrap();
+
+        let files_dir = dir.path.join("store");
+        let (file_id, sha256, size) = hard_link_from(&files_dir, &source, "source.txt")
+            .await
+            .unwrap();
+
+        assert_eq!(size, 11);
+        assert_eq!(
+            sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+
+        let on_disk = resolve_file_path(&files_dir, &file_id).unwrap();
+        assert_eq!(std::fs::read(&on_disk).unwrap(), b"hello world");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hard_link_from_shares_inode_with_source() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = TempDir::new();
+        let source = dir.path.join("source.bin");
+        std::fs::write(&source, b"shared").unwrap();
+
+        let files_dir = dir.path.join("store");
+        let (file_id, _, _) = hard_link_from(&files_dir, &source, "source.bin")
+            .await
+            .unwrap();
+        let on_disk = resolve_file_path(&files_dir, &file_id).unwrap();
+
+        let src_inode = std::fs::metadata(&source).unwrap().ino();
+        let dst_inode = std::fs::metadata(&on_disk).unwrap().ino();
+        assert_eq!(
+            src_inode, dst_inode,
+            "hard link should share inode with source"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_link_from_missing_source_errors() {
+        let dir = TempDir::new();
+        let missing = dir.path.join("does-not-exist");
+        let result = hard_link_from(&dir.path, &missing, "x.txt").await;
+        assert!(result.is_err());
     }
 }

--- a/crates/crackctl/src/client.rs
+++ b/crates/crackctl/src/client.rs
@@ -74,6 +74,20 @@ struct AuthorizeWorkerPayload {
     pub name: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ServerInfo {
+    #[allow(dead_code)]
+    pub files_dir: String,
+    pub device_id: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct HardlinkPayload {
+    pub source_path: String,
+    pub file_type: String,
+    pub filename: String,
+}
+
 #[derive(Debug, Serialize)]
 struct EnrollWorkerPayload {
     pub name: String,
@@ -345,6 +359,14 @@ impl Client {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "upload".to_string());
 
+        // Same-host fast path: if the source file lives on the same
+        // filesystem as the coord's files_dir, ask the coord to hard-link
+        // it in place instead of transferring bytes.
+        #[cfg(unix)]
+        if let Some(record) = self.try_hardlink_upload(path, &file_name, file_type).await {
+            return Ok(record);
+        }
+
         let file = tokio::fs::File::open(path)
             .await
             .with_context(|| format!("failed to open file: {}", path.display()))?;
@@ -403,6 +425,77 @@ impl Client {
         let resp = Self::check(resp).await?;
         let record: FileRecord = resp.json().await.context("failed to parse file record")?;
         Ok(record)
+    }
+
+    /// Attempt the same-host fast path: if our local source file lives on
+    /// the same filesystem as the coord's files_dir, ask the coord to
+    /// hard-link it into the store instead of transferring bytes.
+    ///
+    /// Returns `Some(record)` on success, `None` on any failure —
+    /// non-success is always safe to interpret as "fall back to streaming
+    /// upload." This covers older coords (404 on server-info), non-Unix
+    /// clients, different filesystems, missing/unreadable files,
+    /// permission denied on hard-link, etc.
+    #[cfg(unix)]
+    async fn try_hardlink_upload(
+        &self,
+        path: &Path,
+        filename: &str,
+        file_type: &str,
+    ) -> Option<FileRecord> {
+        use std::os::unix::fs::MetadataExt;
+
+        let absolute = match path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => return None,
+        };
+        let source_meta = match tokio::fs::metadata(&absolute).await {
+            Ok(m) => m,
+            Err(_) => return None,
+        };
+        if !source_meta.is_file() {
+            return None;
+        }
+        let source_dev = source_meta.dev();
+
+        // Ask coord for its files_dir device id. If this endpoint doesn't
+        // exist (older coord), fall through to streaming.
+        let resp = self
+            .http
+            .get(self.url("/api/v1/server-info"))
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let server_info: ServerInfo = resp.json().await.ok()?;
+
+        // `device_id == 0` is the "not supported" sentinel the coord
+        // returns on non-Unix hosts, and is also extremely unlikely to
+        // coincidentally match a real device. Either way: skip the fast
+        // path.
+        if server_info.device_id == 0 || source_dev != server_info.device_id {
+            return None;
+        }
+
+        let payload = HardlinkPayload {
+            source_path: absolute.to_string_lossy().to_string(),
+            file_type: file_type.to_string(),
+            filename: filename.to_string(),
+        };
+
+        let resp = self
+            .http
+            .post(self.url("/api/v1/files/hardlink"))
+            .json(&payload)
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        resp.json::<FileRecord>().await.ok()
     }
 
     pub async fn list_files(&self) -> Result<Vec<FileRecord>> {


### PR DESCRIPTION
## Summary
When the operator runs \`crackctl\` on the same box as \`crack-coord\` (the most common single-server deployment, plus \`--with-agent\` dev setups), a \`crackctl file upload /data/rockyou2024.txt\` for a 100 GB file shouldn't actually transfer 100 GB — the file is already on the coord's filesystem. This slice detects that case and asks the coord to hard-link the file into its store instead of streaming bytes.

**Observable effect:** same-box uploads complete in ~50 ms instead of minutes. Everything else looks identical.

## How it works

**Client** (cfg(unix)):
1. \`canonicalize(source_path)\` to resolve symlinks
2. \`stat(source).st_dev\` → source device id
3. \`GET /api/v1/server-info\` → coord's \`{ files_dir, device_id }\`
4. If devices match: \`POST /api/v1/files/hardlink { source_path, file_type, filename }\`
5. Any failure (older coord without server-info, non-Unix client, different filesystem, permission denied, etc.) silently falls through to the streaming upload from Slice 3

**Coord**:
- \`GET /api/v1/server-info\`: returns \`files_dir\` absolute path + device_id (0 on non-Unix)
- \`POST /api/v1/files/hardlink\`: verifies source is a regular file on the same device, hard-links into \`files_dir/<uuid>.<ext>\`, streams sha256 over the linked file (no copy), runs the Slice-2 dedup short-circuit, returns \`FileRecord\`

## Security note
\`source_path\` is taken from client input and the coord opens it with its own privileges. This is deliberately loose because the REST API is bound to 127.0.0.1 — the client is the same trusted operator running the coord. Rejections:
- non-absolute paths
- non-regular files (no devices, sockets, FIFOs)
- source on a different device than \`files_dir\`

## Walls fixed
Wall #1 for the same-host case (CLI \`tokio::fs::read\`). Wall #2-#4 already fixed by Slice 3, remain so for remote uploads.

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 51 tests in crack-coord (was 48), all pass. +3 unit tests for \`hard_link_from\` (roundtrip, inode shared, missing source errors)
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] Manual smoke: same-box: \`truncate -s 5G /tmp/big\`, \`crackctl file upload /tmp/big\`, should return in < 1s. \`stat\` the file in \`data/files/\` and confirm the inode matches \`/tmp/big\`.
- [ ] Manual smoke: different-filesystem: put a file on a tmpfs mount, confirm client falls through to streaming upload.
- [ ] Manual smoke: symlinks are followed via \`canonicalize\` — linking to a real file on the same device works; to a file on a different device falls through.

Auto-merge queued.