### PR TITLE
feat(dispatch): DictionaryByHash — agents pull wordlists on demand (Slice 6/11)

### DIFF
--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -12,6 +12,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+use crate::cache::ContentCache;
 use crate::config::RunConfig;
 use crate::runner::{HashcatRunConfig, HashcatRunner, RunnerEvent};
 use crate::status;
@@ -239,6 +240,22 @@ async fn connect_and_run(
     let (runner_tx, mut runner_rx) = mpsc::channel::<(Uuid, Uuid, RunnerEvent)>(256);
     let mut heartbeat = tokio::time::interval(Duration::from_secs(15));
 
+    // Channel for WorkerMessages produced off-loop (e.g. by ContentCache
+    // pull tasks). The main loop drains this and writes to the Noise
+    // stream — we can't share `stream`/`transport` across tasks because
+    // snow's TransportState is `!Send`.
+    let (outbound_tx, mut outbound_rx) = mpsc::channel::<WorkerMessage>(64);
+
+    // Channel for "chunk is ready to run" events. When an AssignChunk
+    // arrives for DictionaryByHash we spawn a pull task that resolves
+    // the wordlist/rules paths via the ContentCache; once paths are
+    // ready, the task posts here and the main loop starts hashcat.
+    let (ready_tx, mut ready_rx) = mpsc::channel::<PendingChunk>(16);
+
+    // Content-addressed file cache for pull-based dispatch. Cheap to
+    // clone (Arc inside).
+    let content_cache = ContentCache::new(config.cache_dir());
+
     // Track running chunks: chunk_id -> kill signal sender (at most one at a time)
     let mut active_chunks: HashMap<Uuid, oneshot::Sender<()>> = HashMap::new();
     // Track chunk -> task mapping (reserved for future use, e.g. reconnection)
@@ -255,11 +272,15 @@ async fn connect_and_run(
             Heartbeat,
             RunnerEvent(Uuid, Uuid, RunnerEvent),
             TcpReadable,
+            OutboundMessage(WorkerMessage),
+            ChunkReady(PendingChunk),
         }
 
         let action = tokio::select! {
             _ = heartbeat.tick() => Action::Heartbeat,
             Some((cid, tid, ev)) = runner_rx.recv() => Action::RunnerEvent(cid, tid, ev),
+            Some(m) = outbound_rx.recv() => Action::OutboundMessage(m),
+            Some(pc) = ready_rx.recv() => Action::ChunkReady(pc),
             result = stream.readable() => {
                 result.context("TCP stream error")?;
                 Action::TcpReadable
@@ -309,6 +330,34 @@ async fn connect_and_run(
                         )
                         .await?;
                     }
+                }
+            }
+
+            Action::OutboundMessage(m) => {
+                // Message produced off-loop (e.g. by a ContentCache pull task).
+                send_message(&mut stream, &mut transport, &m).await?;
+            }
+
+            Action::ChunkReady(pending) => {
+                if active_chunks.is_empty() {
+                    start_hashcat(
+                        &pending.run_config,
+                        pending.chunk_id,
+                        pending.task_id,
+                        &mut stream,
+                        &mut transport,
+                        &mut active_chunks,
+                        &mut _chunk_task,
+                        &runner_tx,
+                    )
+                    .await?;
+                } else {
+                    info!(
+                        chunk_id = %pending.chunk_id,
+                        queue_len = pending_queue.len() + 1,
+                        "queuing resolved chunk (another hashcat is running)"
+                    );
+                    pending_queue.push_back(pending);
                 }
             }
 
