### PR TITLE
Fix invalid YAML in dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,10 @@ jobs:
 
       - name: Comment on major updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: gh pr comment "$PR_URL" --body "Major version bump detected ($DEP_NAMES: $PREVIOUS → $NEW). Auto-merge skipped — please review manually."
+        # Block scalar: the message contains ": " which is invalid in a plain
+        # YAML scalar and made the whole workflow file fail validation.
+        run: |
+          gh pr comment "$PR_URL" --body "Major version bump detected ($DEP_NAMES: $PREVIOUS → $NEW). Auto-merge skipped — please review manually."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}


### PR DESCRIPTION
Closes #63

## Summary
- The `Dependabot auto-merge` workflow was invalid YAML: the major-update comment step's unquoted `run:` value contained `": "`, which a YAML plain scalar can't hold. GitHub failed the whole file at validation ("workflow file issue", 0s) on every push.
- Fixed by converting that step's `run:` to a block scalar (`run: |`), so the `": "` is literal.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dependabot-auto-merge.yml'))"` now parses (previously: `mapping values are not allowed here, line 30`).
- `actionlint .github/workflows/dependabot-auto-merge.yml` exits 0.
- Behavior unchanged: still `on: pull_request`, job gated to `dependabot[bot]`; auto-merges patch/minor, comments on major.

## Test plan
- [ ] After merge, confirm no more 0s "workflow file issue" failures on pushes to `main`.
- [ ] Next Dependabot PR: patch/minor auto-merges; a major bump posts the review comment.
