### PR TITLE
feat(operator): pin/unpin/gc CLI + cache visibility (Slice 11/11)

### DIFF
--- a/crates/crack-coord/src/api/files.rs
+++ b/crates/crack-coord/src/api/files.rs
@@ -258,6 +258,67 @@ fn device_id_of(path: &std::path::Path) -> ApiResult<u64> {
     }
 }
 
+/// Pin a file so it's never auto-GC'd. Idempotent.
+pub async fn pin_file(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> ApiResult<impl IntoResponse> {
+    if !db::set_file_pinned(&state.db, &id, true).await? {
+        return Err(ApiError::NotFound(format!("file {id} not found")));
+    }
+    info!(file_id = %id, "pinned file");
+    Ok((StatusCode::OK, Json(serde_json::json!({"pinned": true}))))
+}
+
+/// Unpin a file. Subsequent terminal task transitions can mark it for
+/// GC in the normal way.
+pub async fn unpin_file(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> ApiResult<impl IntoResponse> {
+    if !db::set_file_pinned(&state.db, &id, false).await? {
+        return Err(ApiError::NotFound(format!("file {id} not found")));
+    }
+    info!(file_id = %id, "unpinned file");
+    Ok((StatusCode::OK, Json(serde_json::json!({"pinned": false}))))
+}
+
+/// Trigger a GC pass right now instead of waiting for the periodic
+/// loop. Returns once the pass completes (or errors).
+pub async fn gc_now(State(state): State<Arc<AppState>>) -> ApiResult<impl IntoResponse> {
+    crate::lifecycle::run_gc_once(&state)
+        .await
+        .map_err(|e| ApiError::Internal(format!("gc_pass failed: {e}")))?;
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({"status": "completed"})),
+    ))
+}
+
+#[derive(Serialize)]
+pub struct WorkerCacheStatus {
+    pub worker_id: String,
+    pub file_count: i64,
+    pub total_bytes: i64,
+}
+
+/// Per-worker cache summary used by `crackctl status --cache` and the
+/// TUI workers view.
+pub async fn cache_status(
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<Vec<WorkerCacheStatus>>> {
+    let rows = db::cache_summary_per_worker(&state.db).await?;
+    let entries: Vec<WorkerCacheStatus> = rows
+        .into_iter()
+        .map(|(worker_id, file_count, total_bytes)| WorkerCacheStatus {
+            worker_id,
+            file_count,
+            total_bytes,
+        })
+        .collect();
+    Ok(Json(entries))
+}
+
 pub async fn download_file(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/crates/crack-coord/src/api/mod.rs
+++ b/crates/crack-coord/src/api/mod.rs
@@ -94,8 +94,12 @@ pub fn create_router(state: Arc<AppState>) -> Router {
                 .layer(DefaultBodyLimit::disable()),
         )
         .route("/api/v1/files/hardlink", post(files::hardlink_file))
+        .route("/api/v1/files/gc", post(files::gc_now))
         .route("/api/v1/files/{id}", get(files::download_file))
+        .route("/api/v1/files/{id}/pin", post(files::pin_file))
+        .route("/api/v1/files/{id}/unpin", post(files::unpin_file))
         .route("/api/v1/server-info", get(files::server_info))
+        .route("/api/v1/cache/status", get(files::cache_status))
         // Workers
         .route("/api/v1/workers", get(workers::list_workers))
         .route("/api/v1/workers/authorize", post(workers::authorize_worker))

--- a/crates/crack-coord/src/lifecycle.rs
+++ b/crates/crack-coord/src/lifecycle.rs
@@ -44,6 +44,13 @@ pub async fn run_gc_loop(state: Arc<AppState>) {
     }
 }
 
+/// Run one GC pass on demand. Same logic as the periodic loop —
+/// callable from `POST /api/v1/files/gc` so operators can flush
+/// reclaimed disk immediately instead of waiting for the next tick.
+pub async fn run_gc_once(state: &AppState) -> Result<()> {
+    gc_pass(state).await
+}
+
 async fn gc_pass(state: &AppState) -> Result<()> {
     let queued = db::list_gc_queue(&state.db).await?;
     for (sha, attempts) in queued {

--- a/crates/crack-coord/src/storage/db.rs
+++ b/crates/crack-coord/src/storage/db.rs
@@ -1398,6 +1398,48 @@ pub async fn set_gc_state_deleting(pool: &SqlitePool, sha256: &str) -> Result<()
     Ok(())
 }
 
+/// Toggle the `pinned` flag on a single file. Pinned files are skipped
+/// by the GC loop even when their refcount is zero.
+pub async fn set_file_pinned(pool: &SqlitePool, file_id: &str, pinned: bool) -> Result<bool> {
+    let result = sqlx::query("UPDATE files SET pinned = ?1 WHERE id = ?2")
+        .bind(if pinned { 1i64 } else { 0 })
+        .bind(file_id)
+        .execute(pool)
+        .await
+        .context("updating files.pinned")?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Per-worker cache summary: how many entries the worker holds and the
+/// total bytes those entries represent. Powers `crackctl status --cache`
+/// and the TUI's workers-view cache column.
+pub async fn cache_summary_per_worker(pool: &SqlitePool) -> Result<Vec<(String, i64, i64)>> {
+    // Returns (worker_id, file_count, total_bytes) — including 0/0 rows
+    // for connected workers with empty caches so the status output lists
+    // every worker, not only the busy ones.
+    let rows = sqlx::query(
+        "SELECT w.id AS wid, \
+                COALESCE(SUM(CASE WHEN wce.file_sha256 IS NOT NULL THEN 1 ELSE 0 END), 0) AS file_count, \
+                COALESCE(SUM(wce.size_bytes), 0) AS total_bytes \
+         FROM workers w \
+         LEFT JOIN worker_cache_entries wce ON wce.worker_id = w.id \
+         GROUP BY w.id \
+         ORDER BY w.id",
+    )
+    .fetch_all(pool)
+    .await
+    .context("computing cache_summary_per_worker")?;
+    rows.iter()
+        .map(|r| {
+            Ok((
+                r.get::<String, _>("wid"),
+                r.get::<i64, _>("file_count"),
+                r.get::<i64, _>("total_bytes"),
+            ))
+        })
+        .collect()
+}
+
 /// All sha256s currently considered "live" on the coord — i.e. files with
 /// `gc_state = 'active'`. Used by reconciliation to tell a (re)connecting
 /// worker which content it's still allowed to keep cached.
@@ -2611,6 +2653,67 @@ mod tests {
             workers_with_file(&pool, "shared").await.unwrap(),
             vec!["w-b".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn set_file_pinned_round_trip() {
+        let pool = mem_pool().await;
+        seed_file(&pool, "f-pin", "sha-pin").await;
+
+        // Pin → reflected in is_sha_pinned and column.
+        let updated = set_file_pinned(&pool, "f-pin", true).await.unwrap();
+        assert!(updated);
+        assert!(is_sha_pinned(&pool, "sha-pin").await.unwrap());
+
+        // Unpin.
+        let updated = set_file_pinned(&pool, "f-pin", false).await.unwrap();
+        assert!(updated);
+        assert!(!is_sha_pinned(&pool, "sha-pin").await.unwrap());
+
+        // Missing file id returns false.
+        assert!(!set_file_pinned(&pool, "nonexistent", true).await.unwrap());
+    }
+
+    async fn seed_worker(pool: &SqlitePool, id: &str, name: &str) {
+        let now = Utc::now();
+        let worker = Worker {
+            id: id.to_string(),
+            name: name.to_string(),
+            public_key: format!("pk-{id}"),
+            devices: vec![],
+            hashcat_version: None,
+            os: None,
+            status: WorkerStatus::Idle,
+            created_at: now,
+            last_seen_at: now,
+        };
+        create_or_update_worker(pool, &worker).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cache_summary_includes_workers_with_empty_caches() {
+        let pool = mem_pool().await;
+        seed_worker(&pool, "w-empty", "empty").await;
+        seed_worker(&pool, "w-busy", "busy").await;
+        sync_worker_cache_manifest(
+            &pool,
+            "w-busy",
+            &[manifest_entry("aa", 100), manifest_entry("bb", 250)],
+        )
+        .await
+        .unwrap();
+
+        let mut summary = cache_summary_per_worker(&pool).await.unwrap();
+        summary.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(summary.len(), 2);
+        // w-busy: 2 files, 350 bytes total
+        let busy = summary.iter().find(|s| s.0 == "w-busy").unwrap();
+        assert_eq!(busy.1, 2);
+        assert_eq!(busy.2, 350);
+        // w-empty: 0/0, but still listed
+        let empty = summary.iter().find(|s| s.0 == "w-empty").unwrap();
+        assert_eq!(empty.1, 0);
+        assert_eq!(empty.2, 0);
     }
 
     #[tokio::test]

--- a/crates/crack-coord/src/tui/app.rs
+++ b/crates/crack-coord/src/tui/app.rs
@@ -101,6 +101,10 @@ pub struct TuiState {
     pub status: Option<SystemStatus>,
     pub campaigns: Vec<Campaign>,
     pub campaign_phases: Vec<CampaignPhase>,
+    /// Per-worker content cache summary keyed by worker_id —
+    /// (file_count, total_bytes). Powers the cache column on the
+    /// workers view.
+    pub cache_summary: std::collections::HashMap<String, (i64, i64)>,
 }
 
 impl TuiState {
@@ -128,6 +132,7 @@ impl TuiState {
             status: None,
             campaigns: Vec::new(),
             campaign_phases: Vec::new(),
+            cache_summary: std::collections::HashMap::new(),
         }
     }
 
@@ -282,6 +287,7 @@ impl TuiState {
         self.audit_entries = data.audit_entries;
         self.status = data.status;
         self.campaigns = data.campaigns;
+        self.cache_summary = data.cache_summary;
 
         if let Some(chunks) = data.chunks {
             self.chunks = chunks;
@@ -302,4 +308,6 @@ pub struct TuiData {
     pub status: Option<SystemStatus>,
     pub campaigns: Vec<Campaign>,
     pub campaign_phases: Option<Vec<CampaignPhase>>,
+    /// Per-worker (file_count, total_bytes), keyed by worker_id.
+    pub cache_summary: std::collections::HashMap<String, (i64, i64)>,
 }

--- a/crates/crack-coord/src/tui/mod.rs
+++ b/crates/crack-coord/src/tui/mod.rs
@@ -110,6 +110,12 @@ fn spawn_data_refresher(
                 .unwrap_or_default();
             let status = db::get_system_status(&state.db).await.ok();
             let campaigns = db::list_campaigns(&state.db).await.unwrap_or_default();
+            let cache_summary = db::cache_summary_per_worker(&state.db)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(wid, count, bytes)| (wid, (count, bytes)))
+                .collect::<std::collections::HashMap<_, _>>();
 
             let chunks = if let Some(tid) = selected_task_id {
                 Some(
@@ -140,6 +146,7 @@ fn spawn_data_refresher(
                 status,
                 campaigns,
                 campaign_phases,
+                cache_summary,
             };
 
             if data_tx.send(data).is_err() {

--- a/crates/crack-coord/src/tui/views/workers.rs
+++ b/crates/crack-coord/src/tui/views/workers.rs
@@ -84,6 +84,17 @@ pub fn render_worker_detail(f: &mut Frame, area: Rect, state: &TuiState) {
         format!("{}h ago", elapsed.num_hours())
     };
 
+    let cache_summary = state
+        .cache_summary
+        .get(&worker.id)
+        .copied()
+        .unwrap_or((0, 0));
+    let cache_str = format!(
+        "{} files, {}",
+        cache_summary.0,
+        format_bytes(cache_summary.1)
+    );
+
     let mut lines = vec![
         Line::from(vec![
             Span::styled("  ID:           ", Style::default().fg(Theme::SUBTEXT0)),
@@ -114,6 +125,10 @@ pub fn render_worker_detail(f: &mut Frame, area: Rect, state: &TuiState) {
                 Style::default().fg(Theme::TEXT),
             ),
         ]),
+        Line::from(vec![
+            Span::styled("  Cache:        ", Style::default().fg(Theme::SUBTEXT0)),
+            Span::styled(cache_str, Style::default().fg(Theme::TEXT)),
+        ]),
         Line::default(),
         Line::from(Span::styled(
             "  Devices:",
@@ -139,4 +154,26 @@ pub fn render_worker_detail(f: &mut Frame, area: Rect, state: &TuiState) {
 
     let paragraph = Paragraph::new(lines).block(block);
     f.render_widget(paragraph, area);
+}
+
+/// Render `bytes` in IEC units (KiB / MiB / GiB / TiB) with one decimal
+/// place. Negative values clamp to "0 B" — they shouldn't happen, but the
+/// underlying SUM(...) i64 leaves the door open and we'd rather not panic
+/// inside the render path.
+fn format_bytes(bytes: i64) -> String {
+    if bytes <= 0 {
+        return "0 B".to_string();
+    }
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} B", bytes)
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
 }

--- a/crates/crackctl/src/client.rs
+++ b/crates/crackctl/src/client.rs
@@ -81,6 +81,13 @@ struct ServerInfo {
     pub device_id: u64,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct WorkerCacheStatus {
+    pub worker_id: String,
+    pub file_count: i64,
+    pub total_bytes: i64,
+}
+
 #[derive(Debug, Serialize)]
 struct HardlinkPayload {
     pub source_path: String,
@@ -509,6 +516,52 @@ impl Client {
         let resp = Self::check(resp).await?;
         let files: Vec<FileRecord> = resp.json().await.context("failed to parse files")?;
         Ok(files)
+    }
+
+    pub async fn pin_file(&self, file_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/api/v1/files/{file_id}/pin")))
+            .send()
+            .await
+            .context("failed to reach coordinator")?;
+        Self::check(resp).await?;
+        Ok(())
+    }
+
+    pub async fn unpin_file(&self, file_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/api/v1/files/{file_id}/unpin")))
+            .send()
+            .await
+            .context("failed to reach coordinator")?;
+        Self::check(resp).await?;
+        Ok(())
+    }
+
+    pub async fn gc_now(&self) -> Result<()> {
+        let resp = self
+            .http
+            .post(self.url("/api/v1/files/gc"))
+            .send()
+            .await
+            .context("failed to reach coordinator")?;
+        Self::check(resp).await?;
+        Ok(())
+    }
+
+    pub async fn cache_status(&self) -> Result<Vec<WorkerCacheStatus>> {
+        let resp = self
+            .http
+            .get(self.url("/api/v1/cache/status"))
+            .send()
+            .await
+            .context("failed to reach coordinator")?;
+        let resp = Self::check(resp).await?;
+        let entries: Vec<WorkerCacheStatus> =
+            resp.json().await.context("failed to parse cache status")?;
+        Ok(entries)
     }
 
     // ── Workers ──

--- a/crates/crackctl/src/display.rs
+++ b/crates/crackctl/src/display.rs
@@ -310,6 +310,27 @@ pub fn print_status(status: &SystemStatus) {
     );
 }
 
+/// Per-worker content cache summary appended to `crackctl status --cache`.
+pub fn print_cache_status(entries: &[crate::client::WorkerCacheStatus]) {
+    println!();
+    println!("\u{2550}\u{2550}\u{2550} Cache (per worker) \u{2550}\u{2550}\u{2550}");
+    println!();
+    if entries.is_empty() {
+        println!("  (no workers known to the coordinator)");
+        return;
+    }
+    println!("  {:<40} {:>8} {:>14}", "WORKER ID", "FILES", "BYTES");
+    println!("  {}", "-".repeat(64));
+    for e in entries {
+        println!(
+            "  {:<40} {:>8} {:>14}",
+            short_id(&e.worker_id),
+            e.file_count,
+            human_size(e.total_bytes)
+        );
+    }
+}
+
 // ── Potfile ──
 
 pub fn print_potfile_stats(stats: &PotfileStats) {

--- a/crates/crackctl/src/main.rs
+++ b/crates/crackctl/src/main.rs
@@ -56,7 +56,12 @@ enum Commands {
         action: PotfileAction,
     },
     /// Show system overview
-    Status,
+    Status {
+        /// Append a per-worker content-cache summary (file count and
+        /// total bytes for each connected worker).
+        #[arg(long)]
+        cache: bool,
+    },
 }
 
 // ── Task subcommands ──
@@ -153,6 +158,19 @@ enum FileAction {
     },
     /// List uploaded files
     List,
+    /// Pin a file so it's never auto-GC'd by the coord
+    Pin {
+        /// File ID (from `file list`)
+        id: String,
+    },
+    /// Unpin a file: GC may reclaim it once no task/campaign references it
+    Unpin {
+        /// File ID (from `file list`)
+        id: String,
+    },
+    /// Trigger an immediate GC pass on the coord (drains the queue
+    /// instead of waiting for the periodic 60s tick)
+    Gc,
 }
 
 // ── Worker subcommands ──
@@ -295,7 +313,7 @@ async fn main() -> Result<()> {
         Commands::Worker { action } => handle_worker(&client, action).await?,
         Commands::Campaign { action } => handle_campaign(&client, action).await?,
         Commands::Potfile { action } => handle_potfile(&client, action).await?,
-        Commands::Status => handle_status(&client).await?,
+        Commands::Status { cache } => handle_status(&client, cache).await?,
     }
 
     Ok(())
@@ -414,6 +432,21 @@ async fn handle_file(client: &Client, action: FileAction) -> Result<()> {
         FileAction::List => {
             let files = client.list_files().await?;
             display::print_files(&files);
+        }
+
+        FileAction::Pin { id } => {
+            client.pin_file(&id).await?;
+            println!("File {id} pinned (GC will skip it).");
+        }
+
+        FileAction::Unpin { id } => {
+            client.unpin_file(&id).await?;
+            println!("File {id} unpinned.");
+        }
+
+        FileAction::Gc => {
+            client.gc_now().await?;
+            println!("GC pass complete.");
         }
     }
 
@@ -587,8 +620,12 @@ async fn handle_potfile(client: &Client, action: PotfileAction) -> Result<()> {
     Ok(())
 }
 
-async fn handle_status(client: &Client) -> Result<()> {
+async fn handle_status(client: &Client, with_cache: bool) -> Result<()> {
     let status = client.get_status().await?;
     display::print_status(&status);
+    if with_cache {
+        let entries = client.cache_status().await?;
+        display::print_cache_status(&entries);
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
**Closes the 11-slice big-file plan.** Three new \`crackctl\` subcommands and a status flag surface the lifecycle machinery built across Slices 7–10:

| Surface | Purpose |
|---|---|
| \`crackctl file pin <id>\` | Set \`files.pinned=1\`. GC skips this file forever. |
| \`crackctl file unpin <id>\` | Clear the pin. Normal refcount-driven GC resumes. |
| \`crackctl file gc\` | Trigger an immediate GC pass on the coord — no waiting for the 60s tick. |
| \`crackctl status --cache\` | Per-worker cache summary (file count + total bytes). |
| TUI workers view | Adds a \`Cache:\` line on the detail panel. |

## REST
- \`POST /api/v1/files/{id}/pin\`
- \`POST /api/v1/files/{id}/unpin\`
- \`POST /api/v1/files/gc\`
- \`GET /api/v1/cache/status\`

## Coord internals
- \`db::set_file_pinned\` — idempotent UPDATE on \`files.pinned\`
- \`db::cache_summary_per_worker\` — LEFT JOIN \`workers\` + \`worker_cache_entries\` so idle workers still appear (with 0/0)
- \`lifecycle::run_gc_once\` — public wrapper around the existing \`gc_pass\` so the API handler can fire one synchronously

## TUI
The workers detail view now shows a "Cache:" line formatted as \`<n> files, <bytes>\` with IEC units. TuiState carries a \`HashMap<worker_id, (file_count, total_bytes)>\` populated from the same DB helper as the CLI.

## Tests (3 new)
- \`set_file_pinned\` round-trip + missing-id no-op
- \`cache_summary_per_worker\` includes empty-cache workers in result

Totals: crack-agent 64, crack-common 52, crack-coord 69.

## Plan complete
Every byte on every disk is now:
- **Ref-counted** by tasks/campaigns (Slice 7)
- **Evicted** from agent caches when refs drop (Slice 8)
- **Reconciled** on (re)connect to catch any drift (Slice 9)
- **LRU-managed** within a configurable budget on each agent (Slice 10)
- **Pinnable / GC-triggerable / introspectable** by the operator (Slice 11)

## Test plan
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — all pass
- [x] \`cargo audit\` — 0 findings
- [ ] CI green
- [ ] Manual smoke: \`crackctl file pin <id>\`; complete a task using that file; confirm GC doesn't reclaim it. \`crackctl file unpin <id>\`; \`crackctl file gc\`; confirm reclaim happens immediately. \`crackctl status --cache\` shows per-worker rows.

Auto-merge queued.