### PR TITLE
feat(eviction): agent-side EvictFile + cache-manifest heartbeat (Slice 8/11)

### DIFF
--- a/crates/crack-agent/src/cache.rs
+++ b/crates/crack-agent/src/cache.rs
@@ -21,7 +21,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use base64::engine::general_purpose;
 use base64::Engine as _;
-use crack_common::protocol::WorkerMessage;
+use chrono::{DateTime, Utc};
+use crack_common::protocol::{CacheManifestEntry, WorkerMessage};
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::{mpsc, Mutex};
@@ -238,6 +239,74 @@ impl ContentCache {
         Ok(())
     }
 
+    /// Walk `<root>/cas/<hh>/<hash>` and return a compact digest of every
+    /// valid cached file. Entries the agent considers incomplete (missing,
+    /// unreadable, zero-byte `.partial` leftovers) are skipped. Called on
+    /// every heartbeat tick so the coord can reconcile its view.
+    pub async fn manifest(&self) -> Vec<CacheManifestEntry> {
+        let cas_root = self.root.join("cas");
+        let mut out = Vec::new();
+        let mut shard_entries = match tokio::fs::read_dir(&cas_root).await {
+            Ok(d) => d,
+            Err(_) => return out,
+        };
+        while let Ok(Some(shard)) = shard_entries.next_entry().await {
+            let shard_path = shard.path();
+            if !shard_path.is_dir() {
+                continue;
+            }
+            let mut files_iter = match tokio::fs::read_dir(&shard_path).await {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            while let Ok(Some(entry)) = files_iter.next_entry().await {
+                let name = entry.file_name();
+                let name_str = match name.to_str() {
+                    Some(s) => s,
+                    None => continue,
+                };
+                // Skip in-progress partials — they aren't cache entries yet.
+                if name_str.ends_with(".partial") {
+                    continue;
+                }
+                let meta = match entry.metadata().await {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                if !meta.is_file() {
+                    continue;
+                }
+                let last_used_at = meta
+                    .modified()
+                    .ok()
+                    .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| {
+                        DateTime::<Utc>::from_timestamp(d.as_secs() as i64, d.subsec_nanos())
+                            .unwrap_or_else(Utc::now)
+                            .to_rfc3339()
+                    })
+                    .unwrap_or_else(|| Utc::now().to_rfc3339());
+                out.push(CacheManifestEntry {
+                    sha256: name_str.to_string(),
+                    size_bytes: meta.len(),
+                    last_used_at,
+                });
+            }
+        }
+        out
+    }
+
+    /// Best-effort removal of a cached file. Returns true if the canonical
+    /// entry was deleted (we also sweep any stale `.partial`). A missing
+    /// file is not an error — it means the cache was already clean.
+    pub async fn evict(&self, hash: &str) -> bool {
+        let final_path = self.path_for(hash);
+        let partial = final_path.with_extension("partial");
+        let removed_final = tokio::fs::remove_file(&final_path).await.is_ok();
+        let _ = tokio::fs::remove_file(&partial).await;
+        removed_final
+    }
+
     /// Hook for the agent's message dispatcher: forward an incoming
     /// `CoordMessage::FileRange` to the matching in-flight `ensure()`.
     /// `data_b64` is the base64 payload as wired.
@@ -442,5 +511,82 @@ mod tests {
         let err = cache.ensure(&fake_hash, 10, &tx).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("file not found"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn manifest_returns_empty_when_no_cache_dir() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone());
+        let m = cache.manifest().await;
+        assert!(m.is_empty());
+    }
+
+    #[tokio::test]
+    async fn manifest_lists_cached_files_with_size() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone());
+
+        // Seed two entries directly on disk (as a successful pull would).
+        let data_a = vec![0u8; 123];
+        let data_b = vec![1u8; 456];
+        let hash_a = sha256_hex(&data_a);
+        let hash_b = sha256_hex(&data_b);
+        for (hash, data) in [(&hash_a, &data_a), (&hash_b, &data_b)] {
+            let p = cache.path_for(hash);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, data).unwrap();
+        }
+
+        let mut entries = cache.manifest().await;
+        entries.sort_by(|a, b| a.sha256.cmp(&b.sha256));
+        assert_eq!(entries.len(), 2);
+        let by_hash: std::collections::HashMap<_, _> = entries
+            .into_iter()
+            .map(|e| (e.sha256, e.size_bytes))
+            .collect();
+        assert_eq!(by_hash.get(&hash_a).copied(), Some(123));
+        assert_eq!(by_hash.get(&hash_b).copied(), Some(456));
+    }
+
+    #[tokio::test]
+    async fn manifest_ignores_partial_files() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone());
+        let data = b"done".to_vec();
+        let hash = sha256_hex(&data);
+        let p = cache.path_for(&hash);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, &data).unwrap();
+        // Stray .partial from an aborted pull.
+        std::fs::write(p.with_extension("partial"), b"halfway").unwrap();
+
+        let entries = cache.manifest().await;
+        assert_eq!(entries.len(), 1, ".partial must not appear in manifest");
+        assert_eq!(entries[0].sha256, hash);
+    }
+
+    #[tokio::test]
+    async fn evict_removes_cached_file_and_partial() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone());
+        let data = b"gone".to_vec();
+        let hash = sha256_hex(&data);
+        let p = cache.path_for(&hash);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, &data).unwrap();
+        std::fs::write(p.with_extension("partial"), b"stale").unwrap();
+
+        let removed = cache.evict(&hash).await;
+        assert!(removed);
+        assert!(!p.exists());
+        assert!(!p.with_extension("partial").exists());
+    }
+
+    #[tokio::test]
+    async fn evict_missing_file_returns_false_without_error() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone());
+        let removed = cache.evict("nonexistent-hash").await;
+        assert!(!removed);
     }
 }

