### PR TITLE
feat(cache): LRU eviction + disk budget on the agent (Slice 10/11)

### DIFF
--- a/crates/crack-agent/src/cache.rs
+++ b/crates/crack-agent/src/cache.rs
@@ -494,7 +494,7 @@ impl ContentCache {
                 });
             }
         }
-        out.sort_by(|a, b| a.last_used_at.cmp(&b.last_used_at));
+        out.sort_by_key(|c| c.last_used_at);
         out
     }
 

--- a/crates/crack-agent/src/cache.rs
+++ b/crates/crack-agent/src/cache.rs
@@ -23,6 +23,7 @@ use base64::engine::general_purpose;
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use crack_common::protocol::{CacheManifestEntry, WorkerMessage};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::{mpsc, Mutex};
@@ -32,9 +33,33 @@ use tokio::sync::{mpsc, Mutex};
 /// keeping them aligned avoids protocol-level surprises.
 const CHUNK_SIZE: u32 = 2 * 1024 * 1024;
 
+/// On-disk record of when each cached entry was last used. Persisted to
+/// `<root>/cas-ledger.json` after every update so the LRU order survives
+/// agent restarts. mtime would be a free fallback but isn't reliably
+/// updated by every filesystem on read.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Ledger {
+    /// Map sha256 → RFC3339 timestamp of last use.
+    entries: HashMap<String, String>,
+}
+
+/// One LRU candidate returned to the agent main loop for eviction
+/// decisions: which sha to drop, how big it is, and when it was last
+/// used.
+#[derive(Debug, Clone)]
+pub struct LruCandidate {
+    pub sha256: String,
+    pub size_bytes: u64,
+    pub last_used_at: DateTime<Utc>,
+}
+
 /// Content-addressed file cache. Cheap to clone via `Arc`.
 pub struct ContentCache {
     root: PathBuf,
+    /// Hard ceiling on bytes stored under `<root>/cas/`. The main loop
+    /// uses `lru_candidates()` to make room before issuing a pull;
+    /// `cache_max_bytes` is the budget that decision is measured against.
+    cache_max_bytes: u64,
     /// Per-hash serialization — prevents two concurrent `ensure()` calls
     /// for the same hash from racing on the same `.partial` file.
     locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
@@ -42,6 +67,9 @@ pub struct ContentCache {
     /// `on_file_error` hooks forward incoming messages through here so the
     /// `ensure()` loop can consume them.
     pending: Mutex<HashMap<String, mpsc::UnboundedSender<ChunkResult>>>,
+    /// In-memory mirror of the on-disk LRU ledger. Touched on every
+    /// `ensure()` (hit or miss) and persisted after each update.
+    ledger: Mutex<Ledger>,
 }
 
 /// Internal message the dispatcher uses to feed `ensure()`.
@@ -55,12 +83,57 @@ enum ChunkResult {
 }
 
 impl ContentCache {
-    pub fn new(root: PathBuf) -> Arc<Self> {
+    pub fn new(root: PathBuf, cache_max_bytes: u64) -> Arc<Self> {
+        let ledger_path = root.join("cas-ledger.json");
+        let ledger = std::fs::read(&ledger_path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<Ledger>(&bytes).ok())
+            .unwrap_or_default();
         Arc::new(Self {
             root,
+            cache_max_bytes,
             locks: Mutex::new(HashMap::new()),
             pending: Mutex::new(HashMap::new()),
+            ledger: Mutex::new(ledger),
         })
+    }
+
+    pub fn cache_max_bytes(&self) -> u64 {
+        self.cache_max_bytes
+    }
+
+    fn ledger_path(&self) -> PathBuf {
+        self.root.join("cas-ledger.json")
+    }
+
+    /// Mark `hash` as used now. Persists the ledger to disk best-effort.
+    pub async fn touch(&self, hash: &str) {
+        let mut ledger = self.ledger.lock().await;
+        ledger
+            .entries
+            .insert(hash.to_string(), Utc::now().to_rfc3339());
+        let snapshot = match serde_json::to_vec(&*ledger) {
+            Ok(b) => b,
+            Err(_) => return,
+        };
+        drop(ledger);
+        if let Some(parent) = self.ledger_path().parent() {
+            let _ = tokio::fs::create_dir_all(parent).await;
+        }
+        let _ = tokio::fs::write(self.ledger_path(), snapshot).await;
+    }
+
+    async fn ledger_remove(&self, hash: &str) {
+        let mut ledger = self.ledger.lock().await;
+        if ledger.entries.remove(hash).is_none() {
+            return;
+        }
+        let snapshot = match serde_json::to_vec(&*ledger) {
+            Ok(b) => b,
+            Err(_) => return,
+        };
+        drop(ledger);
+        let _ = tokio::fs::write(self.ledger_path(), snapshot).await;
     }
 
     /// `<root>/cas/<first-two-chars>/<hash>`.
@@ -85,6 +158,9 @@ impl ContentCache {
     /// dispatcher must forward any `FileRange` / `FileError` messages for
     /// this hash to `on_file_range` / `on_file_error` while the pull is in
     /// flight.
+    ///
+    /// Both cache hits and successful pulls touch the LRU ledger so the
+    /// most-recently-used entries float to the top.
     pub async fn ensure(
         self: &Arc<Self>,
         hash: &str,
@@ -99,10 +175,15 @@ impl ContentCache {
         let _guard = hash_lock.lock().await;
 
         if self.has(hash, size).await {
+            self.touch(hash).await;
             return Ok(self.path_for(hash));
         }
 
-        self.pull_to_disk(hash, size, outbound_tx).await
+        let result = self.pull_to_disk(hash, size, outbound_tx).await;
+        if result.is_ok() {
+            self.touch(hash).await;
+        }
+        result
     }
 
     async fn per_hash_lock(&self, hash: &str) -> Arc<Mutex<()>> {
@@ -297,14 +378,124 @@ impl ContentCache {
     }
 
     /// Best-effort removal of a cached file. Returns true if the canonical
-    /// entry was deleted (we also sweep any stale `.partial`). A missing
-    /// file is not an error — it means the cache was already clean.
+    /// entry was deleted (we also sweep any stale `.partial` and the
+    /// matching ledger entry). A missing file is not an error — it means
+    /// the cache was already clean.
     pub async fn evict(&self, hash: &str) -> bool {
         let final_path = self.path_for(hash);
         let partial = final_path.with_extension("partial");
         let removed_final = tokio::fs::remove_file(&final_path).await.is_ok();
         let _ = tokio::fs::remove_file(&partial).await;
+        if removed_final {
+            self.ledger_remove(hash).await;
+        }
         removed_final
+    }
+
+    /// Total bytes currently consumed by canonical cache entries (skips
+    /// `.partial` companions). Walks the cas/ tree once per call — fine
+    /// for budget checks on the assignment path; not a hot loop.
+    pub async fn total_size(&self) -> u64 {
+        let cas_root = self.root.join("cas");
+        let mut total: u64 = 0;
+        let mut shards = match tokio::fs::read_dir(&cas_root).await {
+            Ok(d) => d,
+            Err(_) => return 0,
+        };
+        while let Ok(Some(shard)) = shards.next_entry().await {
+            let p = shard.path();
+            if !p.is_dir() {
+                continue;
+            }
+            let mut files = match tokio::fs::read_dir(&p).await {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            while let Ok(Some(entry)) = files.next_entry().await {
+                let name = entry.file_name();
+                let name_str = match name.to_str() {
+                    Some(s) => s,
+                    None => continue,
+                };
+                if name_str.ends_with(".partial") {
+                    continue;
+                }
+                if let Ok(meta) = entry.metadata().await {
+                    if meta.is_file() {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+        }
+        total
+    }
+
+    /// LRU-sorted snapshot of every canonical cache entry, oldest-used
+    /// first. Entries without a ledger record fall back to file mtime.
+    /// Returned `last_used_at` is what the caller should compare against
+    /// "is older than" — the agent's main loop walks this list, skipping
+    /// any sha currently in use, evicting until enough room is free.
+    pub async fn lru_candidates(&self) -> Vec<LruCandidate> {
+        let ledger = self.ledger.lock().await;
+        let ledger_snapshot: HashMap<String, String> = ledger.entries.clone();
+        drop(ledger);
+
+        let cas_root = self.root.join("cas");
+        let mut out = Vec::new();
+        let mut shards = match tokio::fs::read_dir(&cas_root).await {
+            Ok(d) => d,
+            Err(_) => return out,
+        };
+        while let Ok(Some(shard)) = shards.next_entry().await {
+            let p = shard.path();
+            if !p.is_dir() {
+                continue;
+            }
+            let mut files = match tokio::fs::read_dir(&p).await {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            while let Ok(Some(entry)) = files.next_entry().await {
+                let name = entry.file_name();
+                let name_str = match name.to_str() {
+                    Some(s) => s,
+                    None => continue,
+                };
+                if name_str.ends_with(".partial") {
+                    continue;
+                }
+                let meta = match entry.metadata().await {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                if !meta.is_file() {
+                    continue;
+                }
+                let last_used_at = ledger_snapshot
+                    .get(name_str)
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|d| d.with_timezone(&Utc))
+                    .or_else(|| {
+                        meta.modified()
+                            .ok()
+                            .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+                            .and_then(|d| {
+                                DateTime::<Utc>::from_timestamp(
+                                    d.as_secs() as i64,
+                                    d.subsec_nanos(),
+                                )
+                            })
+                    })
+                    .unwrap_or_else(Utc::now);
+                out.push(LruCandidate {
+                    sha256: name_str.to_string(),
+                    size_bytes: meta.len(),
+                    last_used_at,
+                });
+            }
+        }
+        out.sort_by(|a, b| a.last_used_at.cmp(&b.last_used_at));
+        out
     }
 
     /// Hook for the agent's message dispatcher: forward an incoming
@@ -361,7 +552,7 @@ mod tests {
     #[test]
     fn path_for_shards_by_prefix() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let p = cache.path_for("abcdef0123456789");
         assert_eq!(p, dir.path.join("cas").join("ab").join("abcdef0123456789"));
     }
@@ -369,14 +560,14 @@ mod tests {
     #[tokio::test]
     async fn has_returns_false_when_missing() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         assert!(!cache.has("deadbeef00000000", 100).await);
     }
 
     #[tokio::test]
     async fn has_returns_false_on_size_mismatch() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let hash = sha256_hex(b"hello");
         let p = cache.path_for(&hash);
         std::fs::create_dir_all(p.parent().unwrap()).unwrap();
@@ -419,7 +610,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_pulls_and_caches_on_miss() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let (tx, rx) = mpsc::channel(16);
 
         let data = b"hello world".to_vec();
@@ -434,7 +625,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_hit_skips_network_roundtrip() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
 
         // Pre-seed the cache.
         let data = b"already cached".to_vec();
@@ -453,7 +644,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_large_file_pulls_multiple_chunks() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let (tx, rx) = mpsc::channel(64);
 
         // 5 MiB — forces at least 3 chunks at the 2 MiB default.
@@ -470,7 +661,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_hash_mismatch_aborts_and_cleans_partial() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let (tx, rx) = mpsc::channel(16);
 
         let correct_data = b"correct".to_vec();
@@ -493,7 +684,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_surfaces_file_error_from_coord() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let (tx, mut rx) = mpsc::channel::<WorkerMessage>(16);
 
         let fake_hash = sha256_hex(b"nope");
@@ -516,7 +707,7 @@ mod tests {
     #[tokio::test]
     async fn manifest_returns_empty_when_no_cache_dir() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let m = cache.manifest().await;
         assert!(m.is_empty());
     }
@@ -524,7 +715,7 @@ mod tests {
     #[tokio::test]
     async fn manifest_lists_cached_files_with_size() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
 
         // Seed two entries directly on disk (as a successful pull would).
         let data_a = vec![0u8; 123];
@@ -551,7 +742,7 @@ mod tests {
     #[tokio::test]
     async fn manifest_ignores_partial_files() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let data = b"done".to_vec();
         let hash = sha256_hex(&data);
         let p = cache.path_for(&hash);
@@ -568,7 +759,7 @@ mod tests {
     #[tokio::test]
     async fn evict_removes_cached_file_and_partial() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let data = b"gone".to_vec();
         let hash = sha256_hex(&data);
         let p = cache.path_for(&hash);
@@ -585,8 +776,85 @@ mod tests {
     #[tokio::test]
     async fn evict_missing_file_returns_false_without_error() {
         let dir = TempDir::new();
-        let cache = ContentCache::new(dir.path.clone());
+        let cache = ContentCache::new(dir.path.clone(), 100 * 1024 * 1024);
         let removed = cache.evict("nonexistent-hash").await;
         assert!(!removed);
+    }
+
+    #[tokio::test]
+    async fn total_size_sums_canonical_files_only() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone(), 1_000_000);
+
+        for (sha, payload) in [("aabb", vec![0u8; 100]), ("ccdd", vec![1u8; 250])] {
+            let p = cache.path_for(sha);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, &payload).unwrap();
+        }
+        // .partial files are excluded.
+        let p = cache.path_for("eeff");
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p.with_extension("partial"), vec![9u8; 999]).unwrap();
+
+        assert_eq!(cache.total_size().await, 350);
+    }
+
+    #[tokio::test]
+    async fn touch_persists_ledger_across_new() {
+        let dir = TempDir::new();
+        {
+            let cache = ContentCache::new(dir.path.clone(), 1_000_000);
+            cache.touch("aabb").await;
+        }
+        // New instance over the same root should pick up the ledger.
+        let cache = ContentCache::new(dir.path.clone(), 1_000_000);
+        let ledger = cache.ledger.lock().await;
+        assert!(
+            ledger.entries.contains_key("aabb"),
+            "ledger entry should survive new() over same root"
+        );
+    }
+
+    #[tokio::test]
+    async fn lru_candidates_orders_by_last_used_ascending() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone(), 1_000_000);
+
+        for (sha, size) in [("aaone", 100u64), ("aatwo", 200), ("aathree", 300)] {
+            let p = cache.path_for(sha);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, vec![0u8; size as usize]).unwrap();
+        }
+        // Touch in a deliberate order: three (oldest), one, two (newest).
+        cache.touch("aathree").await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        cache.touch("aaone").await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        cache.touch("aatwo").await;
+
+        let cands = cache.lru_candidates().await;
+        let order: Vec<&str> = cands.iter().map(|c| c.sha256.as_str()).collect();
+        assert_eq!(order, vec!["aathree", "aaone", "aatwo"]);
+        // Sizes round-trip through the candidate metadata.
+        assert_eq!(cands[0].size_bytes, 300);
+        assert_eq!(cands[1].size_bytes, 100);
+        assert_eq!(cands[2].size_bytes, 200);
+    }
+
+    #[tokio::test]
+    async fn evict_clears_ledger_entry() {
+        let dir = TempDir::new();
+        let cache = ContentCache::new(dir.path.clone(), 1_000_000);
+        let p = cache.path_for("aabb");
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, b"x").unwrap();
+        cache.touch("aabb").await;
+
+        assert!(cache.ledger.lock().await.entries.contains_key("aabb"));
+        assert!(cache.evict("aabb").await);
+        assert!(
+            !cache.ledger.lock().await.entries.contains_key("aabb"),
+            "ledger should be cleaned up after eviction"
+        );
     }
 }

--- a/crates/crack-agent/src/config.rs
+++ b/crates/crack-agent/src/config.rs
@@ -65,6 +65,17 @@ pub struct RunConfig {
     /// Run without TUI (log output only)
     #[arg(long)]
     pub headless: bool,
+
+    /// Maximum bytes the content-addressed cache may consume on disk.
+    /// When a new pull would push past this ceiling, the cache evicts
+    /// least-recently-used entries (skipping any that are currently in
+    /// use by a running chunk) to make room. If still insufficient, the
+    /// chunk is reported as `PullFailed` and the coord reassigns it.
+    ///
+    /// Default: 80 GiB. Override with `--cache-max-bytes` or
+    /// `CRACK_AGENT_CACHE_MAX` (raw bytes).
+    #[arg(long, env = "CRACK_AGENT_CACHE_MAX", default_value_t = 80 * 1024 * 1024 * 1024)]
+    pub cache_max_bytes: u64,
 }
 
 impl RunConfig {

--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
@@ -47,6 +48,49 @@ fn register_cache_holds(
             .insert(pending.chunk_id);
     }
     chunk_cache_holds.insert(pending.chunk_id, pending.cache_holds.clone());
+}
+
+/// Best-effort LRU eviction to free `needed` bytes in the content cache,
+/// skipping any sha currently in use by a running chunk. Stops once the
+/// cache has room for `needed` bytes (cache budget − current size ≥
+/// needed) or no more candidates exist.
+///
+/// Returns the cache headroom after eviction. Caller compares against
+/// `needed` to decide whether the pull can proceed.
+async fn evict_lru_for_budget(
+    cache: &Arc<ContentCache>,
+    needed: u64,
+    running_chunks_using: &HashMap<String, HashSet<Uuid>>,
+) -> u64 {
+    let budget = cache.cache_max_bytes();
+    let mut current = cache.total_size().await;
+    let mut headroom = budget.saturating_sub(current);
+    if headroom >= needed {
+        return headroom;
+    }
+
+    let candidates = cache.lru_candidates().await;
+    for c in candidates {
+        if headroom >= needed {
+            break;
+        }
+        // Skip files actively in use; the deferred-eviction path will
+        // pick them up later but they can't be reclaimed right now.
+        if running_chunks_using
+            .get(&c.sha256)
+            .map(|s| !s.is_empty())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        if cache.evict(&c.sha256).await {
+            // Recompute conservatively: a concurrent writer could have
+            // shifted total_size during eviction.
+            current = current.saturating_sub(c.size_bytes);
+            headroom = budget.saturating_sub(current);
+        }
+    }
+    budget.saturating_sub(cache.total_size().await)
 }
 
 /// Maximum Noise transport message (plaintext side). 64 KiB is well within
@@ -278,7 +322,7 @@ async fn connect_and_run(
 
     // Content-addressed file cache for pull-based dispatch. Cheap to
     // clone (Arc inside).
-    let content_cache = ContentCache::new(config.cache_dir());
+    let content_cache = ContentCache::new(config.cache_dir(), config.cache_max_bytes);
 
     // Track running chunks: chunk_id -> kill signal sender (at most one at a time)
     let mut active_chunks: HashMap<Uuid, oneshot::Sender<()>> = HashMap::new();
@@ -592,6 +636,63 @@ async fn connect_and_run(
                             rules_size,
                         } = attack
                         {
+                            // Pre-flight budget check: how much new disk
+                            // does this chunk need, and is the cache going
+                            // to accommodate it after LRU eviction?
+                            let mut needed: u64 = 0;
+                            if !content_cache.has(&wordlist_sha256, wordlist_size).await {
+                                needed = needed.saturating_add(wordlist_size);
+                            }
+                            if let Some(ref rs) = rules_sha256 {
+                                let rz = rules_size.unwrap_or(0);
+                                if !content_cache.has(rs, rz).await {
+                                    needed = needed.saturating_add(rz);
+                                }
+                            }
+
+                            if needed > content_cache.cache_max_bytes() {
+                                warn!(
+                                    %chunk_id,
+                                    needed,
+                                    budget = content_cache.cache_max_bytes(),
+                                    "PullFailed: requested file exceeds cache budget"
+                                );
+                                let _ = outbound_tx
+                                    .send(WorkerMessage::PullFailed {
+                                        chunk_id,
+                                        hash: wordlist_sha256.clone(),
+                                        reason: "file size exceeds cache budget".to_string(),
+                                    })
+                                    .await;
+                                continue;
+                            }
+
+                            if needed > 0 {
+                                let headroom = evict_lru_for_budget(
+                                    &content_cache,
+                                    needed,
+                                    &running_chunks_using,
+                                )
+                                .await;
+                                if headroom < needed {
+                                    warn!(
+                                        %chunk_id,
+                                        needed,
+                                        headroom,
+                                        "PullFailed: insufficient disk after LRU eviction"
+                                    );
+                                    let _ = outbound_tx
+                                        .send(WorkerMessage::PullFailed {
+                                            chunk_id,
+                                            hash: wordlist_sha256.clone(),
+                                            reason: "insufficient disk after LRU eviction"
+                                                .to_string(),
+                                        })
+                                        .await;
+                                    continue;
+                                }
+                            }
+
                             let cache = content_cache.clone();
                             let outbound = outbound_tx.clone();
                             let ready = ready_tx.clone();

--- a/crates/crack-agent/src/main.rs
+++ b/crates/crack-agent/src/main.rs
@@ -188,6 +188,10 @@ async fn cmd_enroll(
         data_dir: data_dir.to_path_buf(),
         hashcat_path: hashcat_path.to_string(),
         headless: false,
+        cache_max_bytes: std::env::var("CRACK_AGENT_CACHE_MAX")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(80 * 1024 * 1024 * 1024),
     };
 
     // Create cache directory

--- a/crates/crack-common/src/protocol.rs
+++ b/crates/crack-common/src/protocol.rs
@@ -178,6 +178,16 @@ pub enum WorkerMessage {
         kept: Vec<String>,
         evicted: Vec<String>,
     },
+    /// Worker couldn't fetch a file required by a chunk (insufficient
+    /// disk after LRU eviction, content cache budget exhausted, etc.).
+    /// Coord treats this like `ChunkFailed` but with a clearer reason —
+    /// the chunk gets reassigned, ideally to a worker with more cache
+    /// headroom.
+    PullFailed {
+        chunk_id: Uuid,
+        hash: String,
+        reason: String,
+    },
 }
 
 /// Compact digest of a single cached file, carried on every agent
@@ -548,6 +558,30 @@ mod tests {
                 assert!(cache_manifest.is_empty(), "legacy should deserialize empty");
             }
             other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_pull_failed() {
+        let chunk_id = Uuid::new_v4();
+        let msg = WorkerMessage::PullFailed {
+            chunk_id,
+            hash: "deadbeef".to_string(),
+            reason: "insufficient disk after LRU".to_string(),
+        };
+        let encoded = encode_message(&msg).unwrap();
+        let (decoded, _): (WorkerMessage, usize) = decode_message(&encoded).unwrap().unwrap();
+        match decoded {
+            WorkerMessage::PullFailed {
+                chunk_id: cid,
+                hash,
+                reason,
+            } => {
+                assert_eq!(cid, chunk_id);
+                assert_eq!(hash, "deadbeef");
+                assert!(reason.contains("disk"));
+            }
+            other => panic!("expected PullFailed, got {other:?}"),
         }
     }
 

--- a/crates/crack-coord/src/main.rs
+++ b/crates/crack-coord/src/main.rs
@@ -276,6 +276,13 @@ async fn cmd_run(config: RunConfig) -> anyhow::Result<()> {
                 data_dir: agent_data_dir,
                 hashcat_path: hc_path,
                 headless: true,
+                // Built-in agent shares the coord's data dir; default
+                // 80 GiB cache budget is fine for most local setups
+                // (operator can set CRACK_AGENT_CACHE_MAX to override).
+                cache_max_bytes: std::env::var("CRACK_AGENT_CACHE_MAX")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(80 * 1024 * 1024 * 1024),
             };
 
             if let Err(e) = crack_agent::connection::run_connection(&run_config, None).await {

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -553,6 +553,41 @@ async fn handle_worker_message(
             Ok(())
         }
 
+        WorkerMessage::PullFailed {
+            chunk_id,
+            hash,
+            reason,
+        } => {
+            // The agent couldn't fetch a file required by this chunk
+            // (cache budget, disk full, etc.). Treat it like a chunk
+            // failure so the abandoned-chunk reassigner picks it up
+            // for a different worker.
+            db::update_chunk_status(&state.db, *chunk_id, ChunkStatus::Failed).await?;
+
+            let wid = worker_id.as_deref().unwrap_or("unknown");
+            warn!(
+                %chunk_id,
+                worker_id = %wid,
+                %hash,
+                %reason,
+                "pull failed: chunk will be reassigned"
+            );
+
+            db::insert_audit(
+                &state.db,
+                "pull_failed",
+                &format!("Worker {wid} couldn't fetch {hash} for chunk {chunk_id}: {reason}"),
+                None,
+                Some(wid),
+            )
+            .await?;
+
+            if let Some(wid) = worker_id.as_deref() {
+                try_assign_work(state, wid, outbound_tx, transferred_files).await?;
+            }
+            Ok(())
+        }
+
         WorkerMessage::CacheAck { kept, evicted } => {
             // The agent has already evicted what we asked. Drop the
             // evicted shas from our coord-side view immediately so the


### PR DESCRIPTION
## Summary
Caches grow without bound today; an agent picking up a 100 GB wordlist on a 200 GB cache root will eventually fill the disk. This slice adds a configurable per-agent budget, a JSON ledger for true LRU ordering (instead of mtime guessing), and a pre-pull eviction pass that makes room or fails the chunk cleanly via the new \`PullFailed\` message.

## Config
- \`RunConfig::cache_max_bytes\` (default 80 GiB; \`--cache-max-bytes\` flag or \`CRACK_AGENT_CACHE_MAX\` env)

## Protocol (additive)
- \`WorkerMessage::PullFailed { chunk_id, hash, reason }\` — coord treats it like \`ChunkFailed\` but with a clearer reason and an explicit "wrong worker" signal so the abandoned-chunk reassigner can route to a worker with more headroom.

## Cache (\`crack-agent/src/cache.rs\`)
- New \`Ledger\` struct persisted at \`<root>/cas-ledger.json\`. Map sha → RFC3339 timestamp of last use. Updated and persisted on every touch / evict.
- \`ContentCache::new\` now takes \`cache_max_bytes\` and loads the ledger from disk.
- \`ensure()\` touches the ledger on both hit and successful pull.
- \`evict()\` clears the matching ledger entry.
- New: \`total_size()\` walks \`cas/\` and sums canonical file sizes, \`lru_candidates()\` returns \`Vec<LruCandidate>\` sorted by \`last_used\` ascending, \`cache_max_bytes()\` getter.

## Agent main loop (\`connection.rs\`)
\`evict_lru_for_budget(cache, needed, running_chunks_using)\` walks LRU candidates, skipping in-use shas, evicting until the cache has room. Returns final headroom.

\`DictionaryByHash\` arm now does a pre-flight:
1. If the requested file alone exceeds the budget → \`PullFailed\`.
2. Compute \`needed\` (wordlist + rules, only counting misses), call \`evict_lru_for_budget\`. If headroom < needed → \`PullFailed\`.
3. Otherwise spawn the pull task as before.

## Coord
\`WorkerMessage::PullFailed\` handler marks chunk Failed, audit-logs with worker + hash + reason, calls \`try_assign_work\` to keep the worker busy with something else.

## Tests (5 new)
- crack-agent (4): \`total_size\` sums canonical only; ledger persists across \`new()\` over the same root; \`lru_candidates\` orders by last_used ascending; \`evict\` clears the ledger entry
- crack-common (1): \`PullFailed\` round-trip

Totals: crack-agent 64, crack-common 52, crack-coord 67.

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all pass
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] Manual smoke: set \`CRACK_AGENT_CACHE_MAX=1073741824\` (1 GiB), upload three 500 MiB wordlists, run a task per wordlist back-to-back. Confirm the third task triggers LRU eviction of the first wordlist (logs: "evicted by LRU") rather than failing.
- [ ] Manual smoke: set \`CRACK_AGENT_CACHE_MAX=104857600\` (100 MiB), try to assign a task with a 200 MiB wordlist. Confirm \`PullFailed\` arrives at coord with reason "file size exceeds cache budget" and the chunk gets reassigned.

Auto-merge queued.