### PR TITLE
docs: rustdoc audit fixes — drift, # Errors sections, public-API coverage

### DIFF
--- a/crates/crack-agent/src/cache.rs
+++ b/crates/crack-agent/src/cache.rs
@@ -161,6 +161,24 @@ impl ContentCache {
     ///
     /// Both cache hits and successful pulls touch the LRU ledger so the
     /// most-recently-used entries float to the top.
+    ///
+    /// Concurrent calls for the same `hash` serialize on a per-hash mutex —
+    /// the second caller waits and then sees the cached entry.
+    ///
+    /// # Errors
+    /// - `hash` shorter than 2 hex chars (used as the shard prefix).
+    /// - Failure creating the shard directory or writing the `.partial`
+    ///   file.
+    /// - The `outbound_tx` channel is closed before the pull completes.
+    /// - The coord answers with `FileError` (surfaced as
+    ///   `"coord refused file range: <reason>"`).
+    /// - The coord delivers a chunk at the wrong offset, or an empty
+    ///   non-EOF chunk.
+    /// - Total bytes received before EOF differ from the declared `size`.
+    /// - The sha256 of the assembled bytes doesn't match `hash`.
+    /// - The atomic rename `<hash>.partial` → `<hash>` fails.
+    ///
+    /// On any error the in-progress `.partial` is best-effort removed.
     pub async fn ensure(
         self: &Arc<Self>,
         hash: &str,
@@ -324,6 +342,11 @@ impl ContentCache {
     /// valid cached file. Entries the agent considers incomplete (missing,
     /// unreadable, zero-byte `.partial` leftovers) are skipped. Called on
     /// every heartbeat tick so the coord can reconcile its view.
+    ///
+    /// Note: `last_used_at` here is filesystem `mtime`, NOT the in-memory
+    /// LRU ledger consulted by `lru_candidates()`. mtime is "good enough"
+    /// for the coord's reconciliation pass; for in-process LRU ordering
+    /// prefer `lru_candidates()`.
     pub async fn manifest(&self) -> Vec<CacheManifestEntry> {
         let cas_root = self.root.join("cas");
         let mut out = Vec::new();

--- a/crates/crack-agent/src/connection.rs
+++ b/crates/crack-agent/src/connection.rs
@@ -1,3 +1,12 @@
+//! Agent main loop: TCP + Noise IK handshake, registration/enrollment,
+//! and the long-lived `select!` that multiplexes heartbeats, runner
+//! events, off-loop outbound messages, content-cache pulls, and
+//! incoming `CoordMessage`s.
+//!
+//! Everything stays on a single task because `snow::TransportState` is
+//! `!Send`. Off-loop work (cache pulls, hashcat subprocesses) hands
+//! results back via mpsc channels the main loop polls.
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -106,10 +115,18 @@ fn emit(tx: &Option<mpsc::UnboundedSender<AgentEvent>>, event: AgentEvent) {
 
 /// Main entry point: connect to the coordinator and run the message loop.
 ///
-/// On disconnect the function returns an `Err` so the caller can apply
-/// exponential backoff and reconnect.
+/// Loops forever, transparently reconnecting after disconnects with
+/// exponential backoff (capped at 60s) — the caller never sees a transient
+/// failure. Returns `Ok(())` only when the coordinator sends `Shutdown`,
+/// at which point the agent should exit cleanly.
 ///
 /// When `event_tx` is `Some`, agent TUI events are emitted for live display.
+///
+/// # Errors
+/// Returns `Err` only for unrecoverable startup errors (failed to load
+/// the agent keypair or coordinator public key from `data_dir`).
+/// Transient errors during the lifetime of the connection drive the
+/// internal reconnect loop instead.
 pub async fn run_connection(
     config: &RunConfig,
     event_tx: Option<mpsc::UnboundedSender<AgentEvent>>,

--- a/crates/crack-common/src/auth.rs
+++ b/crates/crack-common/src/auth.rs
@@ -1,3 +1,16 @@
+//! Noise IK identity handling: keypair generation, on-disk storage, and
+//! handshake builders for the coord (responder) and agent (initiator).
+//!
+//! Trust model: the coord publishes its static public key out-of-band
+//! (encoded in `EnrollmentToken`). The agent must know that key to
+//! initiate IK; the coord recognizes the agent by the static public key
+//! it presents in the first handshake message and matches it against
+//! the `workers` table.
+//!
+//! On-disk layout under a data directory: `private.key` + `public.key`.
+//! Private key files are created with mode `0o600` on Unix; the `Drop`
+//! impl on `Keypair` zeroizes private-key memory.
+
 use std::path::{Path, PathBuf};
 
 use base64::Engine;
@@ -11,12 +24,19 @@ use crate::error::{CrackError, Result};
 /// and the coordinator is authenticated by its known static key.
 pub static NOISE_PATTERN: &str = "Noise_IK_25519_ChaChaPoly_SHA256";
 
-/// Parse the noise pattern string.
+/// Parse [`NOISE_PATTERN`] into a [`NoiseParams`].
+///
+/// # Panics
+/// Panics if [`NOISE_PATTERN`] is not a valid Noise descriptor — but the
+/// string is a compile-time constant, so this is a programmer error, not
+/// a runtime concern.
 pub fn noise_params() -> NoiseParams {
     NOISE_PATTERN.parse().expect("valid noise pattern")
 }
 
-/// A keypair for Noise protocol identity.
+/// A Curve25519 keypair backing one party's Noise IK identity. Holds
+/// raw key bytes; `Drop` zeroizes `private_key` to keep secret material
+/// out of freed allocations. `public_key` is safe to share/serialize.
 pub struct Keypair {
     pub private_key: Vec<u8>,
     pub public_key: Vec<u8>,
@@ -30,6 +50,10 @@ impl Drop for Keypair {
 
 impl Keypair {
     /// Generate a new Curve25519 keypair.
+    ///
+    /// # Errors
+    /// Returns `CrackError::Noise` if the underlying snow builder fails
+    /// to produce a keypair (e.g. the OS RNG is unavailable).
     pub fn generate() -> Result<Self> {
         let builder = snow::Builder::new(noise_params());
         let dh = builder.generate_keypair().map_err(CrackError::Noise)?;
@@ -44,7 +68,18 @@ impl Keypair {
         base64::engine::general_purpose::STANDARD.encode(&self.public_key)
     }
 
-    /// Save keypair to a directory (private.key + public.key files).
+    /// Persist this keypair under `dir` as `private.key` + `public.key`.
+    ///
+    /// On Unix, `private.key` is created with mode `0o600` atomically
+    /// (single `OpenOptions::open` call) so it is never world-readable
+    /// in between creation and a separate chmod. On non-Unix platforms
+    /// permissions follow the process umask — harden the parent
+    /// directory's ACLs if that matters in your deployment.
+    /// `public.key` is written without restricted permissions.
+    ///
+    /// # Errors
+    /// Any `std::io::Error` from `create_dir_all`, `OpenOptions::open`,
+    /// or `write` propagates unchanged.
     pub fn save_to_dir(&self, dir: &Path) -> Result<()> {
         std::fs::create_dir_all(dir)?;
 
@@ -76,7 +111,15 @@ impl Keypair {
         Ok(())
     }
 
-    /// Load keypair from a directory.
+    /// Load a keypair previously saved by `save_to_dir`. Reads
+    /// `dir/private.key` and `dir/public.key` and returns the
+    /// reconstructed `Keypair`. The private key is wiped on `Drop`.
+    ///
+    /// # Errors
+    /// - `CrackError::Config` when either key file is absent (suggests
+    ///   the user run `init` first).
+    /// - Any `std::io::Error` from `std::fs::read` if the files exist
+    ///   but can't be read.
     pub fn load_from_dir(dir: &Path) -> Result<Self> {
         let priv_path = dir.join("private.key");
         let pub_path = dir.join("public.key");
@@ -99,6 +142,9 @@ impl Keypair {
 }
 
 /// Decode a base64-encoded public key.
+///
+/// # Errors
+/// Returns `CrackError::Base64` if `b64` is not valid base64.
 pub fn decode_public_key(b64: &str) -> Result<Vec<u8>> {
     base64::engine::general_purpose::STANDARD
         .decode(b64)
@@ -124,7 +170,16 @@ pub fn agent_data_dir() -> PathBuf {
         .join("crack-agent")
 }
 
-/// Save a remote public key (coordinator's key on agent, or authorized worker key on coordinator).
+/// Persist a peer's static public key under `dir/filename`.
+///
+/// Used by the coord to remember each authorized worker's key
+/// (`<workers_dir>/<worker_id>.pub`) and by the agent to remember the
+/// coord's key (`coordinator.pub`). Public keys carry no secret material
+/// so no special permissions are applied.
+///
+/// # Errors
+/// Any `std::io::Error` from `create_dir_all` or `write` propagates
+/// unchanged.
 pub fn save_remote_key(dir: &Path, filename: &str, key: &[u8]) -> Result<()> {
     std::fs::create_dir_all(dir)?;
     let path = dir.join(filename);
@@ -132,7 +187,11 @@ pub fn save_remote_key(dir: &Path, filename: &str, key: &[u8]) -> Result<()> {
     Ok(())
 }
 
-/// Load a remote public key.
+/// Load a remote public key previously stored under `dir/filename`.
+///
+/// # Errors
+/// - `CrackError::Config` if the file does not exist.
+/// - Any `std::io::Error` from `std::fs::read`.
 pub fn load_remote_key(dir: &Path, filename: &str) -> Result<Vec<u8>> {
     let path = dir.join(filename);
     if !path.exists() {
@@ -144,7 +203,14 @@ pub fn load_remote_key(dir: &Path, filename: &str) -> Result<Vec<u8>> {
     Ok(std::fs::read(&path)?)
 }
 
-/// Build a Noise responder (coordinator side) for IK handshake.
+/// Build a Noise IK responder (coordinator side) using `keypair` as the
+/// local static. The responder learns the initiator's static public key
+/// from the first handshake message — this is how the coord
+/// authenticates the worker.
+///
+/// # Errors
+/// Returns `CrackError::Noise` if snow rejects the supplied private key
+/// or fails to construct the responder state.
 pub fn build_responder(keypair: &Keypair) -> Result<snow::HandshakeState> {
     snow::Builder::new(noise_params())
         .local_private_key(&keypair.private_key)
@@ -153,8 +219,16 @@ pub fn build_responder(keypair: &Keypair) -> Result<snow::HandshakeState> {
         .map_err(CrackError::Noise)
 }
 
-/// Build a Noise initiator (worker side) for IK handshake.
-/// The worker must know the coordinator's static public key (IK pattern).
+/// Build a Noise IK initiator (worker side).
+///
+/// The worker must know `remote_static` (the coord's static public key,
+/// distributed via `EnrollmentToken`) before initiating — the IK pattern
+/// offers no in-band way to discover it. Mismatched keys cause the
+/// handshake to fail at `read_message` time.
+///
+/// # Errors
+/// Returns `CrackError::Noise` if snow rejects either key (wrong length
+/// or invalid encoding) or fails to construct the initiator state.
 pub fn build_initiator(keypair: &Keypair, remote_static: &[u8]) -> Result<snow::HandshakeState> {
     snow::Builder::new(noise_params())
         .local_private_key(&keypair.private_key)

--- a/crates/crack-common/src/models.rs
+++ b/crates/crack-common/src/models.rs
@@ -1,9 +1,24 @@
+//! Shared data model: tasks, chunks, workers, campaigns, and the REST
+//! request/response shapes wrapping them.
+//!
+//! Every type here is `Serialize + Deserialize` and crosses two
+//! boundaries: the SQLite tables behind `crack-coord::storage::db` and
+//! the public REST API. Field names are wire-format contracts —
+//! renaming is a breaking change for both the agent build and any
+//! external API consumer.
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 // ── Task ──
 
+/// A cracking task: a single attack configuration applied to a single
+/// hash file. Has a lifecycle (`TaskStatus`) driven by the coord's
+/// monitor loop; `next_skip` tracks the cursor used to allocate the next
+/// chunk. `total_keyspace` is filled in during preparation by
+/// `hashcat --keyspace`. A task may belong to a `Campaign` (multi-phase
+/// orchestration) or stand alone (`campaign_id == None`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {
     pub id: Uuid,
@@ -24,14 +39,21 @@ pub struct Task {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
+/// Lifecycle states of a [`Task`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
+    /// Created, awaiting preparation (hash count + keyspace).
     Pending,
+    /// Prepared, no chunk has been dispatched yet.
     Ready,
+    /// At least one chunk has been dispatched or is in flight.
     Running,
+    /// Keyspace fully exhausted (or all hashes cracked).
     Completed,
+    /// Prep failed or all chunks failed.
     Failed,
+    /// Manually stopped via the API.
     Cancelled,
 }
 
@@ -65,6 +87,10 @@ impl std::str::FromStr for TaskStatus {
 
 // ── Attack Config ──
 
+/// Attack mode for a [`Task`]. Maps onto hashcat attack modes 3 (mask),
+/// 0 (dictionary), and 0 + `-r` (dictionary with rules). The chunker
+/// uses this both to compute keyspace and to assemble the per-chunk
+/// `AssignChunkAttack` sent to the worker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AttackConfig {
@@ -83,6 +109,11 @@ pub enum AttackConfig {
 
 // ── Chunk ──
 
+/// A unit of work assigned to a single worker. `skip`/`limit` are
+/// hashcat restore points carved out of the parent task's keyspace;
+/// `assigned_worker` is `None` until dispatch. `progress` is a 0–100
+/// percentage updated from `WorkerMessage::ChunkProgress`. `speed` is
+/// the most recent observed hash rate (H/s).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Chunk {
     pub id: Uuid,
@@ -98,15 +129,24 @@ pub struct Chunk {
     pub cracked_count: u32,
 }
 
+/// Lifecycle of a [`Chunk`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChunkStatus {
+    /// Carved out but not yet dispatched.
     Pending,
+    /// Assignment was sent; no `ChunkStarted` ack received yet.
     Dispatched,
+    /// Worker has spawned hashcat for this chunk.
     Running,
+    /// Hashcat exited with results found.
     Completed,
+    /// Hashcat exited without finding any hashes (keyspace consumed).
     Exhausted,
+    /// Hashcat failed (spawn error, killed, or unrecognized exit).
     Failed,
+    /// Worker stopped sending heartbeats with the chunk in flight; the
+    /// chunk is re-cut and re-dispatched.
     Abandoned,
 }
 
@@ -142,6 +182,11 @@ impl std::str::FromStr for ChunkStatus {
 
 // ── Worker ──
 
+/// A registered cracking node. `id` is the coord's stable identifier
+/// (derived from the worker's static public key); `public_key` is the
+/// authorized Noise static key (base64) used to authenticate every
+/// reconnect. `last_seen_at` is updated on every heartbeat and drives
+/// the disconnect-on-timeout logic in the monitor loop.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Worker {
     pub id: String,
@@ -155,6 +200,8 @@ pub struct Worker {
     pub last_seen_at: DateTime<Utc>,
 }
 
+/// One compute device attached to a worker (CPU/GPU). `speed` is `None`
+/// until a benchmark has run for the device's preferred hash mode.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceInfo {
     pub id: u32,
@@ -163,13 +210,19 @@ pub struct DeviceInfo {
     pub speed: Option<u64>,
 }
 
+/// Liveness state for a [`Worker`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkerStatus {
+    /// Connected, no chunk in flight.
     Idle,
+    /// At least one chunk is being processed.
     Working,
+    /// Currently running `hashcat --benchmark`.
     Benchmarking,
+    /// Heartbeat timeout exceeded; chunks are reassigned.
     Disconnected,
+    /// Will not accept new chunks but is finishing in-flight work.
     Draining,
 }
 
@@ -201,6 +254,9 @@ impl std::str::FromStr for WorkerStatus {
 
 // ── Cracked Hash ──
 
+/// One discovered (hash, plaintext) pair. Inserted as soon as the
+/// worker emits `WorkerMessage::HashCracked` so operators see results
+/// in real time rather than at chunk completion.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CrackedHash {
     pub id: Option<i64>,
@@ -213,6 +269,11 @@ pub struct CrackedHash {
 
 // ── File Record ──
 
+/// A file stored under the coord's content-addressed cache. `id` is a
+/// per-row UUID; `sha256` is the content hash used for dedup and for
+/// agent-side cache addressing. Soft-deleted rows (`gc_state =
+/// 'deleted'`) are filtered out by the lookup helpers in
+/// `storage::db` but remain as FK targets for historical joins.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileRecord {
     pub id: String,
@@ -226,6 +287,9 @@ pub struct FileRecord {
 
 // ── Worker Benchmark ──
 
+/// Most recent measured hash rate for a `(worker, hash_mode)` pair.
+/// Used by `chunker::calculate_chunk_size` to target ~10 minutes of
+/// work per chunk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerBenchmark {
     pub worker_id: String,
@@ -236,6 +300,9 @@ pub struct WorkerBenchmark {
 
 // ── Audit Log ──
 
+/// One row of the security/operations audit log. Recorded for any state
+/// transition that crosses a trust boundary (worker enrollment,
+/// authorization, task creation, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditEntry {
     pub id: Option<i64>,
@@ -248,6 +315,8 @@ pub struct AuditEntry {
 
 // ── System Status ──
 
+/// Coord-wide counters returned by `GET /api/v1/status` for the TUI and
+/// `crackctl status`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemStatus {
     pub total_tasks: u32,
@@ -260,14 +329,29 @@ pub struct SystemStatus {
 
 // ── Enrollment Token ──
 
+/// One-shot bootstrap credential the operator hands to a new worker.
+///
+/// Bundles everything an unenrolled agent needs for first contact: the
+/// coord's static public key (so the IK handshake authenticates the
+/// responder), the single-use `nonce` the coord expects in the
+/// worker's `Enroll` message, the assigned `worker_name`, an expiry,
+/// and the coord's transport address.
+///
+/// `server_addr` is `#[serde(default)]` for backwards compatibility
+/// with tokens issued before the field was added.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnrollmentToken {
-    pub coord_pubkey: String, // base64
-    pub nonce: String,        // hex 16 bytes
+    /// Coordinator's static public key, base64-encoded.
+    pub coord_pubkey: String,
+    /// Single-use, 16-byte hex nonce.
+    pub nonce: String,
+    /// Friendly name assigned to this worker on enrollment.
     pub worker_name: String,
-    pub expires_at: String, // ISO 8601
+    /// ISO 8601 expiry timestamp (rejected after this).
+    pub expires_at: String,
+    /// Coordinator transport address as `host:port`.
     #[serde(default)]
-    pub server_addr: String, // coordinator transport address (host:port)
+    pub server_addr: String,
 }
 
 // ── API request/response types ──
@@ -295,6 +379,9 @@ pub struct UpdateTaskRequest {
 
 // ── Campaign ──
 
+/// Multi-phase orchestration over a single hash file. Each phase
+/// produces a downstream `Task`; remaining-hashes are passed forward so
+/// later phases only attack what earlier phases didn't crack.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Campaign {
     pub id: Uuid,
@@ -313,13 +400,19 @@ pub struct Campaign {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
+/// Lifecycle states of a [`Campaign`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CampaignStatus {
+    /// Created but not yet started.
     Draft,
+    /// At least one phase has been launched.
     Running,
+    /// All phases completed (or all hashes cracked).
     Completed,
+    /// A phase failed terminally and the campaign aborted.
     Failed,
+    /// Manually stopped via the API.
     Cancelled,
 }
 
@@ -351,6 +444,9 @@ impl std::str::FromStr for CampaignStatus {
 
 // ── Campaign Phase ──
 
+/// One attack phase within a [`Campaign`]. Spawns a `Task` when
+/// activated; `hash_file_id` is the (possibly remaining-only) input
+/// for this phase.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CampaignPhase {
     pub id: Uuid,
@@ -367,14 +463,21 @@ pub struct CampaignPhase {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
+/// Lifecycle states of a [`CampaignPhase`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PhaseStatus {
+    /// Not yet activated.
     Pending,
+    /// Phase task is in flight.
     Running,
+    /// Phase task completed with results found.
     Completed,
+    /// Phase task ran but found nothing.
     Exhausted,
+    /// Phase task failed; campaign aborted.
     Failed,
+    /// Auto-skipped (e.g. all hashes already cracked by a prior phase).
     Skipped,
 }
 
@@ -439,6 +542,8 @@ pub enum PhaseConfig {
     },
 }
 
+/// One mask in a `MultiMask` phase. `increment` toggles hashcat's
+/// `--increment` flag for variable-length attacks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MaskEntry {
     pub mask: String,
@@ -449,6 +554,9 @@ pub struct MaskEntry {
 
 // ── Campaign Template ──
 
+/// A reusable named recipe for a campaign — produces a series of
+/// [`TemplatePhase`]s when instantiated. Loaded from
+/// `<data_dir>/templates/`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CampaignTemplate {
     pub name: String,
@@ -457,6 +565,8 @@ pub struct CampaignTemplate {
     pub phases: Vec<TemplatePhase>,
 }
 
+/// One phase entry inside a [`CampaignTemplate`]. Materializes into a
+/// [`CampaignPhase`] at instantiation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplatePhase {
     pub name: String,

--- a/crates/crack-common/src/protocol.rs
+++ b/crates/crack-common/src/protocol.rs
@@ -1,3 +1,11 @@
+//! Wire protocol between coordinator and worker.
+//!
+//! All messages travel over a Noise IK channel as length-framed JSON:
+//! `[4 bytes BE length][serialized payload]`. [`CoordMessage`] originates
+//! at the coord; [`WorkerMessage`] at the worker. See [`encode_message`]
+//! / [`decode_message`] for the framing helpers and [`MAX_MESSAGE_SIZE`]
+//! for the per-frame ceiling.
+
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -7,9 +15,10 @@ use crate::models::DeviceInfo;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum CoordMessage {
-    Welcome {
-        worker_id: String,
-    },
+    /// First message the coord sends after a successful Noise handshake
+    /// and `WorkerMessage::Register`. Conveys the worker's authoritative
+    /// ID (the coord's view, used by the agent for log correlation).
+    Welcome { worker_id: String },
     /// Stream a file to the worker in chunks. The agent reconstructs
     /// the file from ordered chunks and caches it by file_id.
     TransferFileChunk {
@@ -34,26 +43,25 @@ pub enum CoordMessage {
     /// Sent in place of `FileRange` when the coord can't serve the request
     /// (file not found, read error, etc.). The worker aborts its pull and
     /// surfaces the reason.
-    FileError {
-        hash: String,
-        reason: String,
-    },
+    FileError { hash: String, reason: String },
     /// Instruct the worker to evict a file from its content-addressed cache.
     /// Issued by the coord's GC loop after a file's reference count drops
     /// to zero and pin state is clear. The worker defers eviction until no
     /// running chunk is using the file.
-    EvictFile {
-        hash: String,
-    },
+    EvictFile { hash: String },
     /// Sent once when a worker (re)connects: the authoritative list of
     /// sha256s the coord still has on its end. The agent compares against
     /// its own cache manifest and evicts anything not in `expected` —
     /// catches missed `EvictFile` messages from prior sessions and any
     /// drift accumulated while the agent was disconnected. Eviction
     /// defers as usual when a sha is in use by a running chunk.
-    CacheReconcile {
-        expected: Vec<String>,
-    },
+    CacheReconcile { expected: Vec<String> },
+    /// Dispatch a single chunk of work to the worker. The agent runs
+    /// hashcat against the supplied (eagerly inlined) hash file with the
+    /// attack-specific parameters in `attack`. `skip`/`limit` are passed
+    /// through to hashcat as restore points; `extra_args` is appended
+    /// verbatim. Only one chunk runs at a time per agent — additional
+    /// assignments queue locally.
     AssignChunk {
         chunk_id: Uuid,
         task_id: Uuid,
@@ -66,12 +74,17 @@ pub enum CoordMessage {
         attack: AssignChunkAttack,
         extra_args: Vec<String>,
     },
-    AbortChunk {
-        chunk_id: Uuid,
-    },
-    RequestBenchmark {
-        hash_mode: u32,
-    },
+    /// Cancel a running or queued chunk. The agent kills the hashcat
+    /// process (if started) or removes the assignment from its pending
+    /// queue. Idempotent: a duplicate or stale `chunk_id` is a no-op.
+    AbortChunk { chunk_id: Uuid },
+    /// Ask the worker to run `hashcat --benchmark -m <hash_mode>` and
+    /// reply with `WorkerMessage::BenchmarkResult`. The coord uses the
+    /// result to size future chunks (target ~10 minutes per chunk).
+    RequestBenchmark { hash_mode: u32 },
+    /// Tell the worker to terminate. The agent kills any running hashcat
+    /// processes, sends `WorkerMessage::Leaving`, and exits cleanly
+    /// without triggering the reconnect/backoff loop.
     Shutdown,
 }
 
@@ -79,6 +92,9 @@ pub enum CoordMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum AssignChunkAttack {
+    /// Mask attack (hashcat `-a 3`). `mask` uses hashcat's mask language
+    /// (e.g. `?l?l?d?d`); `custom_charsets` populates `?1`..`?4` in mask
+    /// position order.
     BruteForce {
         mask: String,
         custom_charsets: Option<Vec<String>>,
@@ -107,16 +123,24 @@ pub enum AssignChunkAttack {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkerMessage {
+    /// First message the worker sends after the Noise handshake completes
+    /// (or after `Enroll` on a new worker). Carries the agent-chosen
+    /// friendly name plus capability info (hashcat version, OS, devices)
+    /// used by the coord for chunk dispatch decisions. The coord replies
+    /// with `CoordMessage::Welcome`.
     Register {
         worker_name: String,
         hashcat_version: String,
         os: String,
         devices: Vec<DeviceInfo>,
     },
-    Enroll {
-        nonce: String,
-        worker_name: String,
-    },
+    /// One-shot enrollment proof sent in place of `Register` on a brand-
+    /// new worker's first connection. `nonce` matches a value from a
+    /// coord-issued enrollment token (single-use, time-limited);
+    /// `worker_name` must match the token. The coord authorizes the
+    /// worker's static public key on success, after which subsequent
+    /// connections use `Register`.
+    Enroll { nonce: String, worker_name: String },
     /// Periodic heartbeat. Carries a compact digest of the worker's
     /// content-addressed cache so the coord can maintain an authoritative
     /// view of what each worker has on disk — used for targeted
@@ -129,36 +153,59 @@ pub enum WorkerMessage {
         #[serde(default)]
         cache_manifest: Vec<CacheManifestEntry>,
     },
-    ChunkStarted {
-        chunk_id: Uuid,
-    },
+    /// Acknowledgment that the worker has spawned hashcat for `chunk_id`.
+    /// The coord transitions the chunk from `dispatched` to `running`.
+    ChunkStarted { chunk_id: Uuid },
+    /// Periodic progress update emitted while hashcat is running.
+    /// `progress_pct` is the floating-point completion percentage
+    /// (0–100), `speed` is the current hash rate in H/s, and
+    /// `estimated_remaining_secs` is hashcat's ETA when it can compute one.
     ChunkProgress {
         chunk_id: Uuid,
         progress_pct: f64,
         speed: u64,
         estimated_remaining_secs: Option<u64>,
     },
+    /// One cracked hash result. Sent eagerly as hashcat discovers each
+    /// plaintext, not batched at chunk completion — operators see results
+    /// in real time. The coord persists the pair and counts toward
+    /// `tasks.cracked_count`.
     HashCracked {
         chunk_id: Uuid,
         task_id: Uuid,
         hash: String,
         plaintext: String,
     },
+    /// Hashcat exited normally for `chunk_id`. `exit_code` mirrors
+    /// hashcat's status (0 = exhausted, 1 = cracked, etc.).
+    /// `total_cracked` is informational — the coord trusts the stream of
+    /// `HashCracked` messages.
     ChunkCompleted {
         chunk_id: Uuid,
         exit_code: i32,
         total_cracked: u32,
     },
+    /// Hashcat could not be started, was killed, or exited with an
+    /// unrecognized error. `exit_code` is `None` when the failure
+    /// happened before the process produced one (e.g. spawn error). The
+    /// coord requeues the chunk for reassignment.
     ChunkFailed {
         chunk_id: Uuid,
         error: String,
         exit_code: Option<i32>,
     },
-    BenchmarkResult {
-        hash_mode: u32,
-        speed: u64,
-    },
+    /// Reply to `CoordMessage::RequestBenchmark`. `speed` is the
+    /// aggregate hash rate in H/s across all of the worker's devices for
+    /// `hash_mode`. Persisted in `worker_benchmarks` and used to size
+    /// future chunks.
+    BenchmarkResult { hash_mode: u32, speed: u64 },
+    /// Worker is winding down: it will not accept new chunks but is still
+    /// finishing in-flight work. Coord stops dispatch and waits for
+    /// `Leaving`.
     Draining,
+    /// Worker is about to disconnect cleanly. Sent in response to
+    /// `CoordMessage::Shutdown` or before voluntary exit. Coord marks the
+    /// worker disconnected without raising a timeout alarm.
     Leaving,
     /// Ask the coord to send a byte range of a file identified by content
     /// hash (sha256 hex). The coord responds with one or more
@@ -205,11 +252,19 @@ pub struct CacheManifestEntry {
     pub last_used_at: String,
 }
 
-/// Length-prefixed framing for Noise transport messages.
-/// Wire format: [4 bytes big-endian length][encrypted payload]
+/// Hard ceiling on a single decoded message body. Decoder rejects any
+/// length-prefix exceeding this — protects against memory exhaustion from
+/// a malformed or hostile frame. 16 MiB matches the largest
+/// `TransferFileChunk` envelope the protocol can carry.
 pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 
-/// Encode a message to bytes for transmission.
+/// Serialize `msg` as JSON and prepend the 4-byte big-endian length
+/// header used by the wire protocol. Output goes straight onto the
+/// (eventually Noise-encrypted) wire.
+///
+/// # Errors
+/// Returns any `serde_json` serialization failure encountered while
+/// rendering `msg` to JSON.
 pub fn encode_message<T: Serialize>(msg: &T) -> crate::error::Result<Vec<u8>> {
     let json = serde_json::to_vec(msg)?;
     let len = (json.len() as u32).to_be_bytes();
@@ -219,8 +274,18 @@ pub fn encode_message<T: Serialize>(msg: &T) -> crate::error::Result<Vec<u8>> {
     Ok(buf)
 }
 
-/// Read a length-prefixed message from a stream of bytes.
-/// Returns the deserialized message and the number of bytes consumed.
+/// Decode one length-prefixed message from the front of `buf`.
+///
+/// Returns:
+/// - `Ok(Some((msg, n)))` — successfully deserialized; `n` is the number
+///   of bytes consumed (4-byte header + payload). Caller advances past.
+/// - `Ok(None)` — `buf` doesn't yet hold a complete frame (header
+///   truncated or payload incomplete). Caller refills and retries.
+///
+/// # Errors
+/// - `CrackError::Protocol` if the framed length exceeds
+///   `MAX_MESSAGE_SIZE`.
+/// - `CrackError::Json` if the payload bytes do not deserialize into `T`.
 pub fn decode_message<T: for<'de> Deserialize<'de>>(
     buf: &[u8],
 ) -> crate::error::Result<Option<(T, usize)>> {

--- a/crates/crack-coord/src/lifecycle.rs
+++ b/crates/crack-coord/src/lifecycle.rs
@@ -6,16 +6,23 @@
 //! `db::update_campaign_status` call automatically maintains `file_refs`.
 //!
 //! This module runs the GC pass: drains `gc_queue`, deletes coord-side
-//! files whose ref count truly reached zero, removes the DB rows. The
-//! state machine (`active` → `marked` → `deleting` → removed) plus the
-//! queue row survive a coord restart, so an interrupted GC resumes on the
-//! next pass.
+//! files whose ref count truly reached zero, then tombstones the DB rows.
+//! The state machine (`active` → `marked` → `deleting` → `deleted`) plus
+//! the queue row survive a coord restart, so an interrupted GC resumes on
+//! the next pass. The terminal `deleted` state is a soft tombstone, not a
+//! row removal: the `tasks.hash_file_id NOT NULL REFERENCES files(id)` FK
+//! forbids a hard `DELETE` for any file ever consumed by a task.
+//! Tombstoned rows are invisible to dedup (`find_file_by_sha256` /
+//! `get_file_record` filter them out) but remain resolvable as FK targets
+//! for historical joins.
 //!
-//! Slice 7 is coord-side only. Agent-side cache eviction and
-//! reconciliation arrive in Slices 8 and 9. Until then, a file reclaimed
-//! here stays resident in any agent that already cached it — the on-disk
-//! staleness is bounded but non-zero, and fully resolved once those two
-//! slices ship.
+//! Together with Slice 8 (`EvictFile`, `dispatch_evict_for_sha`) and
+//! Slice 9 (`CacheReconcile`), the GC pass closes the loop end-to-end:
+//! reclaimed coord-side files are mirrored into agent caches via
+//! targeted-or-broadcast `EvictFile` and reconciled on every (re)connect.
+//! Agents defer eviction for any sha actively held by a running chunk —
+//! see `crack-agent::ContentCache::evict` and the `running_chunks_using`
+//! map in `crack-agent::connection`.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/crack-coord/src/monitor.rs
+++ b/crates/crack-coord/src/monitor.rs
@@ -1,3 +1,16 @@
+//! Coordinator background monitor.
+//!
+//! One ticker (`HEARTBEAT_CHECK_INTERVAL`) drives four orthogonal passes
+//! in sequence: prepare pending tasks, check worker liveness, reassign
+//! abandoned chunks, and advance campaign phases. Each pass logs its
+//! errors but never propagates — the ticker keeps running so a transient
+//! DB hiccup can't take the loop down.
+//!
+//! Task preparation runs in spawned subtasks because hashcat `--keyspace`
+//! on a large wordlist can take minutes — blocking this loop would also
+//! stall heartbeat checks and the GC pass that shares the same cadence
+//! (see `lifecycle::run_gc_loop`).
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -74,9 +87,21 @@ async fn prepare_pending_tasks(state: &Arc<AppState>) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Prepare a single task: validate hash file, count hashes, compute keyspace,
-/// transition to Running. Runs inside a spawned task so it doesn't block the
-/// monitor loop.
+/// Prepare a single task: validate the hash file, count hashes, compute
+/// the keyspace, then transition the task to `Running`. Runs inside a
+/// spawned task so it doesn't block the monitor loop.
+///
+/// Side-effects: on any of the validation failures (hash-file row
+/// missing, hash file unreadable, file empty, keyspace computation
+/// failing) the task is transitioned to `TaskStatus::Failed` and the
+/// function returns `Ok(())`. Callers must not treat success as
+/// "task is now Running" — re-read the task status if that matters.
+///
+/// # Errors
+/// Returns the underlying `db::*` error only when the failure-path
+/// status update *itself* fails (i.e. we couldn't even mark the task
+/// `Failed`). Validation failures are reported via the task status,
+/// not the return value.
 async fn prepare_one(state: &AppState, task: Task) -> anyhow::Result<()> {
     info!(task_id = %task.id, task_name = %task.name, "preparing pending task");
 

--- a/crates/crack-coord/src/scheduler/chunker.rs
+++ b/crates/crack-coord/src/scheduler/chunker.rs
@@ -1,3 +1,11 @@
+//! Keyspace and chunk-sizing math.
+//!
+//! Bridges hashcat's `--keyspace` output with the coord's `skip`/`limit`
+//! accounting and owns the heuristic that decides how big each per-worker
+//! chunk should be. Dictionary keyspaces are cached by
+//! `(wordlist_sha, rules_sha, hash_mode)` so the slow scan over a large
+//! wordlist runs at most once per (effective-input, mode) tuple.
+
 use std::path::Path;
 
 use anyhow::{bail, Context};
@@ -104,7 +112,14 @@ async fn sha256_for_file(pool: &SqlitePool, file_id: &str) -> anyhow::Result<Opt
     Ok(record.map(|r| r.sha256).filter(|s| !s.is_empty()))
 }
 
-/// Run `hashcat --keyspace` for a dictionary attack (mode 0).
+/// Run `hashcat --keyspace` for a dictionary attack (`-a 0`) against
+/// `hash_mode`, optionally applying a rules file. Returns the parsed
+/// keyspace integer.
+///
+/// # Errors
+/// - Process spawn failure (with hashcat path context).
+/// - Non-zero hashcat exit (carries captured stderr).
+/// - Stdout that doesn't parse as `u64`.
 async fn compute_dictionary_keyspace(
     hashcat_path: &str,
     hash_mode: u32,
@@ -146,7 +161,14 @@ async fn compute_dictionary_keyspace(
     Ok(keyspace)
 }
 
-/// Run `hashcat --keyspace` to get the exact restore-point count.
+/// Run `hashcat --keyspace -a 3 -m <hash_mode> <mask>` and return the
+/// exact restore-point count hashcat will use for `--skip`/`--limit`.
+/// Custom charsets `?1..?N` are passed via `-1`/`-2`/... in order.
+///
+/// # Errors
+/// - Process spawn failure (with hashcat path context).
+/// - Non-zero hashcat exit (carries captured stderr).
+/// - Stdout that doesn't parse as `u64`.
 async fn compute_keyspace_via_hashcat(
     hashcat_path: &str,
     hash_mode: u32,
@@ -305,13 +327,19 @@ fn custom_charset_size(idx: usize, custom_charsets: Option<&[String]>) -> anyhow
 /// Calculate how large each chunk should be for a given worker.
 ///
 /// Strategy:
-/// - If the worker has a known benchmark speed, target 10 minutes of work per chunk:
-///   `worker_speed * 600`.
-/// - Otherwise, divide the keyspace evenly across workers with a 4x multiplier for
-///   granularity: `total_keyspace / (num_workers * 4)`.
-/// - The result is clamped to `[10_000, total_keyspace]`.
-/// - Additionally, when the speed-based chunk exceeds the remaining keyspace divided
-///   by the number of workers, we cap it to ensure all workers get a share.
+/// - If the worker has a known benchmark speed, target 10 minutes of work
+///   per chunk: `worker_speed * 600` (saturating).
+/// - Otherwise, divide the keyspace evenly across workers with a 4x
+///   multiplier for granularity: `total_keyspace / (num_workers * 4)`.
+/// - When more than one worker is available and the speed-based chunk
+///   would exceed `total_keyspace / num_workers`, the chunk is capped to
+///   `fair_share` so every worker gets a slice (only applied when
+///   `fair_share >= MIN_CHUNK`).
+/// - The result is clamped to
+///   `[min(MIN_CHUNK, total_keyspace), total_keyspace]`. When
+///   `total_keyspace < MIN_CHUNK = 10_000` the lower bound collapses to
+///   `total_keyspace` so the chunk is exactly the keyspace.
+/// - `num_workers == 0` is treated as `1` via `.max(1)`.
 pub fn calculate_chunk_size(
     worker_speed: Option<u64>,
     total_keyspace: u64,


### PR DESCRIPTION
## Summary
- Closes #49
- Fixes 3 Critical drift bugs (lifecycle.rs module doc was lying about both the terminal state and the slice-status; `connection::run_connection` doc was the inverse of the function)
- Adds `# Errors` / `# Panics` sections across every public `Result`-returning fn in `crack-common` plus `ContentCache::ensure`
- Documents every `CoordMessage` / `WorkerMessage` variant, every public struct in `models.rs`, every status enum + variant, and adds module `//!` docs to 6 files
- Net: +420 / −71 across 8 files. No code semantics changed.

## Highlights
- **lifecycle.rs**: terminal state in the state machine is now `deleted` (soft tombstone bypassing the `tasks.hash_file_id` FK), not `removed`. Slice 8/9 wording updated to past tense.
- **connection.rs `run_connection`**: doc now correctly says it loops forever with internal backoff and only returns `Ok(())` on coord-issued `Shutdown`. Previous doc would have steered an integrator into building a redundant outer reconnect loop.
- **chunker.rs `calculate_chunk_size`**: clamp interval is `[min(MIN_CHUNK, total_keyspace), total_keyspace]` — previously documented as `[10_000, total_keyspace]`, which is empty when `total_keyspace < 10_000` (test at chunker.rs:472 confirms the small-keyspace behavior).
- **`ContentCache::ensure`**: 8 distinct failure modes (invalid hash, mkdir, channel-closed, offset mismatch, hash mismatch, rename, empty non-EOF chunk, oversize) now enumerated.
- **`Keypair::save_to_dir`**: documents the security-critical Unix mode-0o600 atomic-create contract.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 214 tests pass (52 + 80 + 18 + 64 doctests; no regressions)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo doc --workspace --no-deps` — no new warnings; one pre-existing unrelated warning at `transport/handler.rs:292` flagged in #49 as out of scope

## Out of scope
The `transport/handler.rs:292` `[4-byte BE length][payload]` rustdoc warning is pre-existing (last touched in #48) and not part of this audit. One-character escape; can be folded into a follow-up.