@@ -428,6 +477,7 @@ async fn connect_and_run(
                             AssignChunkAttack::DictionaryWithRules { .. } => {
                                 "dict+rules".to_string()
                             }
+                            AssignChunkAttack::DictionaryByHash { .. } => "dict+hash".to_string(),
                         };
 
                         info!(
@@ -456,6 +506,98 @@ async fn connect_and_run(
                         let outfile_path = config.cache_dir().join(format!("out_{chunk_id}.txt"));
 
                         let cache_dir = config.cache_dir();
+
+                        // DictionaryByHash needs async file resolution via the
+                        // content cache — that can't run on the main loop (it
+                        // has to send RequestFileRange and consume FileRange
+                        // responses from this very loop). Spawn a task that
+                        // resolves paths and hands the ready chunk back via
+                        // ready_tx.
+                        if let AssignChunkAttack::DictionaryByHash {
+                            wordlist_sha256,
+                            wordlist_size,
+                            rules_sha256,
+                            rules_size,
+                        } = attack
+                        {
+                            let cache = content_cache.clone();
+                            let outbound = outbound_tx.clone();
+                            let ready = ready_tx.clone();
+                            let hashcat_path = config.hashcat_path.clone();
+                            tokio::spawn(async move {
+                                let wordlist_path = match cache
+                                    .ensure(&wordlist_sha256, wordlist_size, &outbound)
+                                    .await
+                                {
+                                    Ok(p) => p,
+                                    Err(e) => {
+                                        error!(
+                                            %chunk_id,
+                                            error = %e,
+                                            "failed to fetch wordlist for DictionaryByHash"
+                                        );
+                                        let _ = outbound
+                                            .send(WorkerMessage::ChunkFailed {
+                                                chunk_id,
+                                                error: format!("fetch wordlist: {e}"),
+                                                exit_code: None,
+                                            })
+                                            .await;
+                                        return;
+                                    }
+                                };
+
+                                let rules_path = match rules_sha256 {
+                                    Some(rs) => {
+                                        let rz = rules_size.unwrap_or(0);
+                                        match cache.ensure(&rs, rz, &outbound).await {
+                                            Ok(p) => Some(p),
+                                            Err(e) => {
+                                                error!(
+                                                    %chunk_id,
+                                                    error = %e,
+                                                    "failed to fetch rules for DictionaryByHash"
+                                                );
+                                                let _ = outbound
+                                                    .send(WorkerMessage::ChunkFailed {
+                                                        chunk_id,
+                                                        error: format!("fetch rules: {e}"),
+                                                        exit_code: None,
+                                                    })
+                                                    .await;
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    None => None,
+                                };
+
+                                let run_config = HashcatRunConfig {
+                                    hashcat_path,
+                                    hash_file_path,
+                                    hash_mode,
+                                    attack_mode: 0,
+                                    mask: None,
+                                    skip,
+                                    limit,
+                                    custom_charsets: None,
+                                    wordlist_path: Some(wordlist_path),
+                                    rules_path,
+                                    extra_args,
+                                    outfile_path,
+                                };
+
+                                let _ = ready
+                                    .send(PendingChunk {
+                                        chunk_id,
+                                        task_id,
+                                        run_config,
+                                    })
+                                    .await;
+                            });
+                            continue;
+                        }
+
                         let run_config = match attack {
                             AssignChunkAttack::BruteForce {
                                 mask,
@@ -507,6 +649,9 @@ async fn connect_and_run(
                                 extra_args,
                                 outfile_path,
                             },
+                            AssignChunkAttack::DictionaryByHash { .. } => {
+                                unreachable!("handled via early-return + spawn above")
+                            }
                         };
 
                         // Only run one hashcat at a time to avoid GPU contention.
@@ -569,17 +714,23 @@ async fn connect_and_run(
                         return Ok(());
                     }
 
-                    // Pull-based file fetch responses (Slice 5 plumbing). Wiring
-                    // into ContentCache lands in Slice 6; for now these arrive
-                    // only if the agent speculatively requested a range, which
-                    // it doesn't yet.
+                    // Pull-based file fetch responses. Forward to the content
+                    // cache's pending-pull registry; any in-flight `ensure()`
+                    // keyed by this hash will pick it up.
                     CoordMessage::FileRange {
-                        hash, offset, eof, ..
+                        hash,
+                        offset,
+                        data_b64,
+                        eof,
                     } => {
-                        debug!(%hash, offset, eof, "received FileRange (no pending ensure yet)");
+                        debug!(%hash, offset, eof, "received FileRange");
+                        content_cache
+                            .on_file_range(&hash, offset, &data_b64, eof)
+                            .await;
                     }
                     CoordMessage::FileError { hash, reason } => {
-                        debug!(%hash, %reason, "received FileError (no pending ensure yet)");
+                        debug!(%hash, %reason, "received FileError");
+                        content_cache.on_file_error(&hash, reason).await;
                     }
                 }
             }

--- a/crates/crack-common/src/protocol.rs
+++ b/crates/crack-common/src/protocol.rs
@@ -67,12 +67,23 @@ pub enum AssignChunkAttack {
         mask: String,
         custom_charsets: Option<Vec<String>>,
     },
-    Dictionary {
-        wordlist_file_id: String,
-    },
+    /// Legacy: agent receives the wordlist bytes eagerly via TransferFileChunk
+    /// before this message. Kept for backwards compatibility; new coord
+    /// code prefers `DictionaryByHash` for dictionary attacks.
+    Dictionary { wordlist_file_id: String },
+    /// Legacy: same as `Dictionary` but with a rules file also pushed eagerly.
     DictionaryWithRules {
         wordlist_file_id: String,
         rules_file_id: String,
+    },
+    /// Pull-based dispatch: the agent looks up the referenced files in its
+    /// content-addressed cache by sha256; on miss, it fetches them via
+    /// `RequestFileRange`/`FileRange` from the coord. No eager push.
+    DictionaryByHash {
+        wordlist_sha256: String,
+        wordlist_size: u64,
+        rules_sha256: Option<String>,
+        rules_size: Option<u64>,
     },
 }
 
@@ -615,6 +626,48 @@ mod tests {
         let buf = too_large.to_be_bytes();
         let result: crate::error::Result<Option<(CoordMessage, usize)>> = decode_message(&buf);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn roundtrip_assign_chunk_dict_by_hash() {
+        let chunk_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+        let msg = CoordMessage::AssignChunk {
+            chunk_id,
+            task_id,
+            hash_mode: 0,
+            hash_file_b64: "aGY=".to_string(),
+            hash_file_id: "hf-099".to_string(),
+            skip: 0,
+            limit: 12345,
+            attack: AssignChunkAttack::DictionaryByHash {
+                wordlist_sha256: "a1b2c3".to_string(),
+                wordlist_size: 1_234_567,
+                rules_sha256: Some("deadbeef".to_string()),
+                rules_size: Some(9876),
+            },
+            extra_args: vec![],
+        };
+        let encoded = encode_message(&msg).unwrap();
+        let (decoded, consumed): (CoordMessage, usize) = decode_message(&encoded).unwrap().unwrap();
+        assert_eq!(consumed, encoded.len());
+        match decoded {
+            CoordMessage::AssignChunk { attack, .. } => match attack {
+                AssignChunkAttack::DictionaryByHash {
+                    wordlist_sha256,
+                    wordlist_size,
+                    rules_sha256,
+                    rules_size,
+                } => {
+                    assert_eq!(wordlist_sha256, "a1b2c3");
+                    assert_eq!(wordlist_size, 1_234_567);
+                    assert_eq!(rules_sha256.as_deref(), Some("deadbeef"));
+                    assert_eq!(rules_size, Some(9876));
+                }
+                other => panic!("expected DictionaryByHash, got {other:?}"),
+            },
+            other => panic!("expected AssignChunk, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/crack-coord/src/monitor.rs
+++ b/crates/crack-coord/src/monitor.rs
@@ -269,7 +269,8 @@ async fn reassign_abandoned_chunks(state: &AppState) -> anyhow::Result<()> {
                     error!(task_id = %task.id, error = %e, "failed to transfer attack files for dispatch");
                     continue;
                 }
-                match crate::transport::handler::build_assign_chunk_msg(state, &task, &chunk) {
+                match crate::transport::handler::build_assign_chunk_msg(state, &task, &chunk).await
+                {
                     Ok(msg) => {
                         let _ = conn.tx.send(msg).await;
                     }

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -453,7 +453,7 @@ async fn handle_worker_message(
             if let Some(wid) = worker_id.as_deref() {
                 if let Some((task, new_chunk)) = scheduler::assign_next_chunk(state, wid).await? {
                     send_attack_files(state, &task, outbound_tx, transferred_files).await?;
-                    let msg = build_assign_chunk_msg(state, &task, &new_chunk)?;
+                    let msg = build_assign_chunk_msg(state, &task, &new_chunk).await?;
                     let _ = outbound_tx.send(msg).await;
                 } else {
                     db::update_worker_status(&state.db, wid, WorkerStatus::Idle).await?;
@@ -736,7 +736,14 @@ async fn handle_register(
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Build a CoordMessage::AssignChunk with the hash file data embedded.
-pub(crate) fn build_assign_chunk_msg(
+///
+/// For dictionary-based attacks, emits `DictionaryByHash` whenever we can
+/// look up the referenced file's sha256 + size (the common case). The
+/// agent then pulls the file from its content cache on demand. Falls
+/// back to the legacy `Dictionary` / `DictionaryWithRules` push path
+/// only if a file record is missing or has no sha — effectively never,
+/// for files uploaded via this coord.
+pub(crate) async fn build_assign_chunk_msg(
     state: &AppState,
     task: &Task,
     chunk: &Chunk,
@@ -749,16 +756,50 @@ pub(crate) fn build_assign_chunk_msg(
             mask: mask.clone(),
             custom_charsets: custom_charsets.clone(),
         },
-        AttackConfig::Dictionary { wordlist_file_id } => AssignChunkAttack::Dictionary {
-            wordlist_file_id: wordlist_file_id.clone(),
-        },
+        AttackConfig::Dictionary { wordlist_file_id } => {
+            match file_ref(&state.db, wordlist_file_id).await? {
+                Some((sha, size)) => AssignChunkAttack::DictionaryByHash {
+                    wordlist_sha256: sha,
+                    wordlist_size: size,
+                    rules_sha256: None,
+                    rules_size: None,
+                },
+                None => {
+                    warn!(file_id = %wordlist_file_id, "no sha256 for wordlist, falling back to legacy Dictionary push");
+                    AssignChunkAttack::Dictionary {
+                        wordlist_file_id: wordlist_file_id.clone(),
+                    }
+                }
+            }
+        }
         AttackConfig::DictionaryWithRules {
             wordlist_file_id,
             rules_file_id,
-        } => AssignChunkAttack::DictionaryWithRules {
-            wordlist_file_id: wordlist_file_id.clone(),
-            rules_file_id: rules_file_id.clone(),
-        },
+        } => {
+            let wl = file_ref(&state.db, wordlist_file_id).await?;
+            let rl = file_ref(&state.db, rules_file_id).await?;
+            match (wl, rl) {
+                (Some((w_sha, w_size)), Some((r_sha, r_size))) => {
+                    AssignChunkAttack::DictionaryByHash {
+                        wordlist_sha256: w_sha,
+                        wordlist_size: w_size,
+                        rules_sha256: Some(r_sha),
+                        rules_size: Some(r_size),
+                    }
+                }
+                _ => {
+                    warn!(
+                        wordlist = %wordlist_file_id,
+                        rules = %rules_file_id,
+                        "no sha256 for wordlist/rules, falling back to legacy DictionaryWithRules push"
+                    );
+                    AssignChunkAttack::DictionaryWithRules {
+                        wordlist_file_id: wordlist_file_id.clone(),
+                        rules_file_id: rules_file_id.clone(),
+                    }
+                }
+            }
+        }
     };
 
     // Read the hash file and base64-encode it for transfer over the Noise channel.
@@ -777,6 +818,18 @@ pub(crate) fn build_assign_chunk_msg(
         attack,
         extra_args: task.extra_args.clone(),
     })
+}
+
+/// Look up a file's (sha256, size_bytes) by UUID. Returns None if the record
+/// is missing, or if sha256 is empty (would pollute the content cache).
+async fn file_ref(pool: &sqlx::SqlitePool, file_id: &str) -> anyhow::Result<Option<(String, u64)>> {
+    Ok(db::get_file_record(pool, file_id).await?.and_then(|r| {
+        if r.sha256.is_empty() || r.size_bytes < 0 {
+            None
+        } else {
+            Some((r.sha256, r.size_bytes as u64))
+        }
+    }))
 }
 
 /// Stream a file to a worker in ~40KB chunks via TransferFileChunk messages.
@@ -835,14 +888,18 @@ async fn try_assign_work(
 ) -> anyhow::Result<()> {
     if let Some((task, chunk)) = scheduler::assign_next_chunk(state, wid).await? {
         send_attack_files(state, &task, outbound_tx, transferred_files).await?;
-        let msg = build_assign_chunk_msg(state, &task, &chunk)?;
+        let msg = build_assign_chunk_msg(state, &task, &chunk).await?;
         let _ = outbound_tx.send(msg).await;
     }
     Ok(())
 }
 
-/// If the task uses a dictionary or dictionary+rules attack, transfer the
-/// wordlist and rules files to the worker before sending the chunk assignment.
+/// Transfer referenced attack files to the worker before dispatching a chunk.
+///
+/// When every file has a sha256 recorded, we skip the push entirely — the
+/// agent will pull on demand via the content-addressed cache when it sees
+/// `DictionaryByHash`. The eager `TransferFileChunk` path remains only for
+/// the legacy fallback where a file has no sha (pre-dedup rows).
 async fn send_attack_files(
     state: &AppState,
     task: &Task,
@@ -851,12 +908,20 @@ async fn send_attack_files(
 ) -> anyhow::Result<()> {
     match &task.attack_config {
         AttackConfig::Dictionary { wordlist_file_id } => {
+            if file_ref(&state.db, wordlist_file_id).await?.is_some() {
+                return Ok(());
+            }
             send_file_to_worker(state, wordlist_file_id, outbound_tx, transferred_files).await?;
         }
         AttackConfig::DictionaryWithRules {
             wordlist_file_id,
             rules_file_id,
         } => {
+            let both_hashed = file_ref(&state.db, wordlist_file_id).await?.is_some()
+                && file_ref(&state.db, rules_file_id).await?.is_some();
+            if both_hashed {
+                return Ok(());
+            }
             send_file_to_worker(state, wordlist_file_id, outbound_tx, transferred_files).await?;
             send_file_to_worker(state, rules_file_id, outbound_tx, transferred_files).await?;
         }


### PR DESCRIPTION
## Summary
The slice that flips dispatch over to the pull model. When a task runs a dictionary attack, the coord now emits \`DictionaryByHash\` instead of the legacy \`Dictionary\` / \`DictionaryWithRules\` variants; the agent resolves the wordlist and rules paths via \`ContentCache::ensure()\` (pulling by sha256 if not cached) before starting hashcat.

First user-visible effect of the big-file plan: **running a dictionary task with a fresh agent now fetches the wordlist by sha256 once, caches it under \`<data_dir>/cache/cas/<hh>/<hash>\`, and re-uses it across all subsequent tasks with zero fetch.**

## Architecture change
The agent's main loop was \`!Send\` (snow's TransportState), so any long-running async work had to happen on the same task as the stream reader. That deadlocked with the pull model: \`ensure()\` sends \`RequestFileRange\` and awaits \`FileRange\`, which arrives on the same loop.

Solution:
- Added an \`outbound_tx\` mpsc channel. Off-loop tasks can post \`WorkerMessage\` into it; the main loop drains and writes to the stream.
- Added a \`ready_tx\` mpsc channel for "resolved chunks." When an \`AssignChunk\` arrives with \`DictionaryByHash\`, the main loop spawns a task that calls \`cache.ensure()\` and posts a \`PendingChunk\` to \`ready_tx\`. The main loop picks it up via a new \`Action::ChunkReady\` arm and either starts hashcat or queues.
- \`FileRange\` / \`FileError\` arms forward to \`content_cache.on_file_range\` / \`on_file_error\` so the in-flight \`ensure()\` loop sees them.

## Changes
- **Protocol** (\`crack-common/src/protocol.rs\`): added \`AssignChunkAttack::DictionaryByHash { wordlist_sha256, wordlist_size, rules_sha256, rules_size }\`. Legacy variants stay for backwards compat. Round-trip test.
- **Coord** (\`transport/handler.rs\`): \`build_assign_chunk_msg\` is now async; looks up \`(sha256, size)\` for wordlist + rules via a new \`file_ref\` helper; emits \`DictionaryByHash\` when both are known. \`send_attack_files\` skips the eager \`TransferFileChunk\` push for the same case.
- **Coord** (\`monitor.rs\`): one call site updated to \`.await\` the now-async builder.
- **Agent** (\`connection.rs\`): new outbound + ready channels + action variants; \`DictionaryByHash\` spawns a pull task; \`FileRange\`/\`FileError\` wired into cache.
- **No new deps, no schema changes.**

## Backwards compat
Legacy \`Dictionary\` / \`DictionaryWithRules\` are still accepted by the agent and still emitted by the coord *only* when sha256 isn't on record — effectively never, since \`save_file\` has always set sha256. The legacy push path is kept for safety but never exercised in practice.

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all pass (+1 DictionaryByHash protocol round-trip test). Cache tests from Slice 5 still green (they use the same code path the agent now wires up).
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] **Manual smoke** — this is the first slice with end-to-end behavior change. Steps:
  1. \`crack-coord run --with-agent\` fresh data-dir
  2. Upload a small wordlist: \`crackctl file upload /some/wordlist.txt --type wordlist\`
  3. Upload a hash file and create a dictionary task
  4. Observe agent's \`data_dir/cache/cas/<hh>/<hash>\` populates as task runs
  5. Confirm hashcat completes and cracks appear
  6. Run a *second* task with the same wordlist — confirm \`cache hit\` (no new \`RequestFileRange\` messages in logs)

Auto-merge queued.