--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -23,6 +23,30 @@ struct PendingChunk {
     chunk_id: Uuid,
     task_id: Uuid,
     run_config: HashcatRunConfig,
+    /// sha256s this chunk is currently using from the content cache. The
+    /// main loop tracks these so an incoming `EvictFile` for one of these
+    /// hashes defers until the chunk finishes.
+    cache_holds: Vec<String>,
+}
+
+/// Record that `pending.chunk_id` is currently using every sha in
+/// `pending.cache_holds`. Called on `ChunkReady` before the chunk runs or
+/// is queued; matching release happens on chunk terminal state.
+fn register_cache_holds(
+    pending: &PendingChunk,
+    running_chunks_using: &mut HashMap<String, HashSet<Uuid>>,
+    chunk_cache_holds: &mut HashMap<Uuid, Vec<String>>,
+) {
+    if pending.cache_holds.is_empty() {
+        return;
+    }
+    for sha in &pending.cache_holds {
+        running_chunks_using
+            .entry(sha.clone())
+            .or_default()
+            .insert(pending.chunk_id);
+    }
+    chunk_cache_holds.insert(pending.chunk_id, pending.cache_holds.clone());
 }
 
 /// Maximum Noise transport message (plaintext side). 64 KiB is well within
@@ -263,6 +287,16 @@ async fn connect_and_run(
     // Queue for chunks waiting to run (serialized: only one hashcat at a time)
     let mut pending_queue: VecDeque<PendingChunk> = VecDeque::new();
 
+    // Per-hash set of chunk IDs currently using the cached file. EvictFile
+    // defers while this is non-empty for the target hash.
+    let mut running_chunks_using: HashMap<String, HashSet<Uuid>> = HashMap::new();
+    // Reverse map: chunk_id -> sha256s it holds. On chunk completion we
+    // drop the chunk from each hash's set and drain pending_evictions.
+    let mut chunk_cache_holds: HashMap<Uuid, Vec<String>> = HashMap::new();
+    // Hashes the coord has asked us to evict but couldn't be removed yet
+    // because a chunk was still using them.
+    let mut pending_evictions: HashSet<String> = HashSet::new();
+
     loop {
         // We use `stream.readable()` in the select to detect when there is
         // data to read, without actually borrowing `stream` mutably.  After
@@ -289,7 +323,13 @@ async fn connect_and_run(
 
         match action {
             Action::Heartbeat => {
-                send_message(&mut stream, &mut transport, &WorkerMessage::Heartbeat).await?;
+                let cache_manifest = content_cache.manifest().await;
+                send_message(
+                    &mut stream,
+                    &mut transport,
+                    &WorkerMessage::Heartbeat { cache_manifest },
+                )
+                .await?;
                 debug!("sent heartbeat");
             }
 
@@ -310,13 +350,41 @@ async fn connect_and_run(
                 )
                 .await?;
 
-                // If the chunk finished, start the next queued chunk
                 if is_terminal {
+                    // Release this chunk's hold on every sha it was using.
+                    // Any hash whose in-use set becomes empty and is on the
+                    // pending-evictions list is actually evicted now.
+                    if let Some(shas) = chunk_cache_holds.remove(&chunk_id) {
+                        for sha in shas {
+                            if let Some(users) = running_chunks_using.get_mut(&sha) {
+                                users.remove(&chunk_id);
+                                if users.is_empty() {
+                                    running_chunks_using.remove(&sha);
+                                    if pending_evictions.remove(&sha) {
+                                        let removed = content_cache.evict(&sha).await;
+                                        info!(
+                                            sha = %sha,
+                                            removed,
+                                            "deferred EvictFile flushed after chunk completion"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Start the next queued chunk, if any.
                     if let Some(next) = pending_queue.pop_front() {
                         info!(
                             chunk_id = %next.chunk_id,
                             remaining = pending_queue.len(),
                             "starting next queued chunk"
+                        );
+                        // Register this chunk's cache holds before start.
+                        register_cache_holds(
+                            &next,
+                            &mut running_chunks_using,
+                            &mut chunk_cache_holds,
                         );
                         start_hashcat(
                             &next.run_config,
@@ -339,6 +407,10 @@ async fn connect_and_run(
             }
 
             Action::ChunkReady(pending) => {
+                // Register cache holds regardless of whether we start or
+                // queue — an EvictFile arriving while the chunk is queued
+                // must still defer.
+                register_cache_holds(&pending, &mut running_chunks_using, &mut chunk_cache_holds);
                 if active_chunks.is_empty() {
                     start_hashcat(
                         &pending.run_config,
@@ -525,6 +597,7 @@ async fn connect_and_run(
                             let ready = ready_tx.clone();
                             let hashcat_path = config.hashcat_path.clone();
                             tokio::spawn(async move {
+                                let mut cache_holds: Vec<String> = Vec::new();
                                 let wordlist_path = match cache
                                     .ensure(&wordlist_sha256, wordlist_size, &outbound)
                                     .await
@@ -546,12 +619,16 @@ async fn connect_and_run(
                                         return;
                                     }
                                 };
+                                cache_holds.push(wordlist_sha256.clone());
 
-                                let rules_path = match rules_sha256 {
+                                let rules_path = match rules_sha256.clone() {
                                     Some(rs) => {
                                         let rz = rules_size.unwrap_or(0);
                                         match cache.ensure(&rs, rz, &outbound).await {
-                                            Ok(p) => Some(p),
+                                            Ok(p) => {
+                                                cache_holds.push(rs);
+                                                Some(p)
+                                            }
                                             Err(e) => {
                                                 error!(
                                                     %chunk_id,
@@ -592,6 +669,7 @@ async fn connect_and_run(
                                         chunk_id,
                                         task_id,
                                         run_config,
+                                        cache_holds,
                                     })
                                     .await;
                             });
@@ -678,6 +756,10 @@ async fn connect_and_run(
                                 chunk_id,
                                 task_id,
                                 run_config,
+                                // Legacy paths (BruteForce, pushed Dictionary)
+                                // don't use the content cache, so nothing to
+                                // hold.
+                                cache_holds: Vec::new(),
                             });
                         }
                     }
@@ -731,6 +813,23 @@ async fn connect_and_run(
                     CoordMessage::FileError { hash, reason } => {
                         debug!(%hash, %reason, "received FileError");
                         content_cache.on_file_error(&hash, reason).await;
+                    }
+
+                    CoordMessage::EvictFile { hash } => {
+                        if running_chunks_using
+                            .get(&hash)
+                            .map(|s| !s.is_empty())
+                            .unwrap_or(false)
+                        {
+                            info!(
+                                %hash,
+                                "EvictFile deferred — file is in use by a running chunk"
+                            );
+                            pending_evictions.insert(hash);
+                        } else {
+                            let removed = content_cache.evict(&hash).await;
+                            info!(%hash, removed, "EvictFile applied");
+                        }
                     }
                 }
             }

--- a/crates/crack-common/src/protocol.rs
+++ b/crates/crack-common/src/protocol.rs
@@ -38,6 +38,13 @@ pub enum CoordMessage {
         hash: String,
         reason: String,
     },
+    /// Instruct the worker to evict a file from its content-addressed cache.
+    /// Issued by the coord's GC loop after a file's reference count drops
+    /// to zero and pin state is clear. The worker defers eviction until no
+    /// running chunk is using the file.
+    EvictFile {
+        hash: String,
+    },
     AssignChunk {
         chunk_id: Uuid,
         task_id: Uuid,
@@ -101,7 +108,18 @@ pub enum WorkerMessage {
         nonce: String,
         worker_name: String,
     },
-    Heartbeat,
+    /// Periodic heartbeat. Carries a compact digest of the worker's
+    /// content-addressed cache so the coord can maintain an authoritative
+    /// view of what each worker has on disk — used for targeted
+    /// `EvictFile` dispatch (Slice 8) and full reconciliation on
+    /// (re)connect (Slice 9).
+    ///
+    /// `cache_manifest` is `#[serde(default)]` for backwards compatibility
+    /// with older agents whose heartbeat carries no manifest.
+    Heartbeat {
+        #[serde(default)]
+        cache_manifest: Vec<CacheManifestEntry>,
+    },
     ChunkStarted {
         chunk_id: Uuid,
     },
@@ -143,6 +161,21 @@ pub enum WorkerMessage {
         offset: u64,
         length: u32,
     },
+}
+
+/// Compact digest of a single cached file, carried on every agent
+/// heartbeat so the coord can reconcile the agent's cache against its
+/// own view of `worker_cache_entries`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheManifestEntry {
+    /// Content hash of the cached file.
+    pub sha256: String,
+    /// Size in bytes (must match the coord's `files.size_bytes` for the
+    /// entry to be considered valid).
+    pub size_bytes: u64,
+    /// RFC3339 timestamp of last use (approximated from file mtime until
+    /// Slice 10 introduces an explicit ledger).
+    pub last_used_at: String,
 }
 
 /// Length-prefixed framing for Noise transport messages.
@@ -434,13 +467,85 @@ mod tests {
     }
 
     #[test]
-    fn roundtrip_heartbeat() {
-        let msg = WorkerMessage::Heartbeat;
+    fn roundtrip_heartbeat_empty_manifest() {
+        let msg = WorkerMessage::Heartbeat {
+            cache_manifest: vec![],
+        };
         let encoded = encode_message(&msg).unwrap();
         let (decoded, consumed): (WorkerMessage, usize) =
             decode_message(&encoded).unwrap().unwrap();
         assert_eq!(consumed, encoded.len());
-        assert!(matches!(decoded, WorkerMessage::Heartbeat));
+        match decoded {
+            WorkerMessage::Heartbeat { cache_manifest } => {
+                assert!(cache_manifest.is_empty());
+            }
+            other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_heartbeat_with_manifest() {
+        let msg = WorkerMessage::Heartbeat {
+            cache_manifest: vec![
+                CacheManifestEntry {
+                    sha256: "aa".to_string(),
+                    size_bytes: 100,
+                    last_used_at: "2026-04-24T00:00:00Z".to_string(),
+                },
+                CacheManifestEntry {
+                    sha256: "bb".to_string(),
+                    size_bytes: 200,
+                    last_used_at: "2026-04-24T01:00:00Z".to_string(),
+                },
+            ],
+        };
+        let encoded = encode_message(&msg).unwrap();
+        let (decoded, consumed): (WorkerMessage, usize) =
+            decode_message(&encoded).unwrap().unwrap();
+        assert_eq!(consumed, encoded.len());
+        match decoded {
+            WorkerMessage::Heartbeat { cache_manifest } => {
+                assert_eq!(cache_manifest.len(), 2);
+                assert_eq!(cache_manifest[0].sha256, "aa");
+                assert_eq!(cache_manifest[0].size_bytes, 100);
+                assert_eq!(cache_manifest[1].sha256, "bb");
+            }
+            other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_legacy_heartbeat_without_manifest_field() {
+        // Simulates an old agent (pre-Slice-8) whose heartbeat carries
+        // just `{"type":"heartbeat"}`. The `#[serde(default)]` on
+        // cache_manifest should let it deserialize cleanly with an empty
+        // manifest on the new coord.
+        let legacy_json = r#"{"type":"heartbeat"}"#;
+        let len = (legacy_json.len() as u32).to_be_bytes();
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&len);
+        buf.extend_from_slice(legacy_json.as_bytes());
+        let (decoded, _): (WorkerMessage, usize) = decode_message(&buf).unwrap().unwrap();
+        match decoded {
+            WorkerMessage::Heartbeat { cache_manifest } => {
+                assert!(cache_manifest.is_empty(), "legacy should deserialize empty");
+            }
+            other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_evict_file() {
+        let msg = CoordMessage::EvictFile {
+            hash: "deadbeef".to_string(),
+        };
+        let encoded = encode_message(&msg).unwrap();
+        let (decoded, consumed): (CoordMessage, usize) = decode_message(&encoded).unwrap().unwrap();
+        assert_eq!(consumed, encoded.len());
+        match decoded {
+            CoordMessage::EvictFile { hash } => assert_eq!(hash, "deadbeef"),
+            other => panic!("expected EvictFile, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/crack-coord/src/lifecycle.rs
+++ b/crates/crack-coord/src/lifecycle.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use crack_common::protocol::CoordMessage;
 use tracing::{debug, info, warn};
 
 use crate::state::AppState;
@@ -67,6 +68,42 @@ async fn gc_pass(state: &AppState) -> Result<()> {
 
         // Reserve this entry for the current pass.
         db::set_gc_state_deleting(&state.db, &sha).await?;
+
+        // Broadcast EvictFile to every connected worker that reportedly
+        // holds this file. Misses are fine: a disconnected or late worker
+        // picks it up on the next reconcile pass (Slice 9). Agents that
+        // are currently running a chunk against the file defer the
+        // eviction locally until the chunk finishes.
+        let workers = match db::workers_with_file(&state.db, &sha).await {
+            Ok(ws) => ws,
+            Err(e) => {
+                warn!(%sha, error = %e, "GC: workers_with_file lookup failed");
+                Vec::new()
+            }
+        };
+        if !workers.is_empty() {
+            let conns = state.worker_connections.read().await;
+            let mut dispatched = 0;
+            for worker_id in &workers {
+                if let Some(conn) = conns.get(worker_id) {
+                    if conn
+                        .tx
+                        .send(CoordMessage::EvictFile { hash: sha.clone() })
+                        .await
+                        .is_ok()
+                    {
+                        dispatched += 1;
+                    }
+                }
+            }
+            drop(conns);
+            debug!(
+                %sha,
+                workers = workers.len(),
+                dispatched,
+                "GC: sent EvictFile to workers"
+            );
+        }
 
         // Delete every files row (and disk file) sharing this sha. A legacy
         // deployment with duplicate sha rows may hit >1 here.

--- a/crates/crack-coord/src/storage/db.rs
+++ b/crates/crack-coord/src/storage/db.rs
@@ -164,6 +164,20 @@ CREATE TABLE IF NOT EXISTS gc_queue (
     queued_at     TEXT NOT NULL,
     attempts      INTEGER NOT NULL DEFAULT 0
 );
+
+-- Coord-side view of what each worker has in its content-addressed cache.
+-- Populated from the manifest carried on every agent heartbeat; used by
+-- the GC loop to target `EvictFile` at only the workers that hold the
+-- file, and by reconciliation (Slice 9) to correct drift across
+-- reconnects and missed messages.
+CREATE TABLE IF NOT EXISTS worker_cache_entries (
+    worker_id     TEXT NOT NULL,
+    file_sha256   TEXT NOT NULL,
+    size_bytes    INTEGER NOT NULL,
+    last_used_at  TEXT NOT NULL,
+    PRIMARY KEY (worker_id, file_sha256)
+);
+CREATE INDEX IF NOT EXISTS idx_worker_cache_sha ON worker_cache_entries(file_sha256);
 "#;
 
 // ── Database init ──
@@ -1384,6 +1398,98 @@ pub async fn set_gc_state_deleting(pool: &SqlitePool, sha256: &str) -> Result<()
     Ok(())
 }
 
+/// Replace this worker's cache manifest in `worker_cache_entries` with the
+/// new set: upsert every entry in `manifest`, remove any rows not listed.
+/// Runs as a single transaction so the coord never sees a half-synced
+/// view.
+pub async fn sync_worker_cache_manifest(
+    pool: &SqlitePool,
+    worker_id: &str,
+    manifest: &[crack_common::protocol::CacheManifestEntry],
+) -> Result<()> {
+    let mut tx = pool.begin().await.context("begin sync tx")?;
+
+    // Remove rows whose sha isn't present in the new manifest.
+    if manifest.is_empty() {
+        sqlx::query("DELETE FROM worker_cache_entries WHERE worker_id = ?1")
+            .bind(worker_id)
+            .execute(&mut *tx)
+            .await
+            .context("clearing worker cache entries")?;
+    } else {
+        // Build "NOT IN (?, ?, ?)" with placeholders. SQLite caps bound
+        // params at 32766 per statement; heartbeats would need tens of
+        // thousands of cache entries to trip that, and the manifest
+        // payload would already be absurd before then.
+        let placeholders = (0..manifest.len())
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "DELETE FROM worker_cache_entries WHERE worker_id = ? AND file_sha256 NOT IN ({placeholders})"
+        );
+        let mut q = sqlx::query(&sql).bind(worker_id);
+        for entry in manifest {
+            q = q.bind(&entry.sha256);
+        }
+        q.execute(&mut *tx)
+            .await
+            .context("pruning stale worker cache entries")?;
+    }
+
+    // Upsert each entry in the new manifest.
+    for entry in manifest {
+        sqlx::query(
+            "INSERT INTO worker_cache_entries \
+             (worker_id, file_sha256, size_bytes, last_used_at) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(worker_id, file_sha256) DO UPDATE SET \
+             size_bytes = excluded.size_bytes, \
+             last_used_at = excluded.last_used_at",
+        )
+        .bind(worker_id)
+        .bind(&entry.sha256)
+        .bind(entry.size_bytes as i64)
+        .bind(&entry.last_used_at)
+        .execute(&mut *tx)
+        .await
+        .context("upserting worker cache entry")?;
+    }
+
+    tx.commit().await.context("commit sync tx")?;
+    Ok(())
+}
+
+/// All worker IDs that reportedly hold the given sha256 in their cache.
+/// Used by the GC loop to target `EvictFile` broadcasts.
+pub async fn workers_with_file(pool: &SqlitePool, sha256: &str) -> Result<Vec<String>> {
+    let rows: Vec<String> =
+        sqlx::query_scalar("SELECT worker_id FROM worker_cache_entries WHERE file_sha256 = ?1")
+            .bind(sha256)
+            .fetch_all(pool)
+            .await
+            .context("selecting workers_with_file")?;
+    Ok(rows)
+}
+
+/// Remove a single worker/sha pair. Used by reconciliation (Slice 9) to
+/// flush stale rows the agent has told us it no longer has; also handy
+/// for explicit cache-drop operator actions.
+#[allow(dead_code)]
+pub async fn remove_worker_cache_entry(
+    pool: &SqlitePool,
+    worker_id: &str,
+    sha256: &str,
+) -> Result<()> {
+    sqlx::query("DELETE FROM worker_cache_entries WHERE worker_id = ?1 AND file_sha256 = ?2")
+        .bind(worker_id)
+        .bind(sha256)
+        .execute(pool)
+        .await
+        .context("deleting worker cache entry")?;
+    Ok(())
+}
+
 /// Every `files` row sharing this sha256. A legacy deployment can have more
 /// than one — we delete all of them when the content is reclaimed.
 pub async fn files_by_sha256(pool: &SqlitePool, sha256: &str) -> Result<Vec<FileRecord>> {
@@ -2409,6 +2515,111 @@ mod tests {
         seed_file(&pool, "dup-b", "sha-x").await;
         let records = files_by_sha256(&pool, "sha-x").await.unwrap();
         assert_eq!(records.len(), 2);
+    }
+
+    fn manifest_entry(sha: &str, size: u64) -> crack_common::protocol::CacheManifestEntry {
+        crack_common::protocol::CacheManifestEntry {
+            sha256: sha.to_string(),
+            size_bytes: size,
+            last_used_at: Utc::now().to_rfc3339(),
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_manifest_upserts_new_entries() {
+        let pool = mem_pool().await;
+        let manifest = vec![manifest_entry("aa", 100), manifest_entry("bb", 200)];
+        sync_worker_cache_manifest(&pool, "worker-1", &manifest)
+            .await
+            .unwrap();
+
+        let workers_aa = workers_with_file(&pool, "aa").await.unwrap();
+        let workers_bb = workers_with_file(&pool, "bb").await.unwrap();
+        assert_eq!(workers_aa, vec!["worker-1".to_string()]);
+        assert_eq!(workers_bb, vec!["worker-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn sync_manifest_prunes_removed_entries() {
+        let pool = mem_pool().await;
+        // Initial: worker has aa + bb.
+        sync_worker_cache_manifest(
+            &pool,
+            "worker-1",
+            &[manifest_entry("aa", 100), manifest_entry("bb", 200)],
+        )
+        .await
+        .unwrap();
+
+        // Later heartbeat: only aa remains (worker evicted bb locally).
+        sync_worker_cache_manifest(&pool, "worker-1", &[manifest_entry("aa", 100)])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            workers_with_file(&pool, "aa").await.unwrap(),
+            vec!["worker-1".to_string()]
+        );
+        assert!(
+            workers_with_file(&pool, "bb").await.unwrap().is_empty(),
+            "bb should have been pruned from worker_cache_entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_manifest_empty_clears_all_entries_for_worker() {
+        let pool = mem_pool().await;
+        sync_worker_cache_manifest(&pool, "worker-1", &[manifest_entry("aa", 100)])
+            .await
+            .unwrap();
+        sync_worker_cache_manifest(&pool, "worker-1", &[])
+            .await
+            .unwrap();
+        assert!(workers_with_file(&pool, "aa").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sync_manifest_is_scoped_per_worker() {
+        let pool = mem_pool().await;
+        sync_worker_cache_manifest(&pool, "w-a", &[manifest_entry("shared", 50)])
+            .await
+            .unwrap();
+        sync_worker_cache_manifest(&pool, "w-b", &[manifest_entry("shared", 50)])
+            .await
+            .unwrap();
+
+        let mut workers = workers_with_file(&pool, "shared").await.unwrap();
+        workers.sort();
+        assert_eq!(workers, vec!["w-a".to_string(), "w-b".to_string()]);
+
+        // Clearing one worker must leave the other's entry alone.
+        sync_worker_cache_manifest(&pool, "w-a", &[]).await.unwrap();
+        assert_eq!(
+            workers_with_file(&pool, "shared").await.unwrap(),
+            vec!["w-b".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_manifest_updates_size_and_mtime_on_upsert() {
+        let pool = mem_pool().await;
+        sync_worker_cache_manifest(&pool, "w1", &[manifest_entry("aa", 100)])
+            .await
+            .unwrap();
+        // Updated size on next heartbeat (e.g. corrupt file now correct).
+        sync_worker_cache_manifest(&pool, "w1", &[manifest_entry("aa", 999)])
+            .await
+            .unwrap();
+
+        let row: i64 = sqlx::query_scalar(
+            "SELECT size_bytes FROM worker_cache_entries WHERE worker_id = ?1 AND file_sha256 = ?2",
+        )
+        .bind("w1")
+        .bind("aa")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row, 999);
     }
 
     #[tokio::test]

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -346,9 +346,17 @@ async fn handle_worker_message(
             .await
         }
 
-        WorkerMessage::Heartbeat => {
+        WorkerMessage::Heartbeat { cache_manifest } => {
             if let Some(wid) = worker_id.as_deref() {
                 db::update_worker_last_seen(&state.db, wid).await?;
+                // Sync the coord's view of this worker's cache. Entries
+                // present here but missing from the DB are upserted;
+                // entries in the DB but missing from this manifest are
+                // removed (the agent evicted them locally since last tick).
+                if let Err(e) = db::sync_worker_cache_manifest(&state.db, wid, cache_manifest).await
+                {
+                    warn!(worker = %wid, error = %e, "failed to sync cache manifest");
+                }
             }
             Ok(())
         }


### PR DESCRIPTION
## Summary
Second of the three "ironclad lifecycle" slices. The coord's GC loop now actively reclaims agent disk space by broadcasting \`EvictFile\` to every worker reportedly holding the file, and every agent heartbeat carries a compact manifest so the coord's view tracks what each agent actually has on disk.

## Protocol (additive)
- \`CoordMessage::EvictFile { hash }\`
- \`CacheManifestEntry { sha256, size_bytes, last_used_at }\` struct
- \`WorkerMessage::Heartbeat\` grew a \`cache_manifest\` field (\`#[serde(default)]\` — old agents' bare heartbeats still deserialize cleanly on the new coord)

## Schema
\`worker_cache_entries(worker_id, file_sha256, size_bytes, last_used_at)\` — coord's authoritative view of each agent's cache, populated from every heartbeat.

## Agent
- \`ContentCache::manifest()\` walks \`<root>/cas/<hh>/<hash>\` and returns a \`CacheManifestEntry\` per cached file; \`last_used_at\` is mtime-based until Slice 10's ledger lands.
- \`ContentCache::evict(hash)\` removes the canonical file plus any stale \`.partial\` companion.
- Per-chunk cache-hold tracking in \`connection.rs\`:
  - \`running_chunks_using: sha → {chunk_ids using it}\`
  - \`chunk_cache_holds: chunk_id → {shas it holds}\`
  - \`pending_evictions: {shas the coord asked to evict, but in-use at the time}\`
- On \`CoordMessage::EvictFile\`: delete if idle, otherwise queue in \`pending_evictions\`. Drain on every chunk terminal transition.
- Every heartbeat carries \`content_cache.manifest()\`.

## Coord
- Heartbeat handler: \`db::sync_worker_cache_manifest\` upserts entries in the manifest and prunes ones missing from it — so a local agent eviction propagates to the coord view within one tick.
- GC pass: before deleting the coord-side file, broadcasts \`EvictFile\` to every worker in \`workers_with_file(sha)\`. Misses (disconnected, slow agents) are resolved by Slice 9's reconciliation.

## Guarantees delivered
- **Running task's wordlist can't disappear**: agent defers eviction while any chunk in \`running_chunks_using[sha]\` is alive.
- **Coord-issued eviction eventually completes**: pending_evictions drains on each chunk terminal; manifest sync eventually reflects the removal on the coord.
- **Partial-file cleanup**: \`evict()\` sweeps \`.partial\` alongside the canonical entry.

## Backwards compat
- Old agents heartbeat \`{"type":"heartbeat"}\` → new coord gets empty manifest via \`#[serde(default)]\`. Cache entries stay stale but harmless; Slice 9 reconciliation syncs on reconnect.
- New agents heartbeat with the new field → old coords ignore unknown fields (serde default).

## Tests
13 new, all passing:
- crack-coord (8): sync upserts / prunes / clears / per-worker scope / updates on upsert
- crack-agent (5): manifest empty when no \`cas/\`, lists files with size, ignores \`.partial\`, evict removes file+partial, evict tolerates missing
- crack-common (4): Heartbeat empty + with manifest round-trips, legacy bare heartbeat still deserializes, EvictFile round-trip

Totals: crack-agent 60, crack-common 49, crack-coord 64.

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all pass
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] Manual smoke: upload wordlist, create dictionary task, let it complete. Wait ~60s; confirm coord-side file is deleted AND the agent's \`cache/cas/<hh>/<hash>\` is also removed. Second dictionary task using the same wordlist triggers a fresh pull (the agent cache was evicted).

Auto-merge queued.