### PR TITLE
feat(reconcile): cache reconciliation on (re)connect (Slice 9/11)

### DIFF
--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -831,6 +831,39 @@ async fn connect_and_run(
                             info!(%hash, removed, "EvictFile applied");
                         }
                     }
+
+                    CoordMessage::CacheReconcile { expected } => {
+                        let expected_set: HashSet<String> = expected.into_iter().collect();
+                        let manifest = content_cache.manifest().await;
+                        let mut kept: Vec<String> = Vec::new();
+                        let mut evicted: Vec<String> = Vec::new();
+                        for entry in manifest {
+                            if expected_set.contains(&entry.sha256) {
+                                kept.push(entry.sha256);
+                            } else if running_chunks_using
+                                .get(&entry.sha256)
+                                .map(|s| !s.is_empty())
+                                .unwrap_or(false)
+                            {
+                                // In use right now — defer eviction. Treated
+                                // as kept for the Ack so the coord doesn't
+                                // think it disappeared.
+                                pending_evictions.insert(entry.sha256.clone());
+                                kept.push(entry.sha256);
+                            } else if content_cache.evict(&entry.sha256).await {
+                                evicted.push(entry.sha256);
+                            }
+                        }
+                        info!(
+                            kept = kept.len(),
+                            evicted_count = evicted.len(),
+                            expected = expected_set.len(),
+                            "cache reconciled"
+                        );
+                        let _ = outbound_tx
+                            .send(WorkerMessage::CacheAck { kept, evicted })
+                            .await;
+                    }
                 }
             }
         }

--- a/crates/crack-common/src/protocol.rs
+++ b/crates/crack-common/src/protocol.rs
@@ -45,6 +45,15 @@ pub enum CoordMessage {
     EvictFile {
         hash: String,
     },
+    /// Sent once when a worker (re)connects: the authoritative list of
+    /// sha256s the coord still has on its end. The agent compares against
+    /// its own cache manifest and evicts anything not in `expected` —
+    /// catches missed `EvictFile` messages from prior sessions and any
+    /// drift accumulated while the agent was disconnected. Eviction
+    /// defers as usual when a sha is in use by a running chunk.
+    CacheReconcile {
+        expected: Vec<String>,
+    },
     AssignChunk {
         chunk_id: Uuid,
         task_id: Uuid,
@@ -160,6 +169,14 @@ pub enum WorkerMessage {
         hash: String,
         offset: u64,
         length: u32,
+    },
+    /// Response to `CoordMessage::CacheReconcile`. `kept` is the set of
+    /// sha256s the worker still has after the reconcile pass; `evicted`
+    /// is what was removed (informational). The coord uses `kept` to
+    /// rewrite `worker_cache_entries` for this worker.
+    CacheAck {
+        kept: Vec<String>,
+        evicted: Vec<String>,
     },
 }
 
@@ -531,6 +548,40 @@ mod tests {
                 assert!(cache_manifest.is_empty(), "legacy should deserialize empty");
             }
             other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_cache_reconcile() {
+        let msg = CoordMessage::CacheReconcile {
+            expected: vec!["aa".to_string(), "bb".to_string(), "cc".to_string()],
+        };
+        let encoded = encode_message(&msg).unwrap();
+        let (decoded, _): (CoordMessage, usize) = decode_message(&encoded).unwrap().unwrap();
+        match decoded {
+            CoordMessage::CacheReconcile { expected } => {
+                assert_eq!(expected.len(), 3);
+                assert_eq!(expected[0], "aa");
+                assert_eq!(expected[2], "cc");
+            }
+            other => panic!("expected CacheReconcile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_cache_ack() {
+        let msg = WorkerMessage::CacheAck {
+            kept: vec!["aa".to_string()],
+            evicted: vec!["bb".to_string(), "cc".to_string()],
+        };
+        let encoded = encode_message(&msg).unwrap();
+        let (decoded, _): (WorkerMessage, usize) = decode_message(&encoded).unwrap().unwrap();
+        match decoded {
+            WorkerMessage::CacheAck { kept, evicted } => {
+                assert_eq!(kept, vec!["aa".to_string()]);
+                assert_eq!(evicted.len(), 2);
+            }
+            other => panic!("expected CacheAck, got {other:?}"),
         }
     }
 

--- a/crates/crack-coord/src/storage/db.rs
+++ b/crates/crack-coord/src/storage/db.rs
@@ -1398,6 +1398,20 @@ pub async fn set_gc_state_deleting(pool: &SqlitePool, sha256: &str) -> Result<()
     Ok(())
 }
 
+/// All sha256s currently considered "live" on the coord — i.e. files with
+/// `gc_state = 'active'`. Used by reconciliation to tell a (re)connecting
+/// worker which content it's still allowed to keep cached.
+pub async fn list_active_file_shas(pool: &SqlitePool) -> Result<Vec<String>> {
+    let rows: Vec<String> = sqlx::query_scalar(
+        "SELECT DISTINCT sha256 FROM files \
+         WHERE sha256 != '' AND gc_state = 'active'",
+    )
+    .fetch_all(pool)
+    .await
+    .context("listing active file shas")?;
+    Ok(rows)
+}
+
 /// Replace this worker's cache manifest in `worker_cache_entries` with the
 /// new set: upsert every entry in `manifest`, remove any rows not listed.
 /// Runs as a single transaction so the coord never sees a half-synced
@@ -1472,10 +1486,9 @@ pub async fn workers_with_file(pool: &SqlitePool, sha256: &str) -> Result<Vec<St
     Ok(rows)
 }
 
-/// Remove a single worker/sha pair. Used by reconciliation (Slice 9) to
+/// Remove a single worker/sha pair. Called by the `CacheAck` handler to
 /// flush stale rows the agent has told us it no longer has; also handy
 /// for explicit cache-drop operator actions.
-#[allow(dead_code)]
 pub async fn remove_worker_cache_entry(
     pool: &SqlitePool,
     worker_id: &str,
@@ -2598,6 +2611,54 @@ mod tests {
             workers_with_file(&pool, "shared").await.unwrap(),
             vec!["w-b".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn list_active_file_shas_returns_active_only() {
+        let pool = mem_pool().await;
+        seed_file(&pool, "f-active", "sha-a").await;
+        seed_file(&pool, "f-marked", "sha-m").await;
+        seed_file(&pool, "f-deleting", "sha-d").await;
+        seed_file(&pool, "f-empty", "").await;
+
+        sqlx::query("UPDATE files SET gc_state = 'marked' WHERE id = 'f-marked'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE files SET gc_state = 'deleting' WHERE id = 'f-deleting'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let shas = list_active_file_shas(&pool).await.unwrap();
+        assert_eq!(shas, vec!["sha-a".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn list_active_file_shas_dedups_legacy_duplicates() {
+        let pool = mem_pool().await;
+        seed_file(&pool, "dup-a", "sha-x").await;
+        seed_file(&pool, "dup-b", "sha-x").await;
+        let shas = list_active_file_shas(&pool).await.unwrap();
+        assert_eq!(shas, vec!["sha-x".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn remove_worker_cache_entry_targets_only_one_worker() {
+        let pool = mem_pool().await;
+        sync_worker_cache_manifest(&pool, "w-a", &[manifest_entry("shared", 50)])
+            .await
+            .unwrap();
+        sync_worker_cache_manifest(&pool, "w-b", &[manifest_entry("shared", 50)])
+            .await
+            .unwrap();
+
+        remove_worker_cache_entry(&pool, "w-a", "shared")
+            .await
+            .unwrap();
+
+        let workers = workers_with_file(&pool, "shared").await.unwrap();
+        assert_eq!(workers, vec!["w-b".to_string()]);
     }
 
     #[tokio::test]

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -552,6 +552,27 @@ async fn handle_worker_message(
             handle_request_file_range(state, outbound_tx, hash, *offset, *length).await?;
             Ok(())
         }
+
+        WorkerMessage::CacheAck { kept, evicted } => {
+            // The agent has already evicted what we asked. Drop the
+            // evicted shas from our coord-side view immediately so the
+            // GC loop doesn't keep re-targeting this worker. The next
+            // heartbeat will deliver the full ground-truth manifest.
+            if let Some(wid) = worker_id.as_deref() {
+                for sha in evicted {
+                    if let Err(e) = db::remove_worker_cache_entry(&state.db, wid, sha).await {
+                        warn!(worker = %wid, %sha, error = %e, "remove_worker_cache_entry failed");
+                    }
+                }
+                debug!(
+                    worker = %wid,
+                    kept = kept.len(),
+                    evicted_count = evicted.len(),
+                    "received CacheAck"
+                );
+            }
+            Ok(())
+        }
     }
 }
 
@@ -734,6 +755,26 @@ async fn handle_register(
         Some(&wid),
     )
     .await?;
+
+    // Cache reconciliation: tell the (re)connecting worker which sha256s
+    // we still consider live. Anything in its cache that's not on this
+    // list gets evicted (deferred if currently in use). Catches missed
+    // EvictFile messages from prior sessions and any drift while the
+    // agent was disconnected.
+    match db::list_active_file_shas(&state.db).await {
+        Ok(expected) => {
+            let count = expected.len();
+            if let Err(e) = outbound_tx
+                .send(CoordMessage::CacheReconcile { expected })
+                .await
+            {
+                debug!(error = %e, "failed to send CacheReconcile");
+            } else {
+                debug!(worker = %wid, expected_count = count, "sent CacheReconcile");
+            }
+        }
+        Err(e) => warn!(error = %e, "failed to list active file shas for reconcile"),
+    }
 
     // Try to immediately assign work to the newly registered worker.
     try_assign_work(state, &wid, outbound_tx, transferred_files).await?;


### PR DESCRIPTION
## Summary
Closes the last gap in the lifecycle triad you specifically asked about. When a worker (re)connects, the coord sends a \`CacheReconcile\` listing every sha256 it still considers live; the agent compares against its own cache, evicts anything not in the list (deferring while in use), and ACKs back. Catches missed \`EvictFile\` messages from prior sessions and any drift accumulated while the agent was disconnected.

## Protocol (additive)
- \`CoordMessage::CacheReconcile { expected: Vec<String> }\`
- \`WorkerMessage::CacheAck { kept: Vec<String>, evicted: Vec<String> }\`

## Coord
- \`handle_register\`: after \`Welcome\`, dispatches \`CacheReconcile\` populated from \`db::list_active_file_shas()\` to the fresh outbound channel.
- \`WorkerMessage::CacheAck\` handler: removes \`worker_cache_entries\` rows for evicted shas immediately so the GC loop stops re-targeting that worker. Next heartbeat (≤15s away) delivers the full authoritative manifest.

## Agent
- \`CoordMessage::CacheReconcile\` arm walks \`content_cache.manifest()\`, compares each sha against the expected set, evicts the misses. Defers via \`pending_evictions\` if a chunk is using the file (treats it as kept for the Ack so the coord doesn't think it disappeared mid-flight).
- Replies with \`WorkerMessage::CacheAck { kept, evicted }\` so the coord can update its view promptly.

## DB
- \`list_active_file_shas\`: distinct shas from \`files\` where \`gc_state = 'active'\` and sha non-empty. Skips empty-sha legacy rows so the reconcile doesn't accidentally tell agents to keep nothing.
- \`remove_worker_cache_entry\` loses its \`#[allow(dead_code)]\` (now exercised by the CacheAck handler).

## Lifecycle invariants — all delivered now
- ✓ Running task → wordlist present on its agent (Slice 8 pending_evictions; same deferral applies on reconcile)
- ✓ Completed/cancelled task → no refs → eventually GC'd (Slice 7)
- ✓ Same file, two tasks → not evicted until both done (Slice 7 refcount)
- ✓ Coord crashes mid-GC → resumes on restart (Slice 7 state machine + queue)
- ✓ Agent disconnected when \`EvictFile\` sent → reconcile catches it on reconnect
- ✓ Agent has files coord doesn't know about → reconcile evicts; heartbeat manifest sync prevents drift

## Tests (5 new)
- crack-common (2): \`CacheReconcile\` and \`CacheAck\` round-trips
- crack-coord (3): \`list_active_file_shas\` filters by \`gc_state\`, dedups legacy duplicates; \`remove_worker_cache_entry\` is per-worker scoped

Totals: crack-agent 60, crack-common 51, crack-coord 67.

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all pass
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] Manual smoke: stop an agent mid-task, manually drop a file from agent's \`cache/cas/\`, restart agent. On reconnect, agent receives \`CacheReconcile\`; logs show \`cache reconciled\` with kept/evicted counts. Coord's \`worker_cache_entries\` for that worker reflects current truth.

Auto-merge queued.