### PR TITLE
fix(lifecycle): close GC vs heartbeat-sync race for cache eviction

### DIFF
--- a/crates/crack-coord/src/lifecycle.rs
+++ b/crates/crack-coord/src/lifecycle.rs
@@ -17,6 +17,7 @@
 //! staleness is bounded but non-zero, and fully resolved once those two
 //! slices ship.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -24,7 +25,7 @@ use anyhow::Result;
 use crack_common::protocol::CoordMessage;
 use tracing::{debug, info, warn};
 
-use crate::state::AppState;
+use crate::state::{AppState, WorkerConnection};
 use crate::storage::{db, files};
 
 const GC_INTERVAL: Duration = Duration::from_secs(60);
@@ -76,11 +77,13 @@ async fn gc_pass(state: &AppState) -> Result<()> {
         // Reserve this entry for the current pass.
         db::set_gc_state_deleting(&state.db, &sha).await?;
 
-        // Broadcast EvictFile to every connected worker that reportedly
-        // holds this file. Misses are fine: a disconnected or late worker
-        // picks it up on the next reconcile pass (Slice 9). Agents that
-        // are currently running a chunk against the file defer the
-        // eviction locally until the chunk finishes.
+        // Tell holders to drop this file from their cache. The DB-backed
+        // list (`workers_with_file`) is heartbeat-driven and can lag a
+        // freshly-pulled file by up to one heartbeat interval (~15s).
+        // When the targeted list is empty we fall back to a broadcast
+        // across every connected worker — agents without the file no-op
+        // locally (`crack-agent::ContentCache::evict` returns false on a
+        // missing path). See issue #45.
         let workers = match db::workers_with_file(&state.db, &sha).await {
             Ok(ws) => ws,
             Err(e) => {
@@ -88,29 +91,16 @@ async fn gc_pass(state: &AppState) -> Result<()> {
                 Vec::new()
             }
         };
-        if !workers.is_empty() {
-            let conns = state.worker_connections.read().await;
-            let mut dispatched = 0;
-            for worker_id in &workers {
-                if let Some(conn) = conns.get(worker_id) {
-                    if conn
-                        .tx
-                        .send(CoordMessage::EvictFile { hash: sha.clone() })
-                        .await
-                        .is_ok()
-                    {
-                        dispatched += 1;
-                    }
-                }
-            }
-            drop(conns);
-            debug!(
-                %sha,
-                workers = workers.len(),
-                dispatched,
-                "GC: sent EvictFile to workers"
-            );
-        }
+        let conns = state.worker_connections.read().await;
+        let (dispatched, fallback) = dispatch_evict_for_sha(&conns, &sha, &workers).await;
+        drop(conns);
+        debug!(
+            %sha,
+            fallback,
+            targeted = workers.len(),
+            dispatched,
+            "GC: EvictFile dispatch complete"
+        );
 
         // Reclaim every files row (and disk file) sharing this sha. A
         // legacy deployment with duplicate sha rows may hit >1 here.
@@ -143,4 +133,151 @@ async fn gc_pass(state: &AppState) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Send `EvictFile` for `sha` to the workers that should drop it.
+///
+/// Two paths:
+/// - **Targeted**: when `targeted` is non-empty, send only to those
+///   worker IDs (the heartbeat-derived view said they hold the file).
+/// - **Fallback broadcast**: when `targeted` is empty, send to every
+///   connected worker. The coord's view of who-holds-what is
+///   heartbeat-driven (every 15s), so a freshly-pulled file may not
+///   yet appear in `worker_cache_entries`; broadcasting closes that
+///   race. Agents without the file no-op locally
+///   (`ContentCache::evict` returns `false`).
+///
+/// Returns `(dispatched, fallback)` — dispatch count and whether the
+/// fallback path fired. Fully read-only on `conns`; safe to call while
+/// holding the `worker_connections` read lock.
+pub(crate) async fn dispatch_evict_for_sha(
+    conns: &HashMap<String, WorkerConnection>,
+    sha: &str,
+    targeted: &[String],
+) -> (usize, bool) {
+    let mut dispatched = 0usize;
+    let fallback = targeted.is_empty();
+
+    if fallback {
+        for (worker_id, conn) in conns.iter() {
+            if conn
+                .tx
+                .send(CoordMessage::EvictFile {
+                    hash: sha.to_string(),
+                })
+                .await
+                .is_ok()
+            {
+                dispatched += 1;
+            } else {
+                debug!(%sha, %worker_id, "GC: fallback EvictFile send failed");
+            }
+        }
+    } else {
+        for worker_id in targeted {
+            if let Some(conn) = conns.get(worker_id) {
+                if conn
+                    .tx
+                    .send(CoordMessage::EvictFile {
+                        hash: sha.to_string(),
+                    })
+                    .await
+                    .is_ok()
+                {
+                    dispatched += 1;
+                }
+            }
+        }
+    }
+    (dispatched, fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn fake_conn(worker_id: &str) -> (WorkerConnection, mpsc::Receiver<CoordMessage>) {
+        let (tx, rx) = mpsc::channel(64);
+        let conn = WorkerConnection {
+            worker_id: worker_id.to_string(),
+            name: worker_id.to_string(),
+            tx,
+            peer_addr: "127.0.0.1:0".to_string(),
+        };
+        (conn, rx)
+    }
+
+    #[tokio::test]
+    async fn dispatch_evict_targets_only_known_holders() {
+        let (c1, mut r1) = fake_conn("w1");
+        let (c2, mut r2) = fake_conn("w2");
+        let (c3, mut r3) = fake_conn("w3");
+        let mut conns = HashMap::new();
+        conns.insert("w1".to_string(), c1);
+        conns.insert("w2".to_string(), c2);
+        conns.insert("w3".to_string(), c3);
+
+        let (dispatched, fallback) =
+            dispatch_evict_for_sha(&conns, "sha-x", &["w1".to_string()]).await;
+
+        assert_eq!(dispatched, 1);
+        assert!(!fallback);
+        // Only w1 received the message.
+        assert!(matches!(r1.try_recv(), Ok(CoordMessage::EvictFile { hash }) if hash == "sha-x"));
+        assert!(r2.try_recv().is_err());
+        assert!(r3.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn dispatch_evict_falls_back_to_broadcast_when_targeted_empty() {
+        // Primary regression for #45: heartbeat hasn't yet sync'd the
+        // freshly-pulled file, so workers_with_file returns empty. The
+        // fallback must reach every connected worker.
+        let (c1, mut r1) = fake_conn("w1");
+        let (c2, mut r2) = fake_conn("w2");
+        let (c3, mut r3) = fake_conn("w3");
+        let mut conns = HashMap::new();
+        conns.insert("w1".to_string(), c1);
+        conns.insert("w2".to_string(), c2);
+        conns.insert("w3".to_string(), c3);
+
+        let (dispatched, fallback) = dispatch_evict_for_sha(&conns, "sha-y", &[]).await;
+
+        assert_eq!(dispatched, 3);
+        assert!(fallback);
+        for r in [&mut r1, &mut r2, &mut r3] {
+            assert!(
+                matches!(r.try_recv(), Ok(CoordMessage::EvictFile { hash }) if hash == "sha-y")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_evict_with_no_connections_is_safe_noop() {
+        let conns: HashMap<String, WorkerConnection> = HashMap::new();
+        let (dispatched, fallback) = dispatch_evict_for_sha(&conns, "sha-z", &[]).await;
+        assert_eq!(dispatched, 0);
+        assert!(fallback);
+    }
+
+    #[tokio::test]
+    async fn dispatch_evict_with_failed_send_is_counted_as_miss() {
+        let (c1, mut r1) = fake_conn("w1");
+        let (c2, _r2_dropped) = fake_conn("w2"); // drop receiver below
+        let (c3, mut r3) = fake_conn("w3");
+        let mut conns = HashMap::new();
+        conns.insert("w1".to_string(), c1);
+        conns.insert("w2".to_string(), c2);
+        conns.insert("w3".to_string(), c3);
+        // Drop w2's receiver so its tx.send returns Err.
+        drop(_r2_dropped);
+
+        let (dispatched, fallback) = dispatch_evict_for_sha(&conns, "sha-q", &[]).await;
+
+        assert_eq!(dispatched, 2, "w2's failed send must not be counted");
+        assert!(fallback);
+        assert!(matches!(r1.try_recv(), Ok(CoordMessage::EvictFile { hash }) if hash == "sha-q"));
+        assert!(matches!(r3.try_recv(), Ok(CoordMessage::EvictFile { hash }) if hash == "sha-q"));
+    }
 }

--- a/crates/crack-coord/src/transport/handler.rs
+++ b/crates/crack-coord/src/transport/handler.rs
@@ -357,6 +357,32 @@ async fn handle_worker_message(
                 {
                     warn!(worker = %wid, error = %e, "failed to sync cache manifest");
                 }
+
+                // Drift-correction tick (issue #45). If the manifest carries
+                // a sha that is no longer active on the coord, tell the agent
+                // to evict it. Catches: missed `EvictFile` (mpsc backpressure
+                // / transient drop), post-coord-restart staleness, and any
+                // other cause of view divergence between coord and agent.
+                // Same-cycle double-fires (this PR's gc_pass fallback +
+                // heartbeat re-evict) are harmless: agent's `evict` is
+                // idempotent and no-ops a second call.
+                match db::list_active_file_shas(&state.db).await {
+                    Ok(active) => {
+                        let active: std::collections::HashSet<_> = active.into_iter().collect();
+                        for entry in cache_manifest {
+                            if !active.contains(&entry.sha256) {
+                                let _ = outbound_tx
+                                    .send(CoordMessage::EvictFile {
+                                        hash: entry.sha256.clone(),
+                                    })
+                                    .await;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(worker = %wid, error = %e, "drift-correction lookup failed")
+                    }
+                }
             }
             Ok(())
         }


### PR DESCRIPTION
## Summary

Closes #45.

GC's `EvictFile` dispatch read `worker_cache_entries`, which is only populated by the agent heartbeat (every 15s) via `db::sync_worker_cache_manifest`. A wordlist freshly pulled by an agent didn't appear in the coord's view until the next heartbeat — so if GC fired in that window, no `EvictFile` was sent and the agent's cache file leaked until the next reconnect. Slice 9's `CacheReconcile` only fires on register, so a healthy long-lived agent never recovered.

Reliable repro on tiny wordlists (sub-second hashcat runs); 20s sleep before `crackctl file gc` consistently avoided the race.

## Two complementary fixes

| Scenario | Fix 1 (gc_pass fallback) | Fix 2 (heartbeat drift-correction) |
|---|---|---|
| GC fires before first heartbeat after a pull | ✅ broadcasts to everyone | ❌ no heartbeat happened yet |
| Agent missed an `EvictFile` (mpsc backpressure) | ❌ already sent once | ✅ next heartbeat re-evicts |
| Coord restart, in-memory state lost, agent had file | ❌ DB view lags | ✅ next heartbeat sees inactive sha |
| `worker_cache_entries` row out of sync (any cause) | partial | ✅ self-heals next tick |

### Fix 1 — fallback broadcast (`lifecycle.rs`)

When `workers_with_file(sha)` returns empty, broadcast `EvictFile` to every connected worker. Agents without the file no-op locally (`crack-agent::ContentCache::evict` returns `false` for missing paths; the handler at `connection.rs:919-934` is fully idempotent). ~80 bytes per connected worker per reclaimed file.

Refactor: extract `dispatch_evict_for_sha(conns, sha, targeted) -> (dispatched, fallback)` helper from `gc_pass` so the dispatch is unit-testable without an `AppState` harness.

### Fix 2 — drift-correction (`transport/handler.rs`)

After `sync_worker_cache_manifest`, compare manifest shas to `list_active_file_shas` and send `EvictFile` for any sha that's no longer active on the coord. Per-heartbeat-per-worker cost: one query + an O(manifest) HashSet diff.

## Cosmetic risk

If GC fires and broadcasts (Fix 1), then a heartbeat arrives within 15s carrying the now-stale sha (Fix 2 path), the agent receives a second `EvictFile`. Logged as `removed=false` and dropped. Idempotent.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — crack-coord 69 → 73 (+4 helper tests):
  - `dispatch_evict_targets_only_known_holders`
  - `dispatch_evict_falls_back_to_broadcast_when_targeted_empty` (primary regression for #45)
  - `dispatch_evict_with_no_connections_is_safe_noop`
  - `dispatch_evict_with_failed_send_is_counted_as_miss`
- [ ] Manual smoke replay of #45:
  - upload wordlist, immediately create + complete task using it
  - `crackctl file gc` within 15s of completion
  - coord log shows `GC: EvictFile dispatch complete fallback=true dispatched=1`
  - agent's cache directory no longer contains the sha

## Adjacent bug found during investigation (not in this PR)

**Disconnect-without-cleanup leaks `worker_cache_entries` rows forever**: `handler.rs:528, 1086` and `monitor.rs:154` remove the worker from `worker_connections` but never clear its rows from `worker_cache_entries`. Combined with `workers_with_file` not filtering by worker status, GC keeps "dispatching" to disconnected workers. Same shape as #45 but bounded only by reconnect (or never, if the worker is truly gone). Worth filing as a separate issue.

## Independence

Independent of PRs #46 and #47. Branched off main, no shared files.