### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Crackswarm are documented here.
 
+## [0.9.0] - 2026-04-25
+
+### Added
+- Pull-based file RPC over the Noise channel: agents fetch hash files, wordlists, and rules on demand instead of receiving them over a push stream
+- Content-addressed agent cache keyed by sha256, with hardlink fast path for same-host coord/agent setups
+- `DictionaryByHash` dispatch — wordlists are referenced by hash and fetched lazily by agents
+- Reference-counted file lifecycle on the coordinator with background garbage collection of unreferenced files
+- Agent-side `EvictFile` protocol message and per-heartbeat cache manifest
+- Cache reconciliation on (re)connect — coord and agent agree on what each side has after disconnect
+- LRU eviction with configurable disk budget on the agent
+- Operator cache controls in `crackctl`: `file pin`, `file unpin`, `file gc`, plus cache visibility commands
+- Same-host hardlink fast path for local file uploads (avoids redundant copies)
+- Streaming end-to-end byte transfer with progress bar on uploads
+- Upload deduplication by sha256 content hash on the coordinator
+- Keyspace cache and non-blocking task preparation (large keyspace tasks no longer stall the API loop)
+
+### Fixed
+- Race between GC and heartbeat-driven cache sync that could evict files mid-use
+- GC eligibility now re-evaluated on unpin (a file pinned then unpinned would otherwise linger)
+- Soft-delete used during GC to avoid foreign-key violations on in-flight references
+- Clippy 1.95 lints and rustls-webpki CVE patches
+
+### Changed
+- Dependabot auto-merges patch/minor bumps when CI passes
+- Bumped fetch-metadata to v3, polished dependabot config
+- Workspace cargo update — 53 patch/minor dependency bumps
+- Comprehensive rustdoc audit: drift fixes, `# Errors` sections on `Result`-returning public APIs, full public-API coverage
+
 ## [0.8.2] - 2026-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "crack-agent"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "crack-common"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "crack-coord"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "crackctl"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Bump workspace version `0.8.4` → `0.9.0` to trigger the release build for the cache-architecture work since v0.8.4.

## Why 0.9.0 (minor, not patch)

The pull-based file transport, content-addressed agent cache, ref-counted GC, and operator pin/unpin/gc CLI substantially change how files flow between coord and agents. That's a coherent feature wave, not a bug-fix sweep.

## Highlights since v0.8.4

**Added**
- Pull-based file RPC + content-addressed agent cache (#36)
- `DictionaryByHash` lazy wordlist fetch (#37)
- Reference-counted file lifecycle + background GC (#38)
- `EvictFile` + cache-manifest heartbeat (#39)
- Cache reconciliation on (re)connect (#40)
- LRU eviction + disk budget on the agent (#41)
- Operator `file pin/unpin/gc` + cache visibility CLI (#42)
- Same-host hardlink fast path (#35)
- Streaming uploads with progress bar (#34)
- Sha256-based upload dedup (#33)
- Keyspace cache + non-blocking task prep (#32)

**Fixed**
- GC vs heartbeat-sync race (#48)
- GC eligibility re-evaluation on unpin (#47)
- Soft-delete to bypass FK violation during GC (#46)
- Clippy 1.95 + rustls-webpki CVE patches (#28)

**Docs**
- Rustdoc audit: drift, `# Errors` sections, public-API coverage (#50)

Full notes are in `CHANGELOG.md`.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] All four crates show `0.9.0` in `Cargo.lock`
- [x] On merge: `release.yml` workflow auto-builds 5 targets and publishes `v0.9.0` with generated